### PR TITLE
feat: add missing search options for leads and persons

### DIFF
--- a/pipedrive/v2/leads.go
+++ b/pipedrive/v2/leads.go
@@ -20,6 +20,12 @@ const (
 	LeadSearchFieldTitle        LeadSearchField = "title"
 )
 
+type LeadSearchIncludeField string
+
+const (
+	LeadSearchIncludeFieldLeadWasSeen LeadSearchIncludeField = "lead.was_seen"
+)
+
 type LeadSearchItem struct {
 	ResultScore float64                `json:"result_score,omitempty"`
 	Item        map[string]interface{} `json:"item,omitempty"`
@@ -127,6 +133,31 @@ func WithLeadSearchFields(fields ...LeadSearchField) SearchLeadsOption {
 func WithLeadSearchExactMatch(enabled bool) SearchLeadsOption {
 	return searchLeadsOptionFunc(func(cfg *searchLeadsOptions) {
 		cfg.params.ExactMatch = &enabled
+	})
+}
+
+func WithLeadSearchPersonID(id PersonID) SearchLeadsOption {
+	return searchLeadsOptionFunc(func(cfg *searchLeadsOptions) {
+		value := int(id)
+		cfg.params.PersonId = &value
+	})
+}
+
+func WithLeadSearchOrganizationID(id OrganizationID) SearchLeadsOption {
+	return searchLeadsOptionFunc(func(cfg *searchLeadsOptions) {
+		value := int(id)
+		cfg.params.OrganizationId = &value
+	})
+}
+
+func WithLeadSearchIncludeFields(fields ...LeadSearchIncludeField) SearchLeadsOption {
+	return searchLeadsOptionFunc(func(cfg *searchLeadsOptions) {
+		csv := joinCSV(fields)
+		if csv == "" {
+			return
+		}
+		value := genv2.SearchLeadsParamsIncludeFields(csv)
+		cfg.params.IncludeFields = &value
 	})
 }
 

--- a/pipedrive/v2/leads_test.go
+++ b/pipedrive/v2/leads_test.go
@@ -32,6 +32,15 @@ func TestLeadsService_Search(t *testing.T) {
 		if got := q.Get("exact_match"); got != "true" {
 			t.Fatalf("unexpected exact_match: %q", got)
 		}
+		if got := q.Get("person_id"); got != "7" {
+			t.Fatalf("unexpected person_id: %q", got)
+		}
+		if got := q.Get("organization_id"); got != "8" {
+			t.Fatalf("unexpected organization_id: %q", got)
+		}
+		if got := q.Get("include_fields"); got != "lead.was_seen" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
 		if got := q.Get("limit"); got != "2" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
@@ -56,6 +65,9 @@ func TestLeadsService_Search(t *testing.T) {
 		"alpha",
 		WithLeadSearchFields(LeadSearchFieldTitle, LeadSearchFieldNotes),
 		WithLeadSearchExactMatch(true),
+		WithLeadSearchPersonID(PersonID(7)),
+		WithLeadSearchOrganizationID(OrganizationID(8)),
+		WithLeadSearchIncludeFields(LeadSearchIncludeFieldLeadWasSeen),
 		WithLeadSearchPageSize(2),
 		WithLeadSearchCursor("c1"),
 		WithLeadRequestOptions(pipedrive.WithHeader("X-Test", "1")),

--- a/pipedrive/v2/persons.go
+++ b/pipedrive/v2/persons.go
@@ -66,6 +66,12 @@ const (
 	PersonSearchFieldPhone        PersonSearchField = "phone"
 )
 
+type PersonSearchIncludeField string
+
+const (
+	PersonSearchIncludeFieldPicture PersonSearchIncludeField = "person.picture"
+)
+
 type LabeledValue struct {
 	Value   string `json:"value,omitempty"`
 	Primary bool   `json:"primary,omitempty"`
@@ -525,6 +531,24 @@ func WithPersonSearchFields(fields ...PersonSearchField) SearchPersonsOption {
 func WithPersonSearchExactMatch(enabled bool) SearchPersonsOption {
 	return searchPersonsOptionFunc(func(cfg *searchPersonsOptions) {
 		cfg.params.ExactMatch = &enabled
+	})
+}
+
+func WithPersonSearchOrganizationID(id OrganizationID) SearchPersonsOption {
+	return searchPersonsOptionFunc(func(cfg *searchPersonsOptions) {
+		value := int(id)
+		cfg.params.OrganizationId = &value
+	})
+}
+
+func WithPersonSearchIncludeFields(fields ...PersonSearchIncludeField) SearchPersonsOption {
+	return searchPersonsOptionFunc(func(cfg *searchPersonsOptions) {
+		csv := joinCSV(fields)
+		if csv == "" {
+			return
+		}
+		value := genv2.SearchPersonsParamsIncludeFields(csv)
+		cfg.params.IncludeFields = &value
 	})
 }
 

--- a/pipedrive/v2/persons_test.go
+++ b/pipedrive/v2/persons_test.go
@@ -237,6 +237,12 @@ func TestPersonsService_Search(t *testing.T) {
 		if got := q.Get("exact_match"); got != "true" {
 			t.Fatalf("unexpected exact_match: %q", got)
 		}
+		if got := q.Get("organization_id"); got != "15" {
+			t.Fatalf("unexpected organization_id: %q", got)
+		}
+		if got := q.Get("include_fields"); got != "person.picture" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
 		if got := q.Get("limit"); got != "2" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
@@ -258,6 +264,8 @@ func TestPersonsService_Search(t *testing.T) {
 		"ada",
 		WithPersonSearchFields(PersonSearchFieldName, PersonSearchFieldEmail),
 		WithPersonSearchExactMatch(true),
+		WithPersonSearchOrganizationID(OrganizationID(15)),
+		WithPersonSearchIncludeFields(PersonSearchIncludeFieldPicture),
 		WithPersonSearchPageSize(2),
 		WithPersonSearchCursor("c2"),
 	)


### PR DESCRIPTION
- Adds `PersonID`, `OrganizationID` and `IncludeFields` search options for leads
- Adds `OrganizationID` and `IncludeFields` search options for persons
- All search endpoints now have full wrapper coverage for the generated API params