### PR TITLE
chore: bump Go version 1.26.1 -> 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.25.0", "1.26.1"]
+        go: ["1.25.0", "1.26.2"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: true
 
       - name: Security

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/juhokoskela/pipedrive-go
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
# Summary
- Bumps local toolchain and CI to run on the latest Go release, 1.26.2
- Go 1.26.2 fixed multiple CVEs in the standard library
- Fixes failing `govulncheck` test (fails are because of the vulnerable stdlib packages)