### PR TITLE
Raise SDK package coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: SDK coverage
+        if: matrix.go == '1.26.4'
+        run: go test -coverprofile=/tmp/pipedrive-go.cover -covermode=count ./pipedrive ./pipedrive/v1 ./pipedrive/v2
+
+      - name: Coveralls
+        if: matrix.go == '1.26.4'
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: /tmp/pipedrive-go.cover
+          format: golang
+
   security:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: /tmp/pipedrive-go.cover
           format: golang
+          coverage-reporter-version: v0.6.17
 
   security:
     runs-on: ubuntu-latest

--- a/pipedrive/auth_test.go
+++ b/pipedrive/auth_test.go
@@ -2,10 +2,13 @@ package pipedrive
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestNewHTTPClient_AppliesUserAgentAndAPIToken(t *testing.T) {
@@ -38,4 +41,98 @@ func TestNewHTTPClient_AppliesUserAgentAndAPIToken(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	_ = resp.Body.Close()
+}
+
+func TestAPITokenAuth_Apply(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	if err := APITokenAuth("token123").Apply(req); err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if got := req.Header.Get("x-api-token"); got != "token123" {
+		t.Fatalf("unexpected token header: %q", got)
+	}
+
+	if err := APITokenAuth("other").Apply(req); err != nil {
+		t.Fatalf("Apply existing header error: %v", err)
+	}
+	if got := req.Header.Get("x-api-token"); got != "token123" {
+		t.Fatalf("expected existing token to be preserved, got %q", got)
+	}
+
+	if err := APITokenAuth("").Apply(req); err != nil {
+		t.Fatalf("empty auth should not error: %v", err)
+	}
+	if err := APITokenAuth("token").Apply(nil); err != nil {
+		t.Fatalf("nil request should not error: %v", err)
+	}
+}
+
+func TestOAuth2Auth_Apply(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	auth := OAuth2Auth{TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access123"})}
+	if err := auth.Apply(req); err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer access123" {
+		t.Fatalf("unexpected authorization header: %q", got)
+	}
+
+	req.Header.Set("Authorization", "Bearer existing")
+	if err := auth.Apply(req); err != nil {
+		t.Fatalf("Apply existing header error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer existing" {
+		t.Fatalf("expected existing authorization to be preserved, got %q", got)
+	}
+
+	if err := (OAuth2Auth{}).Apply(req); err != nil {
+		t.Fatalf("empty auth should not error: %v", err)
+	}
+	if err := auth.Apply(nil); err != nil {
+		t.Fatalf("nil request should not error: %v", err)
+	}
+}
+
+func TestMultiAuth_ApplySkipsNilAndStopsOnError(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.test", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	wantErr := errors.New("auth failed")
+	auth := MultiAuth{
+		nil,
+		APITokenAuth("token123"),
+		errAuth{err: wantErr},
+		APITokenAuth("after-error"),
+	}
+	err = auth.Apply(req)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected auth error, got %v", err)
+	}
+	if got := req.Header.Get("x-api-token"); got != "token123" {
+		t.Fatalf("unexpected token header: %q", got)
+	}
+}
+
+type errAuth struct {
+	err error
+}
+
+func (a errAuth) Apply(*http.Request) error {
+	return a.err
 }

--- a/pipedrive/errors_test.go
+++ b/pipedrive/errors_test.go
@@ -1,6 +1,7 @@
 package pipedrive
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -66,5 +67,130 @@ func TestRateLimitErrorFromResponse_ParsesHeaders(t *testing.T) {
 	}
 	if !err.Reset.Equal(time.Date(2025, 1, 1, 0, 0, 5, 0, time.UTC)) {
 		t.Fatalf("unexpected reset time: %s", err.Reset)
+	}
+}
+
+func TestAPIError_Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *APIError
+		want string
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: "pipedrive: <nil>",
+		},
+		{
+			name: "code and message",
+			err:  &APIError{Status: 400, Code: "bad_request", Message: "Bad request"},
+			want: "pipedrive: http 400 bad_request: Bad request",
+		},
+		{
+			name: "message only",
+			err:  &APIError{Status: 404, Message: "Not found"},
+			want: "pipedrive: http 404: Not found",
+		},
+		{
+			name: "code only",
+			err:  &APIError{Status: 500, Code: "server_error"},
+			want: "pipedrive: http 500 server_error",
+		},
+		{
+			name: "status only",
+			err:  &APIError{Status: 502},
+			want: "pipedrive: http 502",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitError_ErrorAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	if got := (*RateLimitError)(nil).Error(); got != "pipedrive: rate limit" {
+		t.Fatalf("unexpected nil error string: %q", got)
+	}
+	if got := (&RateLimitError{}).Error(); got != "pipedrive: rate limit" {
+		t.Fatalf("unexpected empty error string: %q", got)
+	}
+
+	apiErr := &APIError{Status: 429, Code: "rate_limit", Message: "Slow down"}
+	err := &RateLimitError{APIError: apiErr, RetryAfter: 3 * time.Second}
+	if got := err.Error(); got != "pipedrive: http 429 rate_limit: Slow down (retry after 3s)" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, apiErr) {
+		t.Fatalf("expected errors.Is to match wrapped APIError")
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	future := now.Add(5 * time.Second).Format(http.TimeFormat)
+	past := now.Add(-5 * time.Second).Format(http.TimeFormat)
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{name: "empty", value: "", want: 0},
+		{name: "seconds", value: "7", want: 7 * time.Second},
+		{name: "negative seconds", value: "-1", want: 0},
+		{name: "future http date", value: future, want: 5 * time.Second},
+		{name: "past http date", value: past, want: 0},
+		{name: "invalid", value: "later", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseRetryAfter(tt.value, now); got != tt.want {
+				t.Fatalf("parseRetryAfter(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseResetHeader(t *testing.T) {
+	t.Parallel()
+
+	httpDate := time.Date(2025, 1, 1, 1, 2, 3, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		value string
+		want  time.Time
+	}{
+		{name: "empty", value: "", want: time.Time{}},
+		{name: "unix seconds", value: "1735689605", want: time.Date(2025, 1, 1, 0, 0, 5, 0, time.UTC)},
+		{name: "unix millis", value: "1735689605123", want: time.Date(2025, 1, 1, 0, 0, 5, 123000000, time.UTC)},
+		{name: "http date", value: httpDate.Format(http.TimeFormat), want: httpDate},
+		{name: "invalid", value: "not-a-time", want: time.Time{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseResetHeader(tt.value); !got.Equal(tt.want) {
+				t.Fatalf("parseResetHeader(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
 	}
 }

--- a/pipedrive/raw_test.go
+++ b/pipedrive/raw_test.go
@@ -2,9 +2,11 @@ package pipedrive
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -220,5 +222,75 @@ func TestRawClient_Do_ReturnsRateLimitErrorWhenLarge429BodyExceedsLimit(t *testi
 	}
 	if rlErr.Limit != 10 || rlErr.Remaining != 0 {
 		t.Fatalf("unexpected rate limit headers: limit=%d remaining=%d", rlErr.Limit, rlErr.Remaining)
+	}
+}
+
+func TestNewRawClient_RejectsInvalidBaseURL(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewRawClient("://bad", nil); err == nil {
+		t.Fatalf("expected parse error")
+	}
+	if _, err := NewRawClient("/relative", nil); err == nil {
+		t.Fatalf("expected missing scheme/host error")
+	}
+}
+
+func TestRawClient_Do_NilClient(t *testing.T) {
+	t.Parallel()
+
+	var raw *RawClient
+	if err := raw.Do(context.Background(), http.MethodGet, "/x", nil, nil, nil); err == nil {
+		t.Fatalf("expected nil client error")
+	}
+}
+
+func TestRawClient_Do_SendsQueryAndJSONBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/base/items" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query()["tag"]; len(got) != 2 || got[0] != "one" || got[1] != "two" {
+			t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Fatalf("unexpected accept: %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content type: %q", got)
+		}
+
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if payload["name"] != "item" {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	raw, err := NewRawClient(srv.URL+"/base/", srv.Client())
+	if err != nil {
+		t.Fatalf("NewRawClient error: %v", err)
+	}
+
+	var out struct {
+		Ok bool `json:"ok"`
+	}
+	query := url.Values{"tag": {"one", "two"}}
+	if err := raw.Do(context.Background(), http.MethodPost, "/items", query, map[string]string{"name": "item"}, &out); err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+	if !out.Ok {
+		t.Fatalf("expected ok")
 	}
 }

--- a/pipedrive/response_limit_test.go
+++ b/pipedrive/response_limit_test.go
@@ -96,6 +96,24 @@ func TestResponseLimitReadCloser_ReportsOverflowOnProbeRead(t *testing.T) {
 	}
 }
 
+func TestResponseLimitReadCloser_AllowsBodyExactlyAtLimit(t *testing.T) {
+	t.Parallel()
+
+	rc := &responseLimitReadCloser{
+		body:      io.NopCloser(strings.NewReader("ab")),
+		limit:     2,
+		remaining: 2,
+	}
+
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	if got := string(body); got != "ab" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
 func TestRawClient_Do_ResponseLimitCanBeOverriddenPerRequest(t *testing.T) {
 	t.Parallel()
 

--- a/pipedrive/retry_test.go
+++ b/pipedrive/retry_test.go
@@ -2,6 +2,7 @@ package pipedrive
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -274,5 +275,94 @@ func TestRetryTransport_NilRequestReturnsError(t *testing.T) {
 	}
 	if err.Error() != "pipedrive: nil request" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryHelpers(t *testing.T) {
+	t.Parallel()
+
+	for _, method := range []string{
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodOptions,
+		http.MethodTrace,
+	} {
+		if !isIdempotentMethod(method) {
+			t.Fatalf("expected %s to be idempotent", method)
+		}
+	}
+	for _, method := range []string{http.MethodPost, http.MethodPatch, "CUSTOM"} {
+		if isIdempotentMethod(method) {
+			t.Fatalf("expected %s to be non-idempotent", method)
+		}
+	}
+
+	if got := fullJitter(0); got != 0 {
+		t.Fatalf("fullJitter(0) = %s, want 0", got)
+	}
+	if got := fullJitter(-time.Second); got != 0 {
+		t.Fatalf("fullJitter(-1s) = %s, want 0", got)
+	}
+	for i := 0; i < 20; i++ {
+		if got := fullJitter(10 * time.Millisecond); got < 0 || got >= 10*time.Millisecond {
+			t.Fatalf("fullJitter out of range: %s", got)
+		}
+	}
+}
+
+func TestSleepWithContext_ReturnsOnCancel(t *testing.T) {
+	t.Parallel()
+
+	if err := sleepWithContext(context.Background(), 0); err != nil {
+		t.Fatalf("zero sleep error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := sleepWithContext(ctx, time.Hour)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+}
+
+func TestSanitizeRetryPolicy_ClampsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	policy := sanitizeRetryPolicy(RetryPolicy{
+		MaxAttempts: -3,
+		BaseDelay:   -time.Second,
+		MaxDelay:    0,
+		Jitter:      nil,
+	})
+
+	if policy.MaxAttempts != 1 {
+		t.Fatalf("expected max attempts 1, got %d", policy.MaxAttempts)
+	}
+	if policy.BaseDelay != 0 {
+		t.Fatalf("expected base delay 0, got %s", policy.BaseDelay)
+	}
+	if policy.MaxDelay != 0 {
+		t.Fatalf("expected max delay 0, got %s", policy.MaxDelay)
+	}
+	if policy.Jitter == nil {
+		t.Fatalf("expected default jitter")
+	}
+	if got := policy.Jitter(3 * time.Second); got != 3*time.Second {
+		t.Fatalf("unexpected default jitter result: %s", got)
+	}
+
+	policy = sanitizeRetryPolicy(RetryPolicy{
+		MaxAttempts: 2,
+		BaseDelay:   time.Second,
+		MaxDelay:    -time.Second,
+		Jitter:      func(d time.Duration) time.Duration { return d / 2 },
+	})
+	if policy.MaxDelay != time.Second {
+		t.Fatalf("expected max delay to default to base delay, got %s", policy.MaxDelay)
+	}
+	if got := policy.Jitter(4 * time.Second); got != 2*time.Second {
+		t.Fatalf("unexpected custom jitter result: %s", got)
 	}
 }

--- a/pipedrive/v1/activity_types_test.go
+++ b/pipedrive/v1/activity_types_test.go
@@ -111,6 +111,9 @@ func TestActivityTypesService_Update(t *testing.T) {
 		if r.URL.Path != "/activityTypes/12" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -138,6 +141,7 @@ func TestActivityTypesService_Update(t *testing.T) {
 		ActivityTypeID(12),
 		WithActivityTypeName("Updated"),
 		WithActivityTypeOrder(2),
+		WithActivityTypesRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -157,6 +161,9 @@ func TestActivityTypesService_Delete(t *testing.T) {
 		if r.URL.Path != "/activityTypes/12" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":12,"name":"Video call","icon_key":"camera"}}`))
 	}))
@@ -167,7 +174,11 @@ func TestActivityTypesService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	deleted, err := client.ActivityTypes.Delete(context.Background(), ActivityTypeID(12))
+	deleted, err := client.ActivityTypes.Delete(
+		context.Background(),
+		ActivityTypeID(12),
+		WithActivityTypesRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}

--- a/pipedrive/v1/call_logs_test.go
+++ b/pipedrive/v1/call_logs_test.go
@@ -83,10 +83,28 @@ func TestCallLogsService_Create(t *testing.T) {
 		if r.URL.Path != "/callLogs" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "\"user_id\":7") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"activity_id\":8") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"subject\":\"Discovery call\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"duration\":\"00:01:00\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"from_phone_number\":\"+321\"") {
+			t.Fatalf("unexpected body: %s", body)
 		}
 		if !strings.Contains(string(body), "\"to_phone_number\":\"+123\"") {
 			t.Fatalf("unexpected body: %s", body)
@@ -95,6 +113,21 @@ func TestCallLogsService_Create(t *testing.T) {
 			t.Fatalf("unexpected body: %s", body)
 		}
 		if !strings.Contains(string(body), "\"start_time\":\"2022-12-12 01:01:01\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"person_id\":9") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"org_id\":10") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"deal_id\":11") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"lead_id\":\"adf21080-0e10-11eb-879b-05d71fb426ec\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"note\":\"Call notes\"") {
 			t.Fatalf("unexpected body: %s", body)
 		}
 
@@ -110,10 +143,21 @@ func TestCallLogsService_Create(t *testing.T) {
 
 	log, err := client.CallLogs.Create(
 		context.Background(),
+		WithCallLogUserID(UserID(7)),
+		WithCallLogActivityID(ActivityID(8)),
+		WithCallLogSubject("Discovery call"),
+		WithCallLogDuration("00:01:00"),
+		WithCallLogFromPhoneNumber("+321"),
 		WithCallLogToPhoneNumber("+123"),
 		WithCallLogOutcome(CallLogOutcomeConnected),
 		WithCallLogStartTime(start),
 		WithCallLogEndTime(end),
+		WithCallLogPersonID(PersonID(9)),
+		WithCallLogOrganizationID(OrganizationID(10)),
+		WithCallLogDealID(DealID(11)),
+		WithCallLogLeadID(LeadID("adf21080-0e10-11eb-879b-05d71fb426ec")),
+		WithCallLogNote("Call notes"),
+		WithCallLogsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -136,6 +180,9 @@ func TestCallLogsService_Get(t *testing.T) {
 		if r.URL.Path != "/callLogs/log-1" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"log-1","outcome":"busy","to_phone_number":"+123","start_time":"2022-12-12 01:01:01","end_time":"2022-12-12 01:02:01"}}`))
 	}))
@@ -146,7 +193,11 @@ func TestCallLogsService_Get(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	log, err := client.CallLogs.Get(context.Background(), CallLogID("log-1"))
+	log, err := client.CallLogs.Get(
+		context.Background(),
+		CallLogID("log-1"),
+		WithCallLogsRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -165,6 +216,9 @@ func TestCallLogsService_Delete(t *testing.T) {
 		if r.URL.Path != "/callLogs/log-1" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	}))
@@ -175,7 +229,11 @@ func TestCallLogsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.CallLogs.Delete(context.Background(), CallLogID("log-1"))
+	ok, err := client.CallLogs.Delete(
+		context.Background(),
+		CallLogID("log-1"),
+		WithCallLogsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -195,6 +253,9 @@ func TestCallLogsService_AddRecording(t *testing.T) {
 		}
 		if r.URL.Path != "/callLogs/log-1/recordings" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "recording" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		contentType := r.Header.Get("Content-Type")
@@ -235,7 +296,13 @@ func TestCallLogsService_AddRecording(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.CallLogs.AddRecording(context.Background(), CallLogID("log-1"), "recording.mp3", bytes.NewReader(audio))
+	ok, err := client.CallLogs.AddRecording(
+		context.Background(),
+		CallLogID("log-1"),
+		"recording.mp3",
+		bytes.NewReader(audio),
+		WithCallLogsRequestOptions(pipedrive.WithHeader("X-Test", "recording")),
+	)
 	if err != nil {
 		t.Fatalf("AddRecording error: %v", err)
 	}

--- a/pipedrive/v1/channels_test.go
+++ b/pipedrive/v1/channels_test.go
@@ -37,6 +37,12 @@ func TestChannelsService_Create(t *testing.T) {
 		if payload["provider_channel_id"] != "provider-1" {
 			t.Fatalf("unexpected provider_channel_id: %#v", payload["provider_channel_id"])
 		}
+		if payload["avatar_url"] != "https://example.com/avatar.png" {
+			t.Fatalf("unexpected avatar_url: %#v", payload["avatar_url"])
+		}
+		if payload["template_support"] != true {
+			t.Fatalf("unexpected template_support: %#v", payload["template_support"])
+		}
 		if payload["provider_type"] != "other" {
 			t.Fatalf("unexpected provider_type: %#v", payload["provider_type"])
 		}
@@ -55,6 +61,8 @@ func TestChannelsService_Create(t *testing.T) {
 		context.Background(),
 		WithChannelName("My Channel"),
 		WithChannelProviderID("provider-1"),
+		WithChannelAvatarURL("https://example.com/avatar.png"),
+		WithChannelTemplateSupport(true),
 		WithChannelProviderType(ChannelProviderTypeOther),
 		WithChannelsRequestOptions(pipedrive.WithHeader("X-Test", "1")),
 	)
@@ -79,6 +87,9 @@ func TestChannelsService_Delete(t *testing.T) {
 		if r.URL.Path != "/channels/chan-1" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	}))
@@ -89,7 +100,11 @@ func TestChannelsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Channels.Delete(context.Background(), ChannelID("chan-1"))
+	ok, err := client.Channels.Delete(
+		context.Background(),
+		ChannelID("chan-1"),
+		WithChannelsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -102,6 +117,8 @@ func TestChannelsService_ReceiveMessage(t *testing.T) {
 	t.Parallel()
 
 	created := time.Date(2022, 3, 1, 7, 58, 0, 0, time.UTC)
+	replyBy := time.Date(2022, 3, 1, 8, 58, 0, 0, time.UTC)
+	attachmentSize := float64(123)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -109,6 +126,9 @@ func TestChannelsService_ReceiveMessage(t *testing.T) {
 		}
 		if r.URL.Path != "/channels/messages/receive" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "receive" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -118,6 +138,15 @@ func TestChannelsService_ReceiveMessage(t *testing.T) {
 			t.Fatalf("unexpected body: %s", body)
 		}
 		if !strings.Contains(string(body), "\"status\":\"sent\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"reply_by\":\"2022-03-01 08:58:00\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"conversation_link\":\"https://example.com/conversations/conv-1\"") {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if !strings.Contains(string(body), "\"attachments\"") {
 			t.Fatalf("unexpected body: %s", body)
 		}
 
@@ -140,6 +169,17 @@ func TestChannelsService_ReceiveMessage(t *testing.T) {
 		WithChannelMessageBody("Hello"),
 		WithChannelMessageStatus(ChannelMessageStatusSent),
 		WithChannelMessageCreatedAt(created),
+		WithChannelMessageReplyBy(replyBy),
+		WithChannelMessageConversationLink("https://example.com/conversations/conv-1"),
+		WithChannelMessageAttachments(ChannelMessageAttachment{
+			ID:         "att-1",
+			Type:       "image/png",
+			Name:       "Image",
+			Size:       &attachmentSize,
+			URL:        "http://example.com/a.png",
+			PreviewURL: "http://example.com/a.preview.png",
+		}),
+		WithChannelsRequestOptions(pipedrive.WithHeader("X-Test", "receive")),
 	)
 	if err != nil {
 		t.Fatalf("ReceiveMessage error: %v", err)
@@ -165,6 +205,9 @@ func TestChannelsService_DeleteConversation(t *testing.T) {
 		if r.URL.Path != "/channels/chan-1/conversations/conv-1" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-conversation" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	}))
@@ -175,7 +218,12 @@ func TestChannelsService_DeleteConversation(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Channels.DeleteConversation(context.Background(), ChannelID("chan-1"), ConversationID("conv-1"))
+	ok, err := client.Channels.DeleteConversation(
+		context.Background(),
+		ChannelID("chan-1"),
+		ConversationID("conv-1"),
+		WithChannelsRequestOptions(pipedrive.WithHeader("X-Test", "delete-conversation")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteConversation error: %v", err)
 	}

--- a/pipedrive/v1/filters_test.go
+++ b/pipedrive/v1/filters_test.go
@@ -98,6 +98,9 @@ func TestFiltersService_Create(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("unexpected content type: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -130,6 +133,7 @@ func TestFiltersService_Create(t *testing.T) {
 		WithFilterName("New Filter"),
 		WithFilterType(FilterTypeDeals),
 		WithFilterConditions(conditions),
+		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -148,6 +152,9 @@ func TestFiltersService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/filters/10" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -174,6 +181,7 @@ func TestFiltersService_Update(t *testing.T) {
 		FilterID(10),
 		WithFilterName("Updated Filter"),
 		WithFilterConditions(FilterConditions{"glue": "and"}),
+		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -193,6 +201,9 @@ func TestFiltersService_Delete(t *testing.T) {
 		if r.URL.Path != "/filters/10" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":10}}`))
 	}))
@@ -203,7 +214,11 @@ func TestFiltersService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Filters.Delete(context.Background(), FilterID(10))
+	result, err := client.Filters.Delete(
+		context.Background(),
+		FilterID(10),
+		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -225,6 +240,9 @@ func TestFiltersService_DeleteBulk(t *testing.T) {
 		if got := r.URL.Query().Get("ids"); got != "1,2,3" {
 			t.Fatalf("unexpected ids: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-bulk" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":[1,2,3]}}`))
 	}))
@@ -235,7 +253,11 @@ func TestFiltersService_DeleteBulk(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Filters.DeleteBulk(context.Background(), []FilterID{1, 2, 3})
+	result, err := client.Filters.DeleteBulk(
+		context.Background(),
+		[]FilterID{1, 2, 3},
+		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "delete-bulk")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteBulk error: %v", err)
 	}
@@ -254,6 +276,9 @@ func TestFiltersService_ListHelpers(t *testing.T) {
 		if r.URL.Path != "/filters/helpers" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "helpers" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"example":1}}`))
 	}))
@@ -264,11 +289,91 @@ func TestFiltersService_ListHelpers(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	helpers, err := client.Filters.ListHelpers(context.Background())
+	helpers, err := client.Filters.ListHelpers(
+		context.Background(),
+		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "helpers")),
+	)
 	if err != nil {
 		t.Fatalf("ListHelpers error: %v", err)
 	}
 	if helpers["success"] != true {
 		t.Fatalf("unexpected helpers: %#v", helpers)
+	}
+}
+
+func TestFiltersService_ErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"server error"}`))
+	})
+
+	conditions := FilterConditions{"glue": "and"}
+	if _, err := client.Filters.List(context.Background()); err == nil {
+		t.Fatalf("expected List error")
+	}
+	if _, err := client.Filters.Get(context.Background(), FilterID(1)); err == nil {
+		t.Fatalf("expected Get error")
+	}
+	if _, err := client.Filters.Create(
+		context.Background(),
+		WithFilterName("Filter"),
+		WithFilterType(FilterTypeDeals),
+		WithFilterConditions(conditions),
+	); err == nil {
+		t.Fatalf("expected Create error")
+	}
+	if _, err := client.Filters.Update(
+		context.Background(),
+		FilterID(1),
+		WithFilterName("Updated"),
+	); err == nil {
+		t.Fatalf("expected Update error")
+	}
+	if _, err := client.Filters.Delete(context.Background(), FilterID(1)); err == nil {
+		t.Fatalf("expected Delete error")
+	}
+	if _, err := client.Filters.DeleteBulk(context.Background(), []FilterID{1, 2}); err == nil {
+		t.Fatalf("expected DeleteBulk error")
+	}
+	if _, err := client.Filters.ListHelpers(context.Background()); err == nil {
+		t.Fatalf("expected ListHelpers error")
+	}
+}
+
+func TestFiltersService_MissingDataErrors(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+
+	conditions := FilterConditions{"glue": "and"}
+	if _, err := client.Filters.Get(context.Background(), FilterID(1)); err == nil {
+		t.Fatalf("expected Get missing data error")
+	}
+	if _, err := client.Filters.Create(
+		context.Background(),
+		WithFilterName("Filter"),
+		WithFilterType(FilterTypeDeals),
+		WithFilterConditions(conditions),
+	); err == nil {
+		t.Fatalf("expected Create missing data error")
+	}
+	if _, err := client.Filters.Update(
+		context.Background(),
+		FilterID(1),
+		WithFilterName("Updated"),
+	); err == nil {
+		t.Fatalf("expected Update missing data error")
+	}
+	if _, err := client.Filters.Delete(context.Background(), FilterID(1)); err == nil {
+		t.Fatalf("expected Delete missing data error")
+	}
+	if _, err := client.Filters.DeleteBulk(context.Background(), []FilterID{1, 2}); err == nil {
+		t.Fatalf("expected DeleteBulk missing data error")
 	}
 }

--- a/pipedrive/v1/goals_test.go
+++ b/pipedrive/v1/goals_test.go
@@ -28,6 +28,9 @@ func TestGoalsService_List(t *testing.T) {
 		if got := q.Get("type.name"); got != "deals_won" {
 			t.Fatalf("unexpected type.name: %q", got)
 		}
+		if got := q.Get("title"); got != "Pipeline goals" {
+			t.Fatalf("unexpected title: %q", got)
+		}
 		if got := q.Get("assignee.id"); got != "12" {
 			t.Fatalf("unexpected assignee.id: %q", got)
 		}
@@ -40,6 +43,12 @@ func TestGoalsService_List(t *testing.T) {
 		if got := q.Get("expected_outcome.target"); got != "42" {
 			t.Fatalf("unexpected expected_outcome.target: %q", got)
 		}
+		if got := q.Get("expected_outcome.tracking_metric"); got != "quantity" {
+			t.Fatalf("unexpected expected_outcome.tracking_metric: %q", got)
+		}
+		if got := q.Get("expected_outcome.currency_id"); got != "978" {
+			t.Fatalf("unexpected expected_outcome.currency_id: %q", got)
+		}
 		if got := q.Get("period.start"); got != "2024-01-01" {
 			t.Fatalf("unexpected period.start: %q", got)
 		}
@@ -48,6 +57,12 @@ func TestGoalsService_List(t *testing.T) {
 		}
 		if got := q["type.params.pipeline_id"]; len(got) != 2 || got[0] != "3" || got[1] != "5" {
 			t.Fatalf("unexpected pipeline ids: %#v", got)
+		}
+		if got := q.Get("type.params.stage_id"); got != "6" {
+			t.Fatalf("unexpected stage_id: %q", got)
+		}
+		if got := q["type.params.activity_type_id"]; len(got) != 2 || got[0] != "7" || got[1] != "8" {
+			t.Fatalf("unexpected activity type ids: %#v", got)
 		}
 		if got := r.Header.Get("X-Test"); got != "1" {
 			t.Fatalf("unexpected header X-Test: %q", got)
@@ -66,11 +81,16 @@ func TestGoalsService_List(t *testing.T) {
 	goals, err := client.Goals.List(
 		context.Background(),
 		WithGoalsTypeName(GoalTypeNameDealsWon),
+		WithGoalsTitle("Pipeline goals"),
 		WithGoalsAssigneeID(12),
 		WithGoalsAssigneeType(GoalAssigneeTypeTeam),
 		WithGoalsActive(true),
 		WithGoalsExpectedOutcomeTarget(42),
+		WithGoalsExpectedOutcomeTrackingMetric(GoalTrackingMetricQuantity),
+		WithGoalsExpectedOutcomeCurrencyID(CurrencyID(978)),
 		WithGoalsTypePipelineIDs(PipelineID(3), PipelineID(5)),
+		WithGoalsTypeStageID(StageID(6)),
+		WithGoalsTypeActivityTypeIDs(ActivityTypeID(7), ActivityTypeID(8)),
 		WithGoalsPeriodStart(start),
 		WithGoalsPeriodEnd(end),
 		WithGoalsRequestOptions(pipedrive.WithHeader("X-Test", "1")),
@@ -131,6 +151,13 @@ func TestGoalsService_Create(t *testing.T) {
 		if !ok || len(pipelines) != 2 || pipelines[0] != float64(1) || pipelines[1] != float64(2) {
 			t.Fatalf("unexpected pipeline ids: %#v", params["pipeline_id"])
 		}
+		if params["stage_id"] != float64(6) {
+			t.Fatalf("unexpected stage_id: %#v", params["stage_id"])
+		}
+		activities, ok := params["activity_type_id"].([]interface{})
+		if !ok || len(activities) != 2 || activities[0] != float64(7) || activities[1] != float64(8) {
+			t.Fatalf("unexpected activity type ids: %#v", params["activity_type_id"])
+		}
 
 		expected, ok := payload["expected_outcome"].(map[string]interface{})
 		if !ok {
@@ -138,6 +165,9 @@ func TestGoalsService_Create(t *testing.T) {
 		}
 		if expected["target"] != float64(100) || expected["tracking_metric"] != "quantity" {
 			t.Fatalf("unexpected expected_outcome: %#v", expected)
+		}
+		if expected["currency_id"] != float64(978) {
+			t.Fatalf("unexpected currency_id: %#v", expected["currency_id"])
 		}
 
 		duration, ok := payload["duration"].(map[string]interface{})
@@ -168,8 +198,11 @@ func TestGoalsService_Create(t *testing.T) {
 		WithGoalAssigneeType(GoalAssigneeTypePerson),
 		WithGoalTypeName(GoalTypeNameDealsStarted),
 		WithGoalTypePipelineIDs(PipelineID(1), PipelineID(2)),
+		WithGoalTypeStageID(StageID(6)),
+		WithGoalTypeActivityTypeIDs(ActivityTypeID(7), ActivityTypeID(8)),
 		WithGoalExpectedOutcomeTarget(100),
 		WithGoalExpectedOutcomeTrackingMetric(GoalTrackingMetricQuantity),
+		WithGoalExpectedOutcomeCurrencyID(CurrencyID(978)),
 		WithGoalDurationStart("2024-01-01"),
 		WithGoalDurationEnd("2024-12-31"),
 		WithGoalInterval(GoalIntervalMonthly),
@@ -192,6 +225,9 @@ func TestGoalsService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/goals/goal-3" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		var payload map[string]interface{}
@@ -223,6 +259,7 @@ func TestGoalsService_Update(t *testing.T) {
 		GoalID("goal-3"),
 		WithGoalTitle("Updated Goal"),
 		WithGoalInterval(GoalIntervalQuarterly),
+		WithGoalsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -242,6 +279,9 @@ func TestGoalsService_Delete(t *testing.T) {
 		if r.URL.Path != "/goals/goal-4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
@@ -253,7 +293,11 @@ func TestGoalsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Goals.Delete(context.Background(), GoalID("goal-4"))
+	ok, err := client.Goals.Delete(
+		context.Background(),
+		GoalID("goal-4"),
+		WithGoalsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -282,6 +326,9 @@ func TestGoalsService_GetResult(t *testing.T) {
 		if got := q.Get("period.end"); got != "2024-02-28" {
 			t.Fatalf("unexpected period.end: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "result" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"progress":3,"goal":{"id":"goal-5","title":"Result goal"}}}`))
@@ -298,6 +345,7 @@ func TestGoalsService_GetResult(t *testing.T) {
 		GoalID("goal-5"),
 		WithGoalResultStartDate(start),
 		WithGoalResultEndDate(end),
+		WithGoalsRequestOptions(pipedrive.WithHeader("X-Test", "result")),
 	)
 	if err != nil {
 		t.Fatalf("GetResult error: %v", err)

--- a/pipedrive/v1/lead_labels_test.go
+++ b/pipedrive/v1/lead_labels_test.go
@@ -58,6 +58,9 @@ func TestLeadLabelsService_Create(t *testing.T) {
 		if r.URL.Path != "/leadLabels" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -84,6 +87,7 @@ func TestLeadLabelsService_Create(t *testing.T) {
 		context.Background(),
 		WithLeadLabelName("Hot"),
 		WithLeadLabelColor(LeadLabelColorRed),
+		WithLeadLabelsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -102,6 +106,9 @@ func TestLeadLabelsService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/leadLabels/f08b42a0-4e75-11ea-9643-03698ef1cfd6" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		var payload map[string]interface{}
@@ -126,6 +133,7 @@ func TestLeadLabelsService_Update(t *testing.T) {
 		context.Background(),
 		LeadLabelID("f08b42a0-4e75-11ea-9643-03698ef1cfd6"),
 		WithLeadLabelColor(LeadLabelColorBlue),
+		WithLeadLabelsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -145,6 +153,9 @@ func TestLeadLabelsService_Delete(t *testing.T) {
 		if r.URL.Path != "/leadLabels/f08b42a0-4e75-11ea-9643-03698ef1cfd6" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"f08b42a0-4e75-11ea-9643-03698ef1cfd6"}}`))
@@ -156,7 +167,11 @@ func TestLeadLabelsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.LeadLabels.Delete(context.Background(), LeadLabelID("f08b42a0-4e75-11ea-9643-03698ef1cfd6"))
+	result, err := client.LeadLabels.Delete(
+		context.Background(),
+		LeadLabelID("f08b42a0-4e75-11ea-9643-03698ef1cfd6"),
+		WithLeadLabelsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}

--- a/pipedrive/v1/leads_test.go
+++ b/pipedrive/v1/leads_test.go
@@ -96,6 +96,27 @@ func TestLeadsService_ListArchived(t *testing.T) {
 		if got := r.URL.Query().Get("limit"); got != "1" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
+		if got := r.URL.Query().Get("start"); got != "2" {
+			t.Fatalf("unexpected start: %q", got)
+		}
+		if got := r.URL.Query().Get("owner_id"); got != "7" {
+			t.Fatalf("unexpected owner_id: %q", got)
+		}
+		if got := r.URL.Query().Get("person_id"); got != "9" {
+			t.Fatalf("unexpected person_id: %q", got)
+		}
+		if got := r.URL.Query().Get("organization_id"); got != "11" {
+			t.Fatalf("unexpected organization_id: %q", got)
+		}
+		if got := r.URL.Query().Get("filter_id"); got != "3" {
+			t.Fatalf("unexpected filter_id: %q", got)
+		}
+		if got := r.URL.Query().Get("sort"); got != "update_time ASC" {
+			t.Fatalf("unexpected sort: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "archived" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":"adf21080-0e10-11eb-879b-05d71fb426ec","title":"Archived","is_archived":true,"add_time":"2020-10-14T11:30:36.551Z"}],"additional_data":{"start":0,"limit":1,"more_items_in_collection":false}}`))
 	}))
@@ -106,7 +127,17 @@ func TestLeadsService_ListArchived(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	leads, page, err := client.Leads.ListArchived(context.Background(), WithArchivedLeadsLimit(1))
+	leads, page, err := client.Leads.ListArchived(
+		context.Background(),
+		WithArchivedLeadsLimit(1),
+		WithArchivedLeadsStart(2),
+		WithArchivedLeadsOwnerID(UserID(7)),
+		WithArchivedLeadsPersonID(PersonID(9)),
+		WithArchivedLeadsOrganizationID(OrganizationID(11)),
+		WithArchivedLeadsFilterID(3),
+		WithArchivedLeadsSort("update_time ASC"),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "archived")),
+	)
 	if err != nil {
 		t.Fatalf("ListArchived error: %v", err)
 	}
@@ -129,6 +160,9 @@ func TestLeadsService_Get(t *testing.T) {
 		if r.URL.Path != "/leads/"+id {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"` + id + `","title":"Lead","add_time":"2020-10-14T11:30:36.551Z"}}`))
 	}))
@@ -139,7 +173,11 @@ func TestLeadsService_Get(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	lead, err := client.Leads.Get(context.Background(), LeadID(id))
+	lead, err := client.Leads.Get(
+		context.Background(),
+		LeadID(id),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -160,6 +198,9 @@ func TestLeadsService_Create(t *testing.T) {
 		if r.URL.Path != "/leads" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -171,11 +212,33 @@ func TestLeadsService_Create(t *testing.T) {
 		if payload["person_id"] != float64(9) {
 			t.Fatalf("unexpected person_id: %#v", payload["person_id"])
 		}
+		if payload["owner_id"] != float64(7) {
+			t.Fatalf("unexpected owner_id: %#v", payload["owner_id"])
+		}
+		if payload["organization_id"] != float64(11) {
+			t.Fatalf("unexpected organization_id: %#v", payload["organization_id"])
+		}
+		value, ok := payload["value"].(map[string]interface{})
+		if !ok || value["amount"] != float64(1000) || value["currency"] != "EUR" {
+			t.Fatalf("unexpected value: %#v", payload["value"])
+		}
 		if payload["expected_close_date"] != "2024-01-10" {
 			t.Fatalf("unexpected expected_close_date: %#v", payload["expected_close_date"])
 		}
+		if payload["visible_to"] != "3" {
+			t.Fatalf("unexpected visible_to: %#v", payload["visible_to"])
+		}
+		if payload["was_seen"] != true {
+			t.Fatalf("unexpected was_seen: %#v", payload["was_seen"])
+		}
 		if payload["origin_id"] != "origin-1" {
 			t.Fatalf("unexpected origin_id: %#v", payload["origin_id"])
+		}
+		if payload["channel"] != float64(2) {
+			t.Fatalf("unexpected channel: %#v", payload["channel"])
+		}
+		if payload["channel_id"] != "channel-1" {
+			t.Fatalf("unexpected channel_id: %#v", payload["channel_id"])
 		}
 		labels := payload["label_ids"].([]interface{})
 		if len(labels) != 1 || labels[0] != labelID {
@@ -195,10 +258,18 @@ func TestLeadsService_Create(t *testing.T) {
 	lead, err := client.Leads.Create(
 		context.Background(),
 		WithLeadTitle("New Lead"),
+		WithLeadOwnerID(UserID(7)),
 		WithLeadPersonID(PersonID(9)),
+		WithLeadOrganizationID(OrganizationID(11)),
 		WithLeadLabelIDs(LeadLabelID(labelID)),
+		WithLeadValue(1000, "EUR"),
 		WithLeadExpectedCloseDate("2024-01-10"),
+		WithLeadVisibleTo("3"),
+		WithLeadWasSeen(true),
 		WithLeadOriginID("origin-1"),
+		WithLeadChannel(2),
+		WithLeadChannelID("channel-1"),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -219,6 +290,9 @@ func TestLeadsService_Update(t *testing.T) {
 		if r.URL.Path != "/leads/"+id {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -229,6 +303,18 @@ func TestLeadsService_Update(t *testing.T) {
 		}
 		if payload["is_archived"] != true {
 			t.Fatalf("unexpected is_archived: %#v", payload["is_archived"])
+		}
+		if payload["owner_id"] != float64(7) {
+			t.Fatalf("unexpected owner_id: %#v", payload["owner_id"])
+		}
+		if payload["organization_id"] != float64(11) {
+			t.Fatalf("unexpected organization_id: %#v", payload["organization_id"])
+		}
+		if payload["channel"] != float64(2) {
+			t.Fatalf("unexpected channel: %#v", payload["channel"])
+		}
+		if payload["channel_id"] != "channel-1" {
+			t.Fatalf("unexpected channel_id: %#v", payload["channel_id"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -245,7 +331,12 @@ func TestLeadsService_Update(t *testing.T) {
 		context.Background(),
 		LeadID(id),
 		WithLeadTitle("Updated"),
+		WithLeadOwnerID(UserID(7)),
+		WithLeadOrganizationID(OrganizationID(11)),
+		WithLeadChannel(2),
+		WithLeadChannelID("channel-1"),
 		WithLeadArchived(true),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -266,6 +357,9 @@ func TestLeadsService_Delete(t *testing.T) {
 		if r.URL.Path != "/leads/"+id {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":"` + id + `"}}`))
 	}))
@@ -276,7 +370,11 @@ func TestLeadsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Leads.Delete(context.Background(), LeadID(id))
+	result, err := client.Leads.Delete(
+		context.Background(),
+		LeadID(id),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -296,6 +394,9 @@ func TestLeadsService_ListPermittedUsers(t *testing.T) {
 		if r.URL.Path != "/leads/"+id+"/permittedUsers" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "permitted-users" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[101,202]}`))
 	}))
@@ -306,7 +407,11 @@ func TestLeadsService_ListPermittedUsers(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	users, err := client.Leads.ListPermittedUsers(context.Background(), LeadID(id))
+	users, err := client.Leads.ListPermittedUsers(
+		context.Background(),
+		LeadID(id),
+		WithLeadsRequestOptions(pipedrive.WithHeader("X-Test", "permitted-users")),
+	)
 	if err != nil {
 		t.Fatalf("ListPermittedUsers error: %v", err)
 	}

--- a/pipedrive/v1/notes_test.go
+++ b/pipedrive/v1/notes_test.go
@@ -60,6 +60,18 @@ func TestNotesService_List(t *testing.T) {
 		if got := q.Get("pinned_to_deal_flag"); got != "1" {
 			t.Fatalf("unexpected pinned_to_deal_flag: %q", got)
 		}
+		if got := q.Get("pinned_to_lead_flag"); got != "1" {
+			t.Fatalf("unexpected pinned_to_lead_flag: %q", got)
+		}
+		if got := q.Get("pinned_to_organization_flag"); got != "1" {
+			t.Fatalf("unexpected pinned_to_organization_flag: %q", got)
+		}
+		if got := q.Get("pinned_to_person_flag"); got != "1" {
+			t.Fatalf("unexpected pinned_to_person_flag: %q", got)
+		}
+		if got := q.Get("pinned_to_project_flag"); got != "1" {
+			t.Fatalf("unexpected pinned_to_project_flag: %q", got)
+		}
 		if got := r.Header.Get("X-Test"); got != "1" {
 			t.Fatalf("unexpected header X-Test: %q", got)
 		}
@@ -91,6 +103,10 @@ func TestNotesService_List(t *testing.T) {
 		WithNotesStartDate(start),
 		WithNotesEndDate(end),
 		WithNotesPinnedToDeal(true),
+		WithNotesPinnedToLead(true),
+		WithNotesPinnedToOrganization(true),
+		WithNotesPinnedToPerson(true),
+		WithNotesPinnedToProject(true),
 		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "1")),
 	)
 	if err != nil {
@@ -123,6 +139,9 @@ func TestNotesService_Create(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("unexpected content type: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -133,6 +152,18 @@ func TestNotesService_Create(t *testing.T) {
 		if payload["deal_id"] != float64(2) {
 			t.Fatalf("unexpected deal_id: %#v", payload["deal_id"])
 		}
+		if payload["lead_id"] != "adf21080-0e10-11eb-879b-05d71fb426ec" {
+			t.Fatalf("unexpected lead_id: %#v", payload["lead_id"])
+		}
+		if payload["person_id"] != float64(3) {
+			t.Fatalf("unexpected person_id: %#v", payload["person_id"])
+		}
+		if payload["org_id"] != float64(4) {
+			t.Fatalf("unexpected org_id: %#v", payload["org_id"])
+		}
+		if payload["project_id"] != float64(5) {
+			t.Fatalf("unexpected project_id: %#v", payload["project_id"])
+		}
 		if payload["user_id"] != float64(7) {
 			t.Fatalf("unexpected user_id: %#v", payload["user_id"])
 		}
@@ -141,6 +172,18 @@ func TestNotesService_Create(t *testing.T) {
 		}
 		if payload["pinned_to_deal_flag"] != float64(1) {
 			t.Fatalf("unexpected pinned_to_deal_flag: %#v", payload["pinned_to_deal_flag"])
+		}
+		if payload["pinned_to_lead_flag"] != float64(1) {
+			t.Fatalf("unexpected pinned_to_lead_flag: %#v", payload["pinned_to_lead_flag"])
+		}
+		if payload["pinned_to_organization_flag"] != float64(1) {
+			t.Fatalf("unexpected pinned_to_organization_flag: %#v", payload["pinned_to_organization_flag"])
+		}
+		if payload["pinned_to_person_flag"] != float64(1) {
+			t.Fatalf("unexpected pinned_to_person_flag: %#v", payload["pinned_to_person_flag"])
+		}
+		if payload["pinned_to_project_flag"] != float64(1) {
+			t.Fatalf("unexpected pinned_to_project_flag: %#v", payload["pinned_to_project_flag"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -156,10 +199,19 @@ func TestNotesService_Create(t *testing.T) {
 	note, err := client.Notes.Create(
 		context.Background(),
 		WithNoteContent("Hello"),
+		WithNoteLeadID(LeadID("adf21080-0e10-11eb-879b-05d71fb426ec")),
 		WithNoteDealID(DealID(2)),
+		WithNotePersonID(PersonID(3)),
+		WithNoteOrganizationID(OrganizationID(4)),
+		WithNoteProjectID(ProjectID(5)),
 		WithNoteUserID(UserID(7)),
 		WithNoteAddTime(time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)),
+		WithNotePinnedToLead(true),
 		WithNotePinnedToDeal(true),
+		WithNotePinnedToOrganization(true),
+		WithNotePinnedToPerson(true),
+		WithNotePinnedToProject(true),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -207,6 +259,9 @@ func TestNotesService_Get(t *testing.T) {
 		if r.URL.Path != "/notes/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":5,"content":"Hello","deal_id":2}}`))
@@ -218,7 +273,11 @@ func TestNotesService_Get(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	note, err := client.Notes.Get(context.Background(), NoteID(5))
+	note, err := client.Notes.Get(
+		context.Background(),
+		NoteID(5),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -237,6 +296,9 @@ func TestNotesService_Update(t *testing.T) {
 		if r.URL.Path != "/notes/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -249,6 +311,30 @@ func TestNotesService_Update(t *testing.T) {
 		}
 		if payload["deal_id"] != float64(2) {
 			t.Fatalf("unexpected deal_id: %#v", payload["deal_id"])
+		}
+		if payload["lead_id"] != "adf21080-0e10-11eb-879b-05d71fb426ec" {
+			t.Fatalf("unexpected lead_id: %#v", payload["lead_id"])
+		}
+		if payload["person_id"] != float64(3) {
+			t.Fatalf("unexpected person_id: %#v", payload["person_id"])
+		}
+		if payload["org_id"] != float64(4) {
+			t.Fatalf("unexpected org_id: %#v", payload["org_id"])
+		}
+		if payload["project_id"] != float64(5) {
+			t.Fatalf("unexpected project_id: %#v", payload["project_id"])
+		}
+		if payload["pinned_to_lead_flag"] != float64(0) {
+			t.Fatalf("unexpected pinned_to_lead_flag: %#v", payload["pinned_to_lead_flag"])
+		}
+		if payload["pinned_to_organization_flag"] != float64(0) {
+			t.Fatalf("unexpected pinned_to_organization_flag: %#v", payload["pinned_to_organization_flag"])
+		}
+		if payload["pinned_to_person_flag"] != float64(0) {
+			t.Fatalf("unexpected pinned_to_person_flag: %#v", payload["pinned_to_person_flag"])
+		}
+		if payload["pinned_to_project_flag"] != float64(0) {
+			t.Fatalf("unexpected pinned_to_project_flag: %#v", payload["pinned_to_project_flag"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -265,8 +351,17 @@ func TestNotesService_Update(t *testing.T) {
 		context.Background(),
 		NoteID(5),
 		WithNoteContent("Updated"),
+		WithNoteLeadID(LeadID("adf21080-0e10-11eb-879b-05d71fb426ec")),
+		WithNotePinnedToLead(false),
 		WithNotePinnedToDeal(false),
 		WithNoteDealID(DealID(2)),
+		WithNotePersonID(PersonID(3)),
+		WithNotePinnedToPerson(false),
+		WithNoteOrganizationID(OrganizationID(4)),
+		WithNotePinnedToOrganization(false),
+		WithNoteProjectID(ProjectID(5)),
+		WithNotePinnedToProject(false),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -300,6 +395,9 @@ func TestNotesService_Delete(t *testing.T) {
 		if r.URL.Path != "/notes/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":true}`))
@@ -311,7 +409,11 @@ func TestNotesService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Notes.Delete(context.Background(), NoteID(5))
+	ok, err := client.Notes.Delete(
+		context.Background(),
+		NoteID(5),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -337,6 +439,9 @@ func TestNotesService_ListComments(t *testing.T) {
 		if got := q.Get("limit"); got != "2" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list-comments" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"uuid":"46c3b0e1-db35-59ca-1828-4817378dff71","content":"This is a comment","add_time":"2021-06-22T07:18:16.750Z"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false,"next_start":1}}}`))
@@ -353,6 +458,7 @@ func TestNotesService_ListComments(t *testing.T) {
 		NoteID(5),
 		WithNoteCommentsStart(1),
 		WithNoteCommentsLimit(2),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "list-comments")),
 	)
 	if err != nil {
 		t.Fatalf("ListComments error: %v", err)
@@ -378,6 +484,9 @@ func TestNotesService_CreateComment(t *testing.T) {
 		if r.URL.Path != "/notes/5/comments" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create-comment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -400,6 +509,7 @@ func TestNotesService_CreateComment(t *testing.T) {
 		context.Background(),
 		NoteID(5),
 		WithNoteCommentContent("Comment"),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "create-comment")),
 	)
 	if err != nil {
 		t.Fatalf("CreateComment error: %v", err)
@@ -435,6 +545,9 @@ func TestNotesService_GetComment(t *testing.T) {
 		if r.URL.Path != "/notes/5/comments/"+commentID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get-comment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"uuid":"` + commentID + `","content":"Comment"}}`))
@@ -446,7 +559,12 @@ func TestNotesService_GetComment(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	comment, err := client.Notes.GetComment(context.Background(), NoteID(5), CommentID(commentID))
+	comment, err := client.Notes.GetComment(
+		context.Background(),
+		NoteID(5),
+		CommentID(commentID),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "get-comment")),
+	)
 	if err != nil {
 		t.Fatalf("GetComment error: %v", err)
 	}
@@ -466,6 +584,9 @@ func TestNotesService_UpdateComment(t *testing.T) {
 		}
 		if r.URL.Path != "/notes/5/comments/"+commentID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-comment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -490,6 +611,7 @@ func TestNotesService_UpdateComment(t *testing.T) {
 		NoteID(5),
 		CommentID(commentID),
 		WithNoteCommentContent("Updated"),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "update-comment")),
 	)
 	if err != nil {
 		t.Fatalf("UpdateComment error: %v", err)
@@ -525,6 +647,9 @@ func TestNotesService_DeleteComment(t *testing.T) {
 		if r.URL.Path != "/notes/5/comments/"+commentID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-comment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":true}`))
@@ -536,7 +661,12 @@ func TestNotesService_DeleteComment(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Notes.DeleteComment(context.Background(), NoteID(5), CommentID(commentID))
+	ok, err := client.Notes.DeleteComment(
+		context.Background(),
+		NoteID(5),
+		CommentID(commentID),
+		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "delete-comment")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteComment error: %v", err)
 	}

--- a/pipedrive/v1/options_line_coverage_test.go
+++ b/pipedrive/v1/options_line_coverage_test.go
@@ -1,0 +1,346 @@
+package v1
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func requireOneV1RequestOption(t *testing.T, name string, opts []pipedrive.RequestOption) {
+	t.Helper()
+
+	if len(opts) != 1 {
+		t.Fatalf("%s request options count = %d, want 1", name, len(opts))
+	}
+}
+
+func TestUsersRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithUsersRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listUsersOptions
+	opt.applyListUsers(&list)
+	requireOneV1RequestOption(t, "list users", list.requestOptions)
+
+	var get getUserOptions
+	opt.applyGetUser(&get)
+	requireOneV1RequestOption(t, "get user", get.requestOptions)
+
+	var current getCurrentUserOptions
+	opt.applyGetCurrentUser(&current)
+	requireOneV1RequestOption(t, "current user", current.requestOptions)
+
+	var permissions getUserPermissionsOptions
+	opt.applyGetUserPermissions(&permissions)
+	requireOneV1RequestOption(t, "user permissions", permissions.requestOptions)
+
+	_ = newListUsersOptions([]ListUsersOption{nil})
+	_ = newGetUserOptions([]GetUserOption{nil})
+	_ = newGetCurrentUserOptions([]GetCurrentUserOption{nil})
+	_ = newGetUserPermissionsOptions([]GetUserPermissionsOption{nil})
+}
+
+func TestFiltersRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listFiltersOptions
+	opt.applyListFilters(&list)
+	requireOneV1RequestOption(t, "list filters", list.requestOptions)
+
+	var get getFilterOptions
+	opt.applyGetFilter(&get)
+	requireOneV1RequestOption(t, "get filter", get.requestOptions)
+
+	var create createFilterOptions
+	opt.applyCreateFilter(&create)
+	requireOneV1RequestOption(t, "create filter", create.requestOptions)
+
+	var update updateFilterOptions
+	opt.applyUpdateFilter(&update)
+	requireOneV1RequestOption(t, "update filter", update.requestOptions)
+
+	var deleteFilter deleteFilterOptions
+	opt.applyDeleteFilter(&deleteFilter)
+	requireOneV1RequestOption(t, "delete filter", deleteFilter.requestOptions)
+
+	var deleteFilters deleteFiltersOptions
+	opt.applyDeleteFilters(&deleteFilters)
+	requireOneV1RequestOption(t, "delete filters", deleteFilters.requestOptions)
+
+	var helpers listFilterHelpersOptions
+	opt.applyListFilterHelpers(&helpers)
+	requireOneV1RequestOption(t, "filter helpers", helpers.requestOptions)
+
+	create = newCreateFilterOptions([]CreateFilterOption{nil, WithFilterConditions(nil)})
+	if create.payload.conditions != nil {
+		t.Fatalf("expected nil filter conditions, got %#v", create.payload.conditions)
+	}
+
+	_ = newListFiltersOptions([]ListFiltersOption{nil})
+	_ = newGetFilterOptions([]GetFilterOption{nil})
+	_ = newUpdateFilterOptions([]UpdateFilterOption{nil})
+	_ = newDeleteFilterOptions([]DeleteFilterOption{nil})
+	_ = newDeleteFiltersOptions([]DeleteFiltersOption{nil})
+	_ = newListFilterHelpersOptions([]ListFilterHelpersOption{nil})
+}
+
+func TestNotesRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listNotesOptions
+	opt.applyListNotes(&list)
+	requireOneV1RequestOption(t, "list notes", list.requestOptions)
+
+	var get getNoteOptions
+	opt.applyGetNote(&get)
+	requireOneV1RequestOption(t, "get note", get.requestOptions)
+
+	var create createNoteOptions
+	opt.applyCreateNote(&create)
+	requireOneV1RequestOption(t, "create note", create.requestOptions)
+
+	var update updateNoteOptions
+	opt.applyUpdateNote(&update)
+	requireOneV1RequestOption(t, "update note", update.requestOptions)
+
+	var deleteNote deleteNoteOptions
+	opt.applyDeleteNote(&deleteNote)
+	requireOneV1RequestOption(t, "delete note", deleteNote.requestOptions)
+
+	var comments listNoteCommentsOptions
+	opt.applyListNoteComments(&comments)
+	requireOneV1RequestOption(t, "list note comments", comments.requestOptions)
+
+	var createComment createNoteCommentOptions
+	opt.applyCreateNoteComment(&createComment)
+	requireOneV1RequestOption(t, "create note comment", createComment.requestOptions)
+
+	var getComment getNoteCommentOptions
+	opt.applyGetNoteComment(&getComment)
+	requireOneV1RequestOption(t, "get note comment", getComment.requestOptions)
+
+	var updateComment updateNoteCommentOptions
+	opt.applyUpdateNoteComment(&updateComment)
+	requireOneV1RequestOption(t, "update note comment", updateComment.requestOptions)
+
+	var deleteComment deleteNoteCommentOptions
+	opt.applyDeleteNoteComment(&deleteComment)
+	requireOneV1RequestOption(t, "delete note comment", deleteComment.requestOptions)
+
+	_ = newListNotesOptions([]ListNotesOption{nil})
+	_ = newGetNoteOptions([]GetNoteOption{nil})
+	_ = newCreateNoteOptions([]CreateNoteOption{nil})
+	_ = newUpdateNoteOptions([]UpdateNoteOption{nil})
+	_ = newDeleteNoteOptions([]DeleteNoteOption{nil})
+	_ = newListNoteCommentsOptions([]ListNoteCommentsOption{nil})
+	_ = newCreateNoteCommentOptions([]CreateNoteCommentOption{nil})
+	_ = newGetNoteCommentOptions([]GetNoteCommentOption{nil})
+	_ = newUpdateNoteCommentOptions([]UpdateNoteCommentOption{nil})
+	_ = newDeleteNoteCommentOptions([]DeleteNoteCommentOption{nil})
+}
+
+func TestActivityTypesRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithActivityTypesRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listActivityTypesOptions
+	opt.applyListActivityTypes(&list)
+	requireOneV1RequestOption(t, "list activity types", list.requestOptions)
+
+	var create createActivityTypeOptions
+	opt.applyCreateActivityType(&create)
+	requireOneV1RequestOption(t, "create activity type", create.requestOptions)
+
+	var update updateActivityTypeOptions
+	opt.applyUpdateActivityType(&update)
+	requireOneV1RequestOption(t, "update activity type", update.requestOptions)
+
+	var deleteActivityType deleteActivityTypeOptions
+	opt.applyDeleteActivityType(&deleteActivityType)
+	requireOneV1RequestOption(t, "delete activity type", deleteActivityType.requestOptions)
+
+	_ = newListActivityTypesOptions([]ListActivityTypesOption{nil})
+	_ = newCreateActivityTypeOptions([]CreateActivityTypeOption{nil})
+	_ = newUpdateActivityTypeOptions([]UpdateActivityTypeOption{nil})
+	_ = newDeleteActivityTypeOptions([]DeleteActivityTypeOption{nil})
+}
+
+func TestLeadLabelsRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithLeadLabelsRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listLeadLabelsOptions
+	opt.applyListLeadLabels(&list)
+	requireOneV1RequestOption(t, "list lead labels", list.requestOptions)
+
+	var create createLeadLabelOptions
+	opt.applyCreateLeadLabel(&create)
+	requireOneV1RequestOption(t, "create lead label", create.requestOptions)
+
+	var update updateLeadLabelOptions
+	opt.applyUpdateLeadLabel(&update)
+	requireOneV1RequestOption(t, "update lead label", update.requestOptions)
+
+	var deleteLeadLabel deleteLeadLabelOptions
+	opt.applyDeleteLeadLabel(&deleteLeadLabel)
+	requireOneV1RequestOption(t, "delete lead label", deleteLeadLabel.requestOptions)
+
+	_ = newListLeadLabelsOptions([]ListLeadLabelsOption{nil})
+	_ = newCreateLeadLabelOptions([]CreateLeadLabelOption{nil})
+	_ = newUpdateLeadLabelOptions([]UpdateLeadLabelOption{nil})
+	_ = newDeleteLeadLabelOptions([]DeleteLeadLabelOption{nil})
+}
+
+func TestWebhooksRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithWebhooksRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listWebhooksOptions
+	opt.applyListWebhooks(&list)
+	requireOneV1RequestOption(t, "list webhooks", list.requestOptions)
+
+	var create createWebhookOptions
+	opt.applyCreateWebhook(&create)
+	requireOneV1RequestOption(t, "create webhook", create.requestOptions)
+
+	var deleteWebhook deleteWebhookOptions
+	opt.applyDeleteWebhook(&deleteWebhook)
+	requireOneV1RequestOption(t, "delete webhook", deleteWebhook.requestOptions)
+
+	_ = newListWebhooksOptions([]ListWebhooksOption{nil})
+	_ = newCreateWebhookOptions([]CreateWebhookOption{nil})
+	_ = newDeleteWebhookOptions([]DeleteWebhookOption{nil})
+}
+
+func TestOrganizationRelationshipsRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithOrganizationRelationshipsRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var list listOrganizationRelationshipsOptions
+	opt.applyListOrganizationRelationships(&list)
+	requireOneV1RequestOption(t, "list organization relationships", list.requestOptions)
+
+	var get getOrganizationRelationshipOptions
+	opt.applyGetOrganizationRelationship(&get)
+	requireOneV1RequestOption(t, "get organization relationship", get.requestOptions)
+
+	var create createOrganizationRelationshipOptions
+	opt.applyCreateOrganizationRelationship(&create)
+	requireOneV1RequestOption(t, "create organization relationship", create.requestOptions)
+
+	var update updateOrganizationRelationshipOptions
+	opt.applyUpdateOrganizationRelationship(&update)
+	requireOneV1RequestOption(t, "update organization relationship", update.requestOptions)
+
+	var deleteRelationship deleteOrganizationRelationshipOptions
+	opt.applyDeleteOrganizationRelationship(&deleteRelationship)
+	requireOneV1RequestOption(t, "delete organization relationship", deleteRelationship.requestOptions)
+
+	_ = newListOrganizationRelationshipsOptions([]ListOrganizationRelationshipsOption{nil})
+	_ = newGetOrganizationRelationshipOptions([]GetOrganizationRelationshipOption{nil})
+	_ = newCreateOrganizationRelationshipOptions([]CreateOrganizationRelationshipOption{nil})
+	_ = newUpdateOrganizationRelationshipOptions([]UpdateOrganizationRelationshipOption{nil})
+	_ = newDeleteOrganizationRelationshipOptions([]DeleteOrganizationRelationshipOption{nil})
+}
+
+func TestFilesOptionsApplyQueryAndRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	query := url.Values{"deal_id": []string{"7"}}
+	cfg := newFilesOptions([]FilesOption{
+		nil,
+		WithFilesQuery(query),
+		WithFilesRequestOptions(pipedrive.WithHeader("X-Test", "1")),
+	})
+
+	if got := cfg.query.Get("deal_id"); got != "7" {
+		t.Fatalf("unexpected deal_id query: %q", got)
+	}
+	requireOneV1RequestOption(t, "files", cfg.requestOptions)
+}
+
+func TestV1OptionFuncsInvokeCallbacks(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	listUsersOptionFunc(func(*listUsersOptions) { called = true }).applyListUsers(&listUsersOptions{})
+	if !called {
+		t.Fatal("expected list users callback")
+	}
+
+	called = false
+	getUserOptionFunc(func(*getUserOptions) { called = true }).applyGetUser(&getUserOptions{})
+	if !called {
+		t.Fatal("expected get user callback")
+	}
+
+	called = false
+	getCurrentUserOptionFunc(func(*getCurrentUserOptions) { called = true }).applyGetCurrentUser(&getCurrentUserOptions{})
+	if !called {
+		t.Fatal("expected get current user callback")
+	}
+
+	called = false
+	getUserPermissionsOptionFunc(func(*getUserPermissionsOptions) { called = true }).applyGetUserPermissions(&getUserPermissionsOptions{})
+	if !called {
+		t.Fatal("expected get user permissions callback")
+	}
+
+	called = false
+	getFilterOptionFunc(func(*getFilterOptions) { called = true }).applyGetFilter(&getFilterOptions{})
+	if !called {
+		t.Fatal("expected get filter callback")
+	}
+
+	called = false
+	deleteFilterOptionFunc(func(*deleteFilterOptions) { called = true }).applyDeleteFilter(&deleteFilterOptions{})
+	if !called {
+		t.Fatal("expected delete filter callback")
+	}
+
+	called = false
+	deleteFiltersOptionFunc(func(*deleteFiltersOptions) { called = true }).applyDeleteFilters(&deleteFiltersOptions{})
+	if !called {
+		t.Fatal("expected delete filters callback")
+	}
+
+	called = false
+	listFilterHelpersOptionFunc(func(*listFilterHelpersOptions) { called = true }).applyListFilterHelpers(&listFilterHelpersOptions{})
+	if !called {
+		t.Fatal("expected list filter helpers callback")
+	}
+
+	called = false
+	listActivityTypesOptionFunc(func(*listActivityTypesOptions) { called = true }).applyListActivityTypes(&listActivityTypesOptions{})
+	if !called {
+		t.Fatal("expected list activity types callback")
+	}
+
+	called = false
+	listLeadLabelsOptionFunc(func(*listLeadLabelsOptions) { called = true }).applyListLeadLabels(&listLeadLabelsOptions{})
+	if !called {
+		t.Fatal("expected list lead labels callback")
+	}
+
+	called = false
+	getOrganizationRelationshipOptionFunc(func(*getOrganizationRelationshipOptions) { called = true }).applyGetOrganizationRelationship(&getOrganizationRelationshipOptions{})
+	if !called {
+		t.Fatal("expected get organization relationship callback")
+	}
+
+	called = false
+	deleteOrganizationRelationshipOptionFunc(func(*deleteOrganizationRelationshipOptions) { called = true }).applyDeleteOrganizationRelationship(&deleteOrganizationRelationshipOptions{})
+	if !called {
+		t.Fatal("expected delete organization relationship callback")
+	}
+}

--- a/pipedrive/v1/organization_relationships_test.go
+++ b/pipedrive/v1/organization_relationships_test.go
@@ -83,6 +83,9 @@ func TestOrganizationRelationshipsService_Create(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Fatalf("unexpected content type: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -116,6 +119,7 @@ func TestOrganizationRelationshipsService_Create(t *testing.T) {
 		WithOrganizationRelationshipOwnerID(OrganizationID(1)),
 		WithOrganizationRelationshipLinkedID(OrganizationID(2)),
 		WithOrganizationRelationshipOrgID(OrganizationID(10)),
+		WithOrganizationRelationshipsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -152,6 +156,9 @@ func TestOrganizationRelationshipsService_Get(t *testing.T) {
 		if got := r.URL.Query().Get("org_id"); got != "10" {
 			t.Fatalf("unexpected org_id: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":5,"type":"parent","rel_owner_org_id":{"value":1},"rel_linked_org_id":{"value":2}}}`))
@@ -167,6 +174,7 @@ func TestOrganizationRelationshipsService_Get(t *testing.T) {
 		context.Background(),
 		OrganizationRelationshipID(5),
 		WithOrganizationRelationshipOrgID(OrganizationID(10)),
+		WithOrganizationRelationshipsRequestOptions(pipedrive.WithHeader("X-Test", "get")),
 	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
@@ -185,6 +193,9 @@ func TestOrganizationRelationshipsService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/organizationRelationships/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -208,6 +219,7 @@ func TestOrganizationRelationshipsService_Update(t *testing.T) {
 		context.Background(),
 		OrganizationRelationshipID(5),
 		WithOrganizationRelationshipType(OrganizationRelationshipTypeRelated),
+		WithOrganizationRelationshipsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -241,6 +253,9 @@ func TestOrganizationRelationshipsService_Delete(t *testing.T) {
 		if r.URL.Path != "/organizationRelationships/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":5}}`))
@@ -252,11 +267,81 @@ func TestOrganizationRelationshipsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.OrganizationRelationships.Delete(context.Background(), OrganizationRelationshipID(5))
+	result, err := client.OrganizationRelationships.Delete(
+		context.Background(),
+		OrganizationRelationshipID(5),
+		WithOrganizationRelationshipsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
 	if result.ID != 5 {
 		t.Fatalf("unexpected delete result: %#v", result)
+	}
+}
+
+func TestOrganizationRelationshipsService_ErrorResponses(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"success":false,"error":"server error"}`))
+	})
+
+	if _, _, err := client.OrganizationRelationships.List(context.Background(), WithOrganizationRelationshipsOrgID(OrganizationID(10))); err == nil {
+		t.Fatalf("expected List error")
+	}
+	if _, err := client.OrganizationRelationships.Get(context.Background(), OrganizationRelationshipID(5)); err == nil {
+		t.Fatalf("expected Get error")
+	}
+	if _, err := client.OrganizationRelationships.Create(
+		context.Background(),
+		WithOrganizationRelationshipType(OrganizationRelationshipTypeParent),
+		WithOrganizationRelationshipOwnerID(OrganizationID(1)),
+		WithOrganizationRelationshipLinkedID(OrganizationID(2)),
+	); err == nil {
+		t.Fatalf("expected Create error")
+	}
+	if _, err := client.OrganizationRelationships.Update(
+		context.Background(),
+		OrganizationRelationshipID(5),
+		WithOrganizationRelationshipType(OrganizationRelationshipTypeRelated),
+	); err == nil {
+		t.Fatalf("expected Update error")
+	}
+	if _, err := client.OrganizationRelationships.Delete(context.Background(), OrganizationRelationshipID(5)); err == nil {
+		t.Fatalf("expected Delete error")
+	}
+}
+
+func TestOrganizationRelationshipsService_MissingDataErrors(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+
+	if _, err := client.OrganizationRelationships.Get(context.Background(), OrganizationRelationshipID(5)); err == nil {
+		t.Fatalf("expected Get missing data error")
+	}
+	if _, err := client.OrganizationRelationships.Create(
+		context.Background(),
+		WithOrganizationRelationshipType(OrganizationRelationshipTypeParent),
+		WithOrganizationRelationshipOwnerID(OrganizationID(1)),
+		WithOrganizationRelationshipLinkedID(OrganizationID(2)),
+	); err == nil {
+		t.Fatalf("expected Create missing data error")
+	}
+	if _, err := client.OrganizationRelationships.Update(
+		context.Background(),
+		OrganizationRelationshipID(5),
+		WithOrganizationRelationshipType(OrganizationRelationshipTypeRelated),
+	); err == nil {
+		t.Fatalf("expected Update missing data error")
+	}
+	if _, err := client.OrganizationRelationships.Delete(context.Background(), OrganizationRelationshipID(5)); err == nil {
+		t.Fatalf("expected Delete missing data error")
 	}
 }

--- a/pipedrive/v1/permission_sets_test.go
+++ b/pipedrive/v1/permission_sets_test.go
@@ -102,6 +102,9 @@ func TestPermissionSetsService_ListAssignments(t *testing.T) {
 		if got := r.URL.Query().Get("limit"); got != "1" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "assignments" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"user_id":10,"permission_set_id":"` + id + `","name":"Sales admin"}]}`))
 	}))
@@ -117,6 +120,7 @@ func TestPermissionSetsService_ListAssignments(t *testing.T) {
 		PermissionSetID(id),
 		WithPermissionSetAssignmentsStart(2),
 		WithPermissionSetAssignmentsLimit(1),
+		WithPermissionSetsRequestOptions(pipedrive.WithHeader("X-Test", "assignments")),
 	)
 	if err != nil {
 		t.Fatalf("ListAssignments error: %v", err)

--- a/pipedrive/v1/projects_test.go
+++ b/pipedrive/v1/projects_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestProjectsService_List(t *testing.T) {
@@ -21,6 +23,9 @@ func TestProjectsService_List(t *testing.T) {
 		if got := r.URL.Query().Get("limit"); got != "1" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":1,"title":"Project"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
@@ -28,7 +33,11 @@ func TestProjectsService_List(t *testing.T) {
 
 	query := url.Values{}
 	query.Set("limit", "1")
-	projects, page, err := client.Projects.List(context.Background(), WithProjectsQuery(query))
+	projects, page, err := client.Projects.List(
+		context.Background(),
+		WithProjectsQuery(query),
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "list")),
+	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -50,6 +59,9 @@ func TestProjectsService_Create(t *testing.T) {
 		if r.URL.Path != "/projects" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -63,7 +75,11 @@ func TestProjectsService_Create(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":2,"title":"New"}}`))
 	})
 
-	project, err := client.Projects.Create(context.Background(), map[string]any{"title": "New"})
+	project, err := client.Projects.Create(
+		context.Background(),
+		map[string]any{"title": "New"},
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
+	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -82,12 +98,19 @@ func TestProjectsService_Get(t *testing.T) {
 		if r.URL.Path != "/projects/3" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":3,"title":"Project"}}`))
 	})
 
-	project, err := client.Projects.Get(context.Background(), ProjectID(3))
+	project, err := client.Projects.Get(
+		context.Background(),
+		ProjectID(3),
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -106,6 +129,9 @@ func TestProjectsService_Update(t *testing.T) {
 		if r.URL.Path != "/projects/4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -119,7 +145,12 @@ func TestProjectsService_Update(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":4,"title":"Updated"}}`))
 	})
 
-	project, err := client.Projects.Update(context.Background(), ProjectID(4), map[string]any{"title": "Updated"})
+	project, err := client.Projects.Update(
+		context.Background(),
+		ProjectID(4),
+		map[string]any{"title": "Updated"},
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
@@ -138,12 +169,19 @@ func TestProjectsService_Delete(t *testing.T) {
 		if r.URL.Path != "/projects/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":5}}`))
 	})
 
-	id, err := client.Projects.Delete(context.Background(), ProjectID(5))
+	id, err := client.Projects.Delete(
+		context.Background(),
+		ProjectID(5),
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -162,12 +200,19 @@ func TestProjectsService_Archive(t *testing.T) {
 		if r.URL.Path != "/projects/6/archive" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "archive" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":6,"status":"archived"}}`))
 	})
 
-	project, err := client.Projects.Archive(context.Background(), ProjectID(6))
+	project, err := client.Projects.Archive(
+		context.Background(),
+		ProjectID(6),
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "archive")),
+	)
 	if err != nil {
 		t.Fatalf("Archive error: %v", err)
 	}
@@ -282,12 +327,19 @@ func TestProjectsService_ListActivities(t *testing.T) {
 		if r.URL.Path != "/projects/10/activities" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "activities" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":1,"subject":"Call"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
 	})
 
-	activities, page, err := client.Projects.ListActivities(context.Background(), ProjectID(10))
+	activities, page, err := client.Projects.ListActivities(
+		context.Background(),
+		ProjectID(10),
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "activities")),
+	)
 	if err != nil {
 		t.Fatalf("ListActivities error: %v", err)
 	}
@@ -357,6 +409,9 @@ func TestProjectsService_UpdatePlanActivity(t *testing.T) {
 		if r.URL.Path != "/projects/12/plan/activities/3" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "plan-activity" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -370,7 +425,13 @@ func TestProjectsService_UpdatePlanActivity(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"status":"done"}}`))
 	})
 
-	plan, err := client.Projects.UpdatePlanActivity(context.Background(), ProjectID(12), ProjectPlanActivityID(3), map[string]any{"status": "done"})
+	plan, err := client.Projects.UpdatePlanActivity(
+		context.Background(),
+		ProjectID(12),
+		ProjectPlanActivityID(3),
+		map[string]any{"status": "done"},
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "plan-activity")),
+	)
 	if err != nil {
 		t.Fatalf("UpdatePlanActivity error: %v", err)
 	}
@@ -389,6 +450,9 @@ func TestProjectsService_UpdatePlanTask(t *testing.T) {
 		if r.URL.Path != "/projects/12/plan/tasks/4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "plan-task" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -402,7 +466,13 @@ func TestProjectsService_UpdatePlanTask(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"title":"Updated"}}`))
 	})
 
-	plan, err := client.Projects.UpdatePlanTask(context.Background(), ProjectID(12), ProjectPlanTaskID(4), map[string]any{"title": "Updated"})
+	plan, err := client.Projects.UpdatePlanTask(
+		context.Background(),
+		ProjectID(12),
+		ProjectPlanTaskID(4),
+		map[string]any{"title": "Updated"},
+		WithProjectsRequestOptions(pipedrive.WithHeader("X-Test", "plan-task")),
+	)
 	if err != nil {
 		t.Fatalf("UpdatePlanTask error: %v", err)
 	}

--- a/pipedrive/v1/roles_test.go
+++ b/pipedrive/v1/roles_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestRolesService_List(t *testing.T) {
@@ -17,12 +20,24 @@ func TestRolesService_List(t *testing.T) {
 		if r.URL.Path != "/roles" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("include"); got != "settings" {
+			t.Fatalf("unexpected include: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":1,"name":"Role"}]}`))
 	})
 
-	roles, err := client.Roles.List(context.Background())
+	query := url.Values{}
+	query.Set("include", "settings")
+	roles, err := client.Roles.List(
+		context.Background(),
+		WithRolesQuery(query),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "list")),
+	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -41,12 +56,19 @@ func TestRolesService_Get(t *testing.T) {
 		if r.URL.Path != "/roles/2" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":2,"name":"Role"}}`))
 	})
 
-	role, err := client.Roles.Get(context.Background(), RoleID(2))
+	role, err := client.Roles.Get(
+		context.Background(),
+		RoleID(2),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -65,6 +87,9 @@ func TestRolesService_Create(t *testing.T) {
 		if r.URL.Path != "/roles" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -78,7 +103,11 @@ func TestRolesService_Create(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":3,"name":"Sales"}}`))
 	})
 
-	role, err := client.Roles.Create(context.Background(), map[string]any{"name": "Sales"})
+	role, err := client.Roles.Create(
+		context.Background(),
+		map[string]any{"name": "Sales"},
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "create")),
+	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -97,6 +126,9 @@ func TestRolesService_Update(t *testing.T) {
 		if r.URL.Path != "/roles/4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -110,7 +142,12 @@ func TestRolesService_Update(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":4,"name":"Updated"}}`))
 	})
 
-	role, err := client.Roles.Update(context.Background(), RoleID(4), map[string]any{"name": "Updated"})
+	role, err := client.Roles.Update(
+		context.Background(),
+		RoleID(4),
+		map[string]any{"name": "Updated"},
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
@@ -129,12 +166,19 @@ func TestRolesService_Delete(t *testing.T) {
 		if r.URL.Path != "/roles/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	})
 
-	ok, err := client.Roles.Delete(context.Background(), RoleID(5))
+	ok, err := client.Roles.Delete(
+		context.Background(),
+		RoleID(5),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -153,12 +197,19 @@ func TestRolesService_ListAssignments(t *testing.T) {
 		if r.URL.Path != "/roles/6/assignments" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "assignments" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"user_id":1,"role_id":6}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
 	})
 
-	assignments, page, err := client.Roles.ListAssignments(context.Background(), RoleID(6))
+	assignments, page, err := client.Roles.ListAssignments(
+		context.Background(),
+		RoleID(6),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "assignments")),
+	)
 	if err != nil {
 		t.Fatalf("ListAssignments error: %v", err)
 	}
@@ -180,6 +231,9 @@ func TestRolesService_AddAssignment(t *testing.T) {
 		if r.URL.Path != "/roles/7/assignments" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "add-assignment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -193,7 +247,12 @@ func TestRolesService_AddAssignment(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"user_id":2,"role_id":7}}`))
 	})
 
-	assignment, err := client.Roles.AddAssignment(context.Background(), RoleID(7), UserID(2))
+	assignment, err := client.Roles.AddAssignment(
+		context.Background(),
+		RoleID(7),
+		UserID(2),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "add-assignment")),
+	)
 	if err != nil {
 		t.Fatalf("AddAssignment error: %v", err)
 	}
@@ -212,6 +271,9 @@ func TestRolesService_DeleteAssignment(t *testing.T) {
 		if r.URL.Path != "/roles/7/assignments" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-assignment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -225,7 +287,12 @@ func TestRolesService_DeleteAssignment(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true}`))
 	})
 
-	ok, err := client.Roles.DeleteAssignment(context.Background(), RoleID(7), UserID(2))
+	ok, err := client.Roles.DeleteAssignment(
+		context.Background(),
+		RoleID(7),
+		UserID(2),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "delete-assignment")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteAssignment error: %v", err)
 	}
@@ -244,12 +311,19 @@ func TestRolesService_ListPipelines(t *testing.T) {
 		if r.URL.Path != "/roles/8/pipelines" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "pipelines" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"pipeline_id":1}]}`))
 	})
 
-	pipelines, err := client.Roles.ListPipelines(context.Background(), RoleID(8))
+	pipelines, err := client.Roles.ListPipelines(
+		context.Background(),
+		RoleID(8),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "pipelines")),
+	)
 	if err != nil {
 		t.Fatalf("ListPipelines error: %v", err)
 	}
@@ -268,6 +342,9 @@ func TestRolesService_UpdatePipelines(t *testing.T) {
 		if r.URL.Path != "/roles/9/pipelines" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update-pipelines" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -281,7 +358,12 @@ func TestRolesService_UpdatePipelines(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"updated":true}}`))
 	})
 
-	data, err := client.Roles.UpdatePipelines(context.Background(), RoleID(9), map[string]any{"pipelines": []int{1}})
+	data, err := client.Roles.UpdatePipelines(
+		context.Background(),
+		RoleID(9),
+		map[string]any{"pipelines": []int{1}},
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "update-pipelines")),
+	)
 	if err != nil {
 		t.Fatalf("UpdatePipelines error: %v", err)
 	}
@@ -300,12 +382,19 @@ func TestRolesService_ListSettings(t *testing.T) {
 		if r.URL.Path != "/roles/10/settings" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "settings" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"key":"deal_default_visibility"}]}`))
 	})
 
-	settings, err := client.Roles.ListSettings(context.Background(), RoleID(10))
+	settings, err := client.Roles.ListSettings(
+		context.Background(),
+		RoleID(10),
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "settings")),
+	)
 	if err != nil {
 		t.Fatalf("ListSettings error: %v", err)
 	}
@@ -324,6 +413,9 @@ func TestRolesService_UpsertSetting(t *testing.T) {
 		if r.URL.Path != "/roles/11/settings" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "upsert-setting" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -337,7 +429,12 @@ func TestRolesService_UpsertSetting(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":11}}`))
 	})
 
-	data, err := client.Roles.UpsertSetting(context.Background(), RoleID(11), map[string]any{"value": 1})
+	data, err := client.Roles.UpsertSetting(
+		context.Background(),
+		RoleID(11),
+		map[string]any{"value": 1},
+		WithRolesRequestOptions(pipedrive.WithHeader("X-Test", "upsert-setting")),
+	)
 	if err != nil {
 		t.Fatalf("UpsertSetting error: %v", err)
 	}

--- a/pipedrive/v1/tasks_test.go
+++ b/pipedrive/v1/tasks_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestTasksService_List(t *testing.T) {
@@ -28,6 +30,9 @@ func TestTasksService_List(t *testing.T) {
 		if got := q.Get("done"); got != "1" {
 			t.Fatalf("unexpected done: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":1,"title":"Task","assignee_id":7,"done":1,"add_time":"2024-01-01 10:00:00","marked_as_done_time":"2024-01-02 10:00:00"}],"additional_data":{"next_cursor":"c1"}}`))
@@ -37,7 +42,11 @@ func TestTasksService_List(t *testing.T) {
 	query.Set("cursor", "c0")
 	query.Set("limit", "2")
 	query.Set("done", "1")
-	tasks, page, err := client.Tasks.List(context.Background(), WithTasksQuery(query))
+	tasks, page, err := client.Tasks.List(
+		context.Background(),
+		WithTasksQuery(query),
+		WithTasksRequestOptions(pipedrive.WithHeader("X-Test", "list")),
+	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -62,12 +71,19 @@ func TestTasksService_Get(t *testing.T) {
 		if r.URL.Path != "/tasks/3" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":3,"title":"Task"}}`))
 	})
 
-	task, err := client.Tasks.Get(context.Background(), TaskID(3))
+	task, err := client.Tasks.Get(
+		context.Background(),
+		TaskID(3),
+		WithTasksRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -86,6 +102,9 @@ func TestTasksService_Create(t *testing.T) {
 		if r.URL.Path != "/tasks" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -99,7 +118,11 @@ func TestTasksService_Create(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":4,"title":"Task"}}`))
 	})
 
-	task, err := client.Tasks.Create(context.Background(), map[string]any{"title": "Task"})
+	task, err := client.Tasks.Create(
+		context.Background(),
+		map[string]any{"title": "Task"},
+		WithTasksRequestOptions(pipedrive.WithHeader("X-Test", "create")),
+	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -118,6 +141,9 @@ func TestTasksService_Update(t *testing.T) {
 		if r.URL.Path != "/tasks/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -131,7 +157,12 @@ func TestTasksService_Update(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":5,"title":"Updated"}}`))
 	})
 
-	task, err := client.Tasks.Update(context.Background(), TaskID(5), map[string]any{"title": "Updated"})
+	task, err := client.Tasks.Update(
+		context.Background(),
+		TaskID(5),
+		map[string]any{"title": "Updated"},
+		WithTasksRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
@@ -150,12 +181,19 @@ func TestTasksService_Delete(t *testing.T) {
 		if r.URL.Path != "/tasks/6" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	})
 
-	ok, err := client.Tasks.Delete(context.Background(), TaskID(6))
+	ok, err := client.Tasks.Delete(
+		context.Background(),
+		TaskID(6),
+		WithTasksRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}

--- a/pipedrive/v1/teams_test.go
+++ b/pipedrive/v1/teams_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestTeamsService_List(t *testing.T) {
@@ -17,12 +20,24 @@ func TestTeamsService_List(t *testing.T) {
 		if r.URL.Path != "/legacyTeams" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("status"); got != "active" {
+			t.Fatalf("unexpected status: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":1,"name":"Team"}]}`))
 	})
 
-	teams, err := client.Teams.List(context.Background())
+	query := url.Values{}
+	query.Set("status", "active")
+	teams, err := client.Teams.List(
+		context.Background(),
+		WithTeamsQuery(query),
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "list")),
+	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
 	}
@@ -41,12 +56,19 @@ func TestTeamsService_Get(t *testing.T) {
 		if r.URL.Path != "/legacyTeams/2" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":2,"name":"Team"}}`))
 	})
 
-	team, err := client.Teams.Get(context.Background(), TeamID(2))
+	team, err := client.Teams.Get(
+		context.Background(),
+		TeamID(2),
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -65,6 +87,9 @@ func TestTeamsService_Create(t *testing.T) {
 		if r.URL.Path != "/legacyTeams" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -78,7 +103,11 @@ func TestTeamsService_Create(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":3,"name":"Sales"}}`))
 	})
 
-	team, err := client.Teams.Create(context.Background(), map[string]any{"name": "Sales"})
+	team, err := client.Teams.Create(
+		context.Background(),
+		map[string]any{"name": "Sales"},
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "create")),
+	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -97,6 +126,9 @@ func TestTeamsService_Update(t *testing.T) {
 		if r.URL.Path != "/legacyTeams/4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -110,7 +142,12 @@ func TestTeamsService_Update(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":4,"name":"Updated"}}`))
 	})
 
-	team, err := client.Teams.Update(context.Background(), TeamID(4), map[string]any{"name": "Updated"})
+	team, err := client.Teams.Update(
+		context.Background(),
+		TeamID(4),
+		map[string]any{"name": "Updated"},
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
 	}
@@ -129,12 +166,19 @@ func TestTeamsService_ListUsers(t *testing.T) {
 		if r.URL.Path != "/legacyTeams/5/users" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "list-users" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[1,2]}`))
 	})
 
-	users, err := client.Teams.ListUsers(context.Background(), TeamID(5))
+	users, err := client.Teams.ListUsers(
+		context.Background(),
+		TeamID(5),
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "list-users")),
+	)
 	if err != nil {
 		t.Fatalf("ListUsers error: %v", err)
 	}
@@ -153,6 +197,9 @@ func TestTeamsService_AddUsers(t *testing.T) {
 		if r.URL.Path != "/legacyTeams/6/users" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "add-users" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string][]int
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -166,7 +213,12 @@ func TestTeamsService_AddUsers(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":[1,2]}`))
 	})
 
-	users, err := client.Teams.AddUsers(context.Background(), TeamID(6), []UserID{1, 2})
+	users, err := client.Teams.AddUsers(
+		context.Background(),
+		TeamID(6),
+		[]UserID{1, 2},
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "add-users")),
+	)
 	if err != nil {
 		t.Fatalf("AddUsers error: %v", err)
 	}
@@ -185,6 +237,9 @@ func TestTeamsService_DeleteUsers(t *testing.T) {
 		if r.URL.Path != "/legacyTeams/7/users" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-users" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var body map[string][]int
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -198,7 +253,12 @@ func TestTeamsService_DeleteUsers(t *testing.T) {
 		_, _ = w.Write([]byte(`{"success":true,"data":[9]}`))
 	})
 
-	users, err := client.Teams.DeleteUsers(context.Background(), TeamID(7), []UserID{9})
+	users, err := client.Teams.DeleteUsers(
+		context.Background(),
+		TeamID(7),
+		[]UserID{9},
+		WithTeamsRequestOptions(pipedrive.WithHeader("X-Test", "delete-users")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteUsers error: %v", err)
 	}

--- a/pipedrive/v1/users_test.go
+++ b/pipedrive/v1/users_test.go
@@ -95,6 +95,9 @@ func TestUsersService_Get(t *testing.T) {
 		if r.URL.Path != "/users/9" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":9,"name":"Sam","email":"sam@example.com","active_flag":true}}`))
@@ -106,7 +109,11 @@ func TestUsersService_Get(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	user, err := client.Users.Get(context.Background(), UserID(9))
+	user, err := client.Users.Get(
+		context.Background(),
+		UserID(9),
+		WithUsersRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
@@ -125,6 +132,9 @@ func TestUsersService_GetCurrent(t *testing.T) {
 		if r.URL.Path != "/users/me" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "current" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":1,"name":"Me","email":"me@example.com","company_id":42,"company_name":"Acme","language":{"language_code":"en","country_code":"US"}}}`))
@@ -136,7 +146,10 @@ func TestUsersService_GetCurrent(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	user, err := client.Users.GetCurrent(context.Background())
+	user, err := client.Users.GetCurrent(
+		context.Background(),
+		WithUsersRequestOptions(pipedrive.WithHeader("X-Test", "current")),
+	)
 	if err != nil {
 		t.Fatalf("GetCurrent error: %v", err)
 	}

--- a/pipedrive/v1/value_types_test.go
+++ b/pipedrive/v1/value_types_test.go
@@ -1,0 +1,175 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func TestNumberBool_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "null", input: "null", want: false},
+		{name: "empty", input: "", want: false},
+		{name: "false", input: "false", want: false},
+		{name: "zero", input: "0", want: false},
+		{name: "true", input: "true", want: true},
+		{name: "one", input: "1", want: true},
+		{name: "numeric", input: "2", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got NumberBool
+			if err := got.UnmarshalJSON([]byte(tt.input)); err != nil {
+				t.Fatalf("UnmarshalJSON error: %v", err)
+			}
+			if bool(got) != tt.want {
+				t.Fatalf("NumberBool = %v, want %v", bool(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestNumberBool_UnmarshalJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	var nilBool *NumberBool
+	if err := nilBool.UnmarshalJSON([]byte("true")); err == nil {
+		t.Fatalf("expected nil receiver error")
+	}
+
+	var value NumberBool
+	if err := value.UnmarshalJSON([]byte(`"bad"`)); err == nil || !strings.Contains(err.Error(), "invalid value") {
+		t.Fatalf("expected invalid value error, got %v", err)
+	}
+}
+
+func TestDateTime_JSON(t *testing.T) {
+	t.Parallel()
+
+	var parsed DateTime
+	if err := parsed.UnmarshalJSON([]byte(`"2024-01-02T03:04:05Z"`)); err != nil {
+		t.Fatalf("UnmarshalJSON RFC3339 error: %v", err)
+	}
+	if parsed.IsZero() {
+		t.Fatalf("expected parsed time")
+	}
+
+	var v1Parsed DateTime
+	if err := v1Parsed.UnmarshalJSON([]byte(`"2024-01-02 03:04"`)); err != nil {
+		t.Fatalf("UnmarshalJSON v1 minute layout error: %v", err)
+	}
+
+	var nullParsed DateTime
+	if err := nullParsed.UnmarshalJSON([]byte("null")); err != nil {
+		t.Fatalf("UnmarshalJSON null error: %v", err)
+	}
+	if !nullParsed.IsZero() {
+		t.Fatalf("expected null to leave zero value")
+	}
+
+	var emptyParsed DateTime
+	if err := emptyParsed.UnmarshalJSON([]byte(`""`)); err != nil {
+		t.Fatalf("UnmarshalJSON empty string error: %v", err)
+	}
+	if !emptyParsed.IsZero() {
+		t.Fatalf("expected empty string to leave zero value")
+	}
+
+	encoded, err := DateTime{Time: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)}.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON error: %v", err)
+	}
+	if string(encoded) != `"2024-01-02 03:04:05"` {
+		t.Fatalf("unexpected encoded time: %s", encoded)
+	}
+
+	zero, err := (DateTime{}).MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON zero error: %v", err)
+	}
+	if string(zero) != "null" {
+		t.Fatalf("unexpected zero encoding: %s", zero)
+	}
+}
+
+func TestDateTime_UnmarshalJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	var nilTime *DateTime
+	if err := nilTime.UnmarshalJSON([]byte(`"2024-01-02"`)); err == nil {
+		t.Fatalf("expected nil receiver error")
+	}
+
+	var value DateTime
+	if err := value.UnmarshalJSON([]byte("not-json")); err == nil {
+		t.Fatalf("expected decode error")
+	}
+	if err := value.UnmarshalJSON([]byte(`"not-a-time"`)); err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestErrorFromResponse(t *testing.T) {
+	t.Parallel()
+
+	apiErr := errorFromResponse(&http.Response{StatusCode: http.StatusBadRequest, Header: http.Header{}}, []byte(`{"error":"bad"}`))
+	var typedAPI *pipedrive.APIError
+	if !errors.As(apiErr, &typedAPI) {
+		t.Fatalf("expected APIError, got %T", apiErr)
+	}
+
+	rateErr := errorFromResponse(&http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{}}, []byte(`{"error":"slow"}`))
+	var typedRate *pipedrive.RateLimitError
+	if !errors.As(rateErr, &typedRate) {
+		t.Fatalf("expected RateLimitError, got %T", rateErr)
+	}
+}
+
+func TestRequestEditorConversionSkipsNil(t *testing.T) {
+	t.Parallel()
+
+	editors := toRequestEditors([]pipedrive.RequestEditorFunc{
+		nil,
+		func(_ context.Context, req *http.Request) error {
+			req.Header.Set("X-Edited", "1")
+			return nil
+		},
+	})
+	if len(editors) != 1 {
+		t.Fatalf("expected one editor, got %d", len(editors))
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if err := editors[0](context.Background(), req); err != nil {
+		t.Fatalf("editor error: %v", err)
+	}
+	if got := req.Header.Get("X-Edited"); got != "1" {
+		t.Fatalf("unexpected edited header: %q", got)
+	}
+}
+
+func TestJoinIDs(t *testing.T) {
+	t.Parallel()
+
+	if got := joinIDs([]FieldID{}); got != "" {
+		t.Fatalf("empty joinIDs = %q", got)
+	}
+	if got := joinIDs([]FieldID{1, 2}); got != "1,2" {
+		t.Fatalf("joinIDs = %q", got)
+	}
+}

--- a/pipedrive/v1/webhooks_test.go
+++ b/pipedrive/v1/webhooks_test.go
@@ -60,6 +60,9 @@ func TestWebhooksService_Create(t *testing.T) {
 		if r.URL.Path != "/webhooks" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode request: %v", err)
@@ -82,6 +85,12 @@ func TestWebhooksService_Create(t *testing.T) {
 		if payload["user_id"] != float64(7) {
 			t.Fatalf("unexpected user_id: %#v", payload["user_id"])
 		}
+		if payload["http_auth_user"] != "api-user" {
+			t.Fatalf("unexpected http_auth_user: %#v", payload["http_auth_user"])
+		}
+		if payload["http_auth_password"] != "api-pass" {
+			t.Fatalf("unexpected http_auth_password: %#v", payload["http_auth_password"])
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":{"id":9,"name":"Webhook","event_action":"create","event_object":"deal","subscription_url":"http://example.org","is_active":1}}`))
 	}))
@@ -99,7 +108,10 @@ func TestWebhooksService_Create(t *testing.T) {
 		WithWebhookEventObject(WebhookEventObjectDeal),
 		WithWebhookName("Webhook"),
 		WithWebhookUserID(7),
+		WithWebhookHTTPAuthUser("api-user"),
+		WithWebhookHTTPAuthPassword("api-pass"),
 		WithWebhookVersion(WebhookVersion2),
+		WithWebhooksRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -119,6 +131,9 @@ func TestWebhooksService_Delete(t *testing.T) {
 		if r.URL.Path != "/webhooks/9" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"status":"ok"}`))
 	}))
@@ -129,7 +144,11 @@ func TestWebhooksService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	ok, err := client.Webhooks.Delete(context.Background(), 9)
+	ok, err := client.Webhooks.Delete(
+		context.Background(),
+		9,
+		WithWebhooksRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}

--- a/pipedrive/v2/activities_test.go
+++ b/pipedrive/v2/activities_test.go
@@ -120,6 +120,9 @@ func TestActivitiesService_Create(t *testing.T) {
 	t.Parallel()
 
 	personID := PersonID(7)
+	dealID := DealID(9)
+	orgID := OrganizationID(8)
+	projectID := ProjectID(6)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -145,8 +148,35 @@ func TestActivitiesService_Create(t *testing.T) {
 		if payload["owner_id"] != float64(5) {
 			t.Fatalf("unexpected owner_id: %v", payload["owner_id"])
 		}
+		if payload["deal_id"] != float64(9) {
+			t.Fatalf("unexpected deal_id: %v", payload["deal_id"])
+		}
 		if payload["lead_id"] != "lead-123" {
 			t.Fatalf("unexpected lead_id: %v", payload["lead_id"])
+		}
+		if payload["person_id"] != float64(7) {
+			t.Fatalf("unexpected person_id: %v", payload["person_id"])
+		}
+		if payload["org_id"] != float64(8) {
+			t.Fatalf("unexpected org_id: %v", payload["org_id"])
+		}
+		if payload["project_id"] != float64(6) {
+			t.Fatalf("unexpected project_id: %v", payload["project_id"])
+		}
+		if payload["due_date"] != "2024-05-10" {
+			t.Fatalf("unexpected due_date: %v", payload["due_date"])
+		}
+		if payload["due_time"] != "09:30" {
+			t.Fatalf("unexpected due_time: %v", payload["due_time"])
+		}
+		if payload["duration"] != "00:30:00" {
+			t.Fatalf("unexpected duration: %v", payload["duration"])
+		}
+		if payload["busy"] != true {
+			t.Fatalf("unexpected busy: %v", payload["busy"])
+		}
+		if payload["done"] != false {
+			t.Fatalf("unexpected done: %v", payload["done"])
 		}
 		location, ok := payload["location"].(map[string]interface{})
 		if !ok || location["value"] != "HQ" {
@@ -159,6 +189,23 @@ func TestActivitiesService_Create(t *testing.T) {
 		participant, ok := participants[0].(map[string]interface{})
 		if !ok || participant["person_id"] != float64(7) {
 			t.Fatalf("unexpected participant: %#v", participants[0])
+		}
+		attendees, ok := payload["attendees"].([]interface{})
+		if !ok || len(attendees) != 1 {
+			t.Fatalf("unexpected attendees: %#v", payload["attendees"])
+		}
+		attendee, ok := attendees[0].(map[string]interface{})
+		if !ok || attendee["email"] != "ada@example.com" {
+			t.Fatalf("unexpected attendee: %#v", attendees[0])
+		}
+		if payload["public_description"] != "Public details" {
+			t.Fatalf("unexpected public_description: %v", payload["public_description"])
+		}
+		if payload["priority"] != float64(1) {
+			t.Fatalf("unexpected priority: %v", payload["priority"])
+		}
+		if payload["note"] != "Private note" {
+			t.Fatalf("unexpected note: %v", payload["note"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -176,9 +223,22 @@ func TestActivitiesService_Create(t *testing.T) {
 		WithActivitySubject("Call"),
 		WithActivityType("call"),
 		WithActivityOwnerID(UserID(5)),
+		WithActivityDealID(dealID),
 		WithActivityLeadID(LeadID("lead-123")),
+		WithActivityPersonID(personID),
+		WithActivityOrgID(orgID),
+		WithActivityProjectID(projectID),
+		WithActivityDueDate("2024-05-10"),
+		WithActivityDueTime("09:30"),
+		WithActivityDuration("00:30:00"),
+		WithActivityBusy(true),
+		WithActivityDone(false),
 		WithActivityLocation(ActivityLocation{Value: "HQ"}),
 		WithActivityParticipants(ActivityParticipant{PersonID: &personID, Primary: true}),
+		WithActivityAttendees(ActivityAttendee{Email: "ada@example.com", Name: "Ada"}),
+		WithActivityPublicDescription("Public details"),
+		WithActivityPriority(1),
+		WithActivityNote("Private note"),
 		WithActivityRequestOptions(pipedrive.WithHeader("X-Test", "2")),
 	)
 	if err != nil {
@@ -198,6 +258,9 @@ func TestActivitiesService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/activities/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		var payload map[string]interface{}
@@ -226,6 +289,7 @@ func TestActivitiesService_Update(t *testing.T) {
 		ActivityID(5),
 		WithActivityDone(true),
 		WithActivityDuration("01:00:00"),
+		WithActivityRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -245,6 +309,9 @@ func TestActivitiesService_Delete(t *testing.T) {
 		if r.URL.Path != "/activities/4" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":4}}`))
@@ -256,11 +323,123 @@ func TestActivitiesService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Activities.Delete(context.Background(), ActivityID(4))
+	result, err := client.Activities.Delete(
+		context.Background(),
+		ActivityID(4),
+		WithActivityRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
 	if result.ID != 4 {
 		t.Fatalf("unexpected delete result: %#v", result)
+	}
+}
+
+func TestActivitiesService_Get(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/activities/4" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("include_fields"); got != "attendees" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":4,"subject":"Call"}}`))
+	})
+
+	activity, err := client.Activities.Get(
+		context.Background(),
+		ActivityID(4),
+		WithActivityIncludeFields(ActivityIncludeFieldAttendees),
+		WithActivityRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if activity.ID != 4 || activity.Subject != "Call" {
+		t.Fatalf("unexpected activity: %#v", activity)
+	}
+}
+
+func TestActivitiesService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/activities" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Activities.ListPager(WithActivitiesPageSize(2), WithActivitiesCursor("start"))
+	var ids []ActivityID
+	for pager.Next(context.Background()) {
+		for _, activity := range pager.Items() {
+			ids = append(ids, activity.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestActivitiesService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/activities" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []ActivityID
+	err := client.Activities.ForEach(context.Background(), func(activity Activity) error {
+		ids = append(ids, activity.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }

--- a/pipedrive/v2/activity_fields_test.go
+++ b/pipedrive/v2/activity_fields_test.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -98,5 +99,297 @@ func TestActivityFieldsService_Get(t *testing.T) {
 	}
 	if field.FieldCode != "cf_2" || field.FieldName != "Note" {
 		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func TestActivityFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	runFieldListPagerTest(t, "/activityFields", func(client *Client) *pipedrive.CursorPager[Field] {
+		return client.ActivityFields.ListPager(WithActivityFieldsPageSize(2), WithActivityFieldsCursor("start"))
+	})
+}
+
+func TestActivityFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	runFieldForEachTest(t, "/activityFields", func(ctx context.Context, client *Client, fn func(Field) error) error {
+		return client.ActivityFields.ForEach(ctx, fn)
+	})
+}
+
+func runFieldGetTest(t *testing.T, path string, get func(context.Context, *Client) (*Field, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("include_fields"); got != "ui_visibility,important_fields" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Priority"}}`))
+	})
+
+	field, err := get(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if field.FieldCode != "cf_1" || field.FieldName != "Priority" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func runFieldListPagerTest(t *testing.T, path string, pagerFor func(*Client) *pipedrive.CursorPager[Field]) {
+	t.Helper()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1"}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_2"}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := pagerFor(client)
+	var codes []string
+	for pager.Next(context.Background()) {
+		for _, field := range pager.Items() {
+			codes = append(codes, field.FieldCode)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(codes) != 2 || codes[0] != "cf_1" || codes[1] != "cf_2" {
+		t.Fatalf("unexpected field codes: %v", codes)
+	}
+}
+
+func runFieldForEachTest(t *testing.T, path string, forEach func(context.Context, *Client, func(Field) error) error) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1"},{"field_code":"cf_2"}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var codes []string
+	err := forEach(context.Background(), client, func(field Field) error {
+		codes = append(codes, field.FieldCode)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(codes) != 2 || codes[0] != "cf_1" || codes[1] != "cf_2" {
+		t.Fatalf("unexpected field codes: %v", codes)
+	}
+}
+
+func runFieldUpdateTest(t *testing.T, path string, update func(context.Context, *Client) (*Field, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["field_name"] != "Priority updated" {
+			t.Fatalf("unexpected field_name: %#v", payload["field_name"])
+		}
+		if payload["field_type"] != "varchar" {
+			t.Fatalf("unexpected field_type: %#v", payload["field_type"])
+		}
+		if payload["description"] != "Updated description" {
+			t.Fatalf("unexpected description: %#v", payload["description"])
+		}
+		if got := payload["ui_visibility"].(map[string]interface{})["add"]; got != true {
+			t.Fatalf("unexpected ui_visibility: %#v", payload["ui_visibility"])
+		}
+		if got := payload["important_fields"].(map[string]interface{})["pipeline_id"]; got != float64(1) {
+			t.Fatalf("unexpected important_fields: %#v", payload["important_fields"])
+		}
+		if got := payload["required_fields"].(map[string]interface{})["stage_id"]; got != float64(2) {
+			t.Fatalf("unexpected required_fields: %#v", payload["required_fields"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Priority updated"}}`))
+	})
+
+	field, err := update(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if field.FieldName != "Priority updated" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func runFieldDeleteTest(t *testing.T, path string, deleteField func(context.Context, *Client) (*Field, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Deleted"}}`))
+	})
+
+	field, err := deleteField(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if field.FieldCode != "cf_1" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func runFieldAddOptionsRequestOptionsTest(t *testing.T, path string, addOptions func(context.Context, *Client) ([]FieldOption, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+	})
+
+	options, err := addOptions(context.Background(), client)
+	if err != nil {
+		t.Fatalf("AddOptions error: %v", err)
+	}
+	if len(options) != 1 || options[0].Label != "Critical" {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+}
+
+func runFieldUpdateOptionsTest(t *testing.T, path string, updateOptions func(context.Context, *Client) ([]FieldOption, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload []map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(payload) != 1 || payload[0]["id"] != float64(1) || payload[0]["label"] != "Critical" {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+	})
+
+	options, err := updateOptions(context.Background(), client)
+	if err != nil {
+		t.Fatalf("UpdateOptions error: %v", err)
+	}
+	if len(options) != 1 || options[0].ID != 1 {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+}
+
+func runFieldDeleteOptionsTest(t *testing.T, path string, deleteOptions func(context.Context, *Client) ([]FieldOption, error)) {
+	t.Helper()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != path {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload []map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(payload) != 2 || payload[0]["id"] != float64(1) || payload[1]["id"] != float64(2) {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}]}`))
+	})
+
+	options, err := deleteOptions(context.Background(), client)
+	if err != nil {
+		t.Fatalf("DeleteOptions error: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("unexpected options: %#v", options)
 	}
 }

--- a/pipedrive/v2/deal_fields_test.go
+++ b/pipedrive/v2/deal_fields_test.go
@@ -164,3 +164,313 @@ func TestDealFieldsService_AddOptions(t *testing.T) {
 		t.Fatalf("unexpected options: %#v", options)
 	}
 }
+
+func TestDealFieldsService_Get(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("include_fields"); got != "ui_visibility,important_fields" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Priority"}}`))
+	})
+
+	field, err := client.DealFields.Get(
+		context.Background(),
+		"cf_1",
+		WithDealFieldIncludeFields(FieldIncludeField("ui_visibility"), FieldIncludeField("important_fields")),
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if field.FieldCode != "cf_1" || field.FieldName != "Priority" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func TestDealFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1"}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_2"}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.DealFields.ListPager(WithDealFieldsPageSize(2), WithDealFieldsCursor("start"))
+	var codes []string
+	for pager.Next(context.Background()) {
+		for _, field := range pager.Items() {
+			codes = append(codes, field.FieldCode)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(codes) != 2 || codes[0] != "cf_1" || codes[1] != "cf_2" {
+		t.Fatalf("unexpected field codes: %v", codes)
+	}
+}
+
+func TestDealFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1"},{"field_code":"cf_2"}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var codes []string
+	err := client.DealFields.ForEach(context.Background(), func(field Field) error {
+		codes = append(codes, field.FieldCode)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(codes) != 2 || codes[0] != "cf_1" || codes[1] != "cf_2" {
+		t.Fatalf("unexpected field codes: %v", codes)
+	}
+}
+
+func TestDealFieldsService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["field_name"] != "Priority updated" {
+			t.Fatalf("unexpected field_name: %#v", payload["field_name"])
+		}
+		if payload["field_type"] != "varchar" {
+			t.Fatalf("unexpected field_type: %#v", payload["field_type"])
+		}
+		if payload["description"] != "Updated description" {
+			t.Fatalf("unexpected description: %#v", payload["description"])
+		}
+		if got := payload["ui_visibility"].(map[string]interface{})["add"]; got != true {
+			t.Fatalf("unexpected ui_visibility: %#v", payload["ui_visibility"])
+		}
+		if got := payload["important_fields"].(map[string]interface{})["pipeline_id"]; got != float64(1) {
+			t.Fatalf("unexpected important_fields: %#v", payload["important_fields"])
+		}
+		if got := payload["required_fields"].(map[string]interface{})["stage_id"]; got != float64(2) {
+			t.Fatalf("unexpected required_fields: %#v", payload["required_fields"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Priority updated"}}`))
+	})
+
+	field, err := client.DealFields.Update(
+		context.Background(),
+		"cf_1",
+		WithDealFieldName("Priority updated"),
+		WithDealFieldType(FieldTypeVarchar),
+		WithDealFieldDescription("Updated description"),
+		WithDealFieldUIVisibility(map[string]interface{}{"add": true}),
+		WithDealFieldImportantFields(map[string]interface{}{"pipeline_id": 1}),
+		WithDealFieldRequiredFields(map[string]interface{}{"stage_id": 2}),
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if field.FieldName != "Priority updated" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func TestDealFieldsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Deleted"}}`))
+	})
+
+	field, err := client.DealFields.Delete(
+		context.Background(),
+		"cf_1",
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if field.FieldCode != "cf_1" {
+		t.Fatalf("unexpected field: %#v", field)
+	}
+}
+
+func TestDealFieldsService_AddOptionsWithRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1/options" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+	})
+
+	options, err := client.DealFields.AddOptions(
+		context.Background(),
+		"cf_1",
+		[]string{"Critical"},
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "add-options")),
+	)
+	if err != nil {
+		t.Fatalf("AddOptions error: %v", err)
+	}
+	if len(options) != 1 || options[0].Label != "Critical" {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+}
+
+func TestDealFieldsService_UpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1/options" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload []map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(payload) != 1 || payload[0]["id"] != float64(1) || payload[0]["label"] != "Critical" {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+	})
+
+	options, err := client.DealFields.UpdateOptions(
+		context.Background(),
+		"cf_1",
+		[]FieldOptionUpdate{{ID: 1, Label: "Critical"}},
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "update-options")),
+	)
+	if err != nil {
+		t.Fatalf("UpdateOptions error: %v", err)
+	}
+	if len(options) != 1 || options[0].ID != 1 {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+}
+
+func TestDealFieldsService_DeleteOptions(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/dealFields/cf_1/options" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete-options" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload []map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(payload) != 2 || payload[0]["id"] != float64(1) || payload[1]["id"] != float64(2) {
+			t.Fatalf("unexpected payload: %#v", payload)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}]}`))
+	})
+
+	options, err := client.DealFields.DeleteOptions(
+		context.Background(),
+		"cf_1",
+		[]int{1, 2},
+		WithDealFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete-options")),
+	)
+	if err != nil {
+		t.Fatalf("DeleteOptions error: %v", err)
+	}
+	if len(options) != 2 {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+}

--- a/pipedrive/v2/deals_test.go
+++ b/pipedrive/v2/deals_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
@@ -20,6 +21,12 @@ func TestDealsService_Get(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/1" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("include_fields"); got != "activities_count,products_count" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := r.URL.Query().Get("custom_fields"); got != "cf_1,cf_2" {
+			t.Fatalf("unexpected custom_fields: %q", got)
 		}
 		if got := r.Header.Get("X-Test"); got != "1" {
 			t.Fatalf("unexpected header X-Test: %q", got)
@@ -37,12 +44,118 @@ func TestDealsService_Get(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	deal, err := client.Deals.Get(context.Background(), 1, WithDealRequestOptions(pipedrive.WithHeader("X-Test", "1")))
+	deal, err := client.Deals.Get(
+		context.Background(),
+		1,
+		WithDealIncludeFields(DealIncludeFieldActivitiesCount, DealIncludeFieldProductsCount),
+		WithDealCustomFields("cf_1", "cf_2"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "1")),
+	)
 	if err != nil {
 		t.Fatalf("Get error: %v", err)
 	}
 	if deal.ID != 1 || deal.Title != "Test deal" {
 		t.Fatalf("unexpected deal: %#v", deal)
+	}
+}
+
+func TestDealsService_List(t *testing.T) {
+	t.Parallel()
+
+	since := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	until := time.Date(2024, 6, 2, 11, 0, 0, 0, time.UTC)
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if got := q.Get("filter_id"); got != "3" {
+			t.Fatalf("unexpected filter_id: %q", got)
+		}
+		if got := q.Get("ids"); got != "7,8" {
+			t.Fatalf("unexpected ids: %q", got)
+		}
+		if got := q.Get("owner_id"); got != "4" {
+			t.Fatalf("unexpected owner_id: %q", got)
+		}
+		if got := q.Get("person_id"); got != "5" {
+			t.Fatalf("unexpected person_id: %q", got)
+		}
+		if got := q.Get("org_id"); got != "6" {
+			t.Fatalf("unexpected org_id: %q", got)
+		}
+		if got := q.Get("pipeline_id"); got != "2" {
+			t.Fatalf("unexpected pipeline_id: %q", got)
+		}
+		if got := q.Get("stage_id"); got != "9" {
+			t.Fatalf("unexpected stage_id: %q", got)
+		}
+		if got := q.Get("status"); got != "open,won" {
+			t.Fatalf("unexpected status: %q", got)
+		}
+		if got := q.Get("updated_since"); got != since.Format(time.RFC3339) {
+			t.Fatalf("unexpected updated_since: %q", got)
+		}
+		if got := q.Get("updated_until"); got != until.Format(time.RFC3339) {
+			t.Fatalf("unexpected updated_until: %q", got)
+		}
+		if got := q.Get("sort_by"); got != "update_time" {
+			t.Fatalf("unexpected sort_by: %q", got)
+		}
+		if got := q.Get("sort_direction"); got != "desc" {
+			t.Fatalf("unexpected sort_direction: %q", got)
+		}
+		if got := q.Get("include_fields"); got != "activities_count,products_count" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := q.Get("custom_fields"); got != "cf_1,cf_2" {
+			t.Fatalf("unexpected custom_fields: %q", got)
+		}
+		if got := q.Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		if got := q.Get("cursor"); got != "c1" {
+			t.Fatalf("unexpected cursor: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":7,"title":"Deal"}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	deals, next, err := client.Deals.List(
+		context.Background(),
+		WithDealsFilterID(3),
+		WithDealsIDs(DealID(7), DealID(8)),
+		WithDealsOwnerID(UserID(4)),
+		WithDealsPersonID(PersonID(5)),
+		WithDealsOrganizationID(OrganizationID(6)),
+		WithDealsPipelineID(PipelineID(2)),
+		WithDealsStageID(StageID(9)),
+		WithDealsStatus(DealStatusOpen, DealStatusWon),
+		WithDealsUpdatedSince(since),
+		WithDealsUpdatedUntil(until),
+		WithDealsSortBy(DealSortByUpdateTime),
+		WithDealsSortDirection(SortDesc),
+		WithDealsIncludeFields(DealIncludeFieldActivitiesCount, DealIncludeFieldProductsCount),
+		WithDealsCustomFields("cf_1", "cf_2"),
+		WithDealsPageSize(2),
+		WithDealsCursor("c1"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "list")),
+	)
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if next != nil {
+		t.Fatalf("expected nil cursor, got %q", *next)
+	}
+	if len(deals) != 1 || deals[0].ID != 7 {
+		t.Fatalf("unexpected deals: %#v", deals)
 	}
 }
 
@@ -184,6 +297,9 @@ func TestDealsService_Create(t *testing.T) {
 		if r.URL.Path != "/deals" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -197,6 +313,62 @@ func TestDealsService_Create(t *testing.T) {
 		}
 		if payload["currency"] != "USD" {
 			t.Fatalf("unexpected currency: %#v", payload["currency"])
+		}
+		if payload["owner_id"] != float64(3) {
+			t.Fatalf("unexpected owner_id: %#v", payload["owner_id"])
+		}
+		if payload["person_id"] != float64(4) {
+			t.Fatalf("unexpected person_id: %#v", payload["person_id"])
+		}
+		if payload["org_id"] != float64(5) {
+			t.Fatalf("unexpected org_id: %#v", payload["org_id"])
+		}
+		if payload["stage_id"] != float64(6) {
+			t.Fatalf("unexpected stage_id: %#v", payload["stage_id"])
+		}
+		if payload["pipeline_id"] != float64(2) {
+			t.Fatalf("unexpected pipeline_id: %#v", payload["pipeline_id"])
+		}
+		if payload["status"] != "open" {
+			t.Fatalf("unexpected status: %#v", payload["status"])
+		}
+		if payload["expected_close_date"] != "2024-06-10" {
+			t.Fatalf("unexpected expected_close_date: %#v", payload["expected_close_date"])
+		}
+		if payload["probability"] != float64(55) {
+			t.Fatalf("unexpected probability: %#v", payload["probability"])
+		}
+		if payload["lost_reason"] != "No budget" {
+			t.Fatalf("unexpected lost_reason: %#v", payload["lost_reason"])
+		}
+		if payload["visible_to"] != float64(3) {
+			t.Fatalf("unexpected visible_to: %#v", payload["visible_to"])
+		}
+		labels, ok := payload["label_ids"].([]interface{})
+		if !ok || len(labels) != 2 || labels[0] != float64(10) || labels[1] != float64(11) {
+			t.Fatalf("unexpected label_ids: %#v", payload["label_ids"])
+		}
+		customFields, ok := payload["custom_fields"].(map[string]interface{})
+		if !ok || customFields["cf_key"] != "value" {
+			t.Fatalf("unexpected custom_fields: %#v", payload["custom_fields"])
+		}
+		if payload["is_archived"] != true {
+			t.Fatalf("unexpected is_archived: %#v", payload["is_archived"])
+		}
+		if payload["is_deleted"] != false {
+			t.Fatalf("unexpected is_deleted: %#v", payload["is_deleted"])
+		}
+		if payload["archive_time"] != "2024-06-11T10:00:00Z" {
+			t.Fatalf("unexpected archive_time: %#v", payload["archive_time"])
+		}
+		if payload["close_time"] != "2024-06-12T10:00:00Z" {
+			t.Fatalf("unexpected close_time: %#v", payload["close_time"])
+		}
+		if payload["lost_time"] != "2024-06-13T10:00:00Z" {
+			t.Fatalf("unexpected lost_time: %#v", payload["lost_time"])
+		}
+		if payload["won_time"] != "2024-06-14T10:00:00Z" {
+			t.Fatalf("unexpected won_time: %#v", payload["won_time"])
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -217,6 +389,25 @@ func TestDealsService_Create(t *testing.T) {
 		WithDealTitle("New Deal"),
 		WithDealValue(1200),
 		WithDealCurrency("USD"),
+		WithDealOwnerID(UserID(3)),
+		WithDealPersonID(PersonID(4)),
+		WithDealOrganizationID(OrganizationID(5)),
+		WithDealStageID(StageID(6)),
+		WithDealPipelineID(PipelineID(2)),
+		WithDealStatus(DealStatusOpen),
+		WithDealExpectedCloseDate("2024-06-10"),
+		WithDealProbability(55),
+		WithDealLostReason("No budget"),
+		WithDealVisibleTo(3),
+		WithDealLabelIDs(10, 11),
+		WithDealCustomFieldsMap(map[string]interface{}{"cf_key": "value"}),
+		WithDealArchived(true),
+		WithDealDeleted(false),
+		WithDealArchiveTime("2024-06-11T10:00:00Z"),
+		WithDealCloseTime("2024-06-12T10:00:00Z"),
+		WithDealLostTime("2024-06-13T10:00:00Z"),
+		WithDealWonTime("2024-06-14T10:00:00Z"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
@@ -235,6 +426,9 @@ func TestDealsService_Update(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		var payload map[string]interface{}
@@ -262,6 +456,7 @@ func TestDealsService_Update(t *testing.T) {
 		context.Background(),
 		DealID(7),
 		WithDealTitle("Updated Deal"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {
 		t.Fatalf("Update error: %v", err)
@@ -281,6 +476,9 @@ func TestDealsService_Delete(t *testing.T) {
 		if r.URL.Path != "/deals/7" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":7}}`))
@@ -295,7 +493,11 @@ func TestDealsService_Delete(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Deals.Delete(context.Background(), DealID(7))
+	result, err := client.Deals.Delete(
+		context.Background(),
+		DealID(7),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
 	if err != nil {
 		t.Fatalf("Delete error: %v", err)
 	}
@@ -327,6 +529,12 @@ func TestDealsService_Search(t *testing.T) {
 		if got := q.Get("status"); got != "open" {
 			t.Fatalf("unexpected status: %q", got)
 		}
+		if got := q.Get("person_id"); got != "5" {
+			t.Fatalf("unexpected person_id: %q", got)
+		}
+		if got := q.Get("organization_id"); got != "6" {
+			t.Fatalf("unexpected organization_id: %q", got)
+		}
 		if got := q.Get("include_fields"); got != "deal.cc_email" {
 			t.Fatalf("unexpected include_fields: %q", got)
 		}
@@ -335,6 +543,9 @@ func TestDealsService_Search(t *testing.T) {
 		}
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "search" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -356,9 +567,12 @@ func TestDealsService_Search(t *testing.T) {
 		WithDealSearchFields(DealSearchFieldTitle),
 		WithDealSearchExactMatch(true),
 		WithDealSearchStatus(DealSearchStatusOpen),
+		WithDealSearchPersonID(PersonID(5)),
+		WithDealSearchOrganizationID(OrganizationID(6)),
 		WithDealSearchIncludeFields(DealSearchIncludeFieldDealCCEmail),
 		WithDealSearchPageSize(1),
 		WithDealSearchCursor("c1"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "search")),
 	)
 	if err != nil {
 		t.Fatalf("Search error: %v", err)
@@ -374,6 +588,9 @@ func TestDealsService_Search(t *testing.T) {
 func TestDealsService_ListArchived(t *testing.T) {
 	t.Parallel()
 
+	since := time.Date(2024, 4, 1, 9, 0, 0, 0, time.UTC)
+	until := time.Date(2024, 4, 2, 9, 0, 0, 0, time.UTC)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Fatalf("unexpected method: %s", r.Method)
@@ -382,11 +599,41 @@ func TestDealsService_ListArchived(t *testing.T) {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		q := r.URL.Query()
+		if got := q.Get("filter_id"); got != "4" {
+			t.Fatalf("unexpected filter_id: %q", got)
+		}
+		if got := q.Get("ids"); got != "2,3" {
+			t.Fatalf("unexpected ids: %q", got)
+		}
 		if got := q.Get("owner_id"); got != "3" {
 			t.Fatalf("unexpected owner_id: %q", got)
 		}
-		if got := q.Get("status"); got != "won" {
+		if got := q.Get("person_id"); got != "5" {
+			t.Fatalf("unexpected person_id: %q", got)
+		}
+		if got := q.Get("org_id"); got != "6" {
+			t.Fatalf("unexpected org_id: %q", got)
+		}
+		if got := q.Get("pipeline_id"); got != "7" {
+			t.Fatalf("unexpected pipeline_id: %q", got)
+		}
+		if got := q.Get("stage_id"); got != "8" {
+			t.Fatalf("unexpected stage_id: %q", got)
+		}
+		if got := q.Get("status"); got != "won,lost" {
 			t.Fatalf("unexpected status: %q", got)
+		}
+		if got := q.Get("updated_since"); got != since.Format(time.RFC3339) {
+			t.Fatalf("unexpected updated_since: %q", got)
+		}
+		if got := q.Get("updated_until"); got != until.Format(time.RFC3339) {
+			t.Fatalf("unexpected updated_until: %q", got)
+		}
+		if got := q.Get("sort_by"); got != "update_time" {
+			t.Fatalf("unexpected sort_by: %q", got)
+		}
+		if got := q.Get("sort_direction"); got != "desc" {
+			t.Fatalf("unexpected sort_direction: %q", got)
 		}
 		if got := q.Get("include_fields"); got != "activities_count" {
 			t.Fatalf("unexpected include_fields: %q", got)
@@ -399,6 +646,9 @@ func TestDealsService_ListArchived(t *testing.T) {
 		}
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "archived" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -416,12 +666,23 @@ func TestDealsService_ListArchived(t *testing.T) {
 
 	deals, next, err := client.Deals.ListArchived(
 		context.Background(),
+		WithArchivedDealsFilterID(4),
+		WithArchivedDealsIDs(DealID(2), DealID(3)),
 		WithArchivedDealsOwnerID(UserID(3)),
-		WithArchivedDealsStatus(DealStatusWon),
+		WithArchivedDealsPersonID(PersonID(5)),
+		WithArchivedDealsOrganizationID(OrganizationID(6)),
+		WithArchivedDealsPipelineID(PipelineID(7)),
+		WithArchivedDealsStageID(StageID(8)),
+		WithArchivedDealsStatus(DealStatusWon, DealStatusLost),
+		WithArchivedDealsUpdatedSince(since),
+		WithArchivedDealsUpdatedUntil(until),
+		WithArchivedDealsSortBy(DealSortByUpdateTime),
+		WithArchivedDealsSortDirection(SortDesc),
 		WithArchivedDealsIncludeFields(DealIncludeFieldActivitiesCount),
 		WithArchivedDealsCustomFields("cf_1"),
 		WithArchivedDealsPageSize(2),
 		WithArchivedDealsCursor("c1"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "archived")),
 	)
 	if err != nil {
 		t.Fatalf("ListArchived error: %v", err)
@@ -431,6 +692,80 @@ func TestDealsService_ListArchived(t *testing.T) {
 	}
 	if len(deals) != 1 || deals[0].ID != 2 {
 		t.Fatalf("unexpected deals: %#v", deals)
+	}
+}
+
+func TestDealsService_ListArchivedPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/archived" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.ListArchivedPager(WithArchivedDealsPageSize(2), WithArchivedDealsCursor("start"))
+	var ids []DealID
+	for pager.Next(context.Background()) {
+		for _, deal := range pager.Items() {
+			ids = append(ids, deal.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachArchived(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/archived" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []DealID
+	err := client.Deals.ForEachArchived(context.Background(), func(deal Deal) error {
+		ids = append(ids, deal.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachArchived error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }
 
@@ -445,6 +780,9 @@ func TestDealsService_ConvertToLead(t *testing.T) {
 		if r.URL.Path != "/deals/7/convert/lead" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "convert" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"conversion_id":"` + convID + `"}}`))
 	}))
@@ -455,7 +793,11 @@ func TestDealsService_ConvertToLead(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	job, err := client.Deals.ConvertToLead(context.Background(), DealID(7))
+	job, err := client.Deals.ConvertToLead(
+		context.Background(),
+		DealID(7),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "convert")),
+	)
 	if err != nil {
 		t.Fatalf("ConvertToLead error: %v", err)
 	}
@@ -476,6 +818,9 @@ func TestDealsService_ConversionStatus(t *testing.T) {
 		if r.URL.Path != "/deals/7/convert/status/"+convID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "conversion-status" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"conversion_id":"` + convID + `","status":"completed","deal_id":9,"lead_id":"` + leadID + `"}}`))
 	}))
@@ -486,7 +831,12 @@ func TestDealsService_ConversionStatus(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	status, err := client.Deals.ConversionStatus(context.Background(), DealID(7), ConversionID(convID))
+	status, err := client.Deals.ConversionStatus(
+		context.Background(),
+		DealID(7),
+		ConversionID(convID),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "conversion-status")),
+	)
 	if err != nil {
 		t.Fatalf("ConversionStatus error: %v", err)
 	}
@@ -518,6 +868,9 @@ func TestDealsService_ListFollowers(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "followers" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"user_id":5}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -533,6 +886,7 @@ func TestDealsService_ListFollowers(t *testing.T) {
 		DealID(7),
 		WithDealFollowersPageSize(2),
 		WithDealFollowersCursor("c1"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "followers")),
 	)
 	if err != nil {
 		t.Fatalf("ListFollowers error: %v", err)
@@ -545,6 +899,77 @@ func TestDealsService_ListFollowers(t *testing.T) {
 	}
 }
 
+func TestDealsService_ListFollowersPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.ListFollowersPager(DealID(7), WithDealFollowersCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, follower := range pager.Items() {
+			ids = append(ids, follower.UserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachFollowers(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"user_id":1},{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Deals.ForEachFollowers(context.Background(), DealID(7), func(follower Follower) error {
+		ids = append(ids, follower.UserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowers error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestDealsService_AddFollower(t *testing.T) {
 	t.Parallel()
 
@@ -554,6 +979,9 @@ func TestDealsService_AddFollower(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/followers" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-follower" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -572,7 +1000,12 @@ func TestDealsService_AddFollower(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	follower, err := client.Deals.AddFollower(context.Background(), DealID(7), UserID(6))
+	follower, err := client.Deals.AddFollower(
+		context.Background(),
+		DealID(7),
+		UserID(6),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "add-follower")),
+	)
 	if err != nil {
 		t.Fatalf("AddFollower error: %v", err)
 	}
@@ -591,6 +1024,9 @@ func TestDealsService_DeleteFollower(t *testing.T) {
 		if r.URL.Path != "/deals/7/followers/6" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-follower" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"user_id":6}}`))
 	}))
@@ -601,7 +1037,12 @@ func TestDealsService_DeleteFollower(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Deals.DeleteFollower(context.Background(), DealID(7), UserID(6))
+	result, err := client.Deals.DeleteFollower(
+		context.Background(),
+		DealID(7),
+		UserID(6),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete-follower")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteFollower error: %v", err)
 	}
@@ -627,6 +1068,9 @@ func TestDealsService_FollowersChangelog(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "followers-changelog" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"action":"added","actor_user_id":1,"follower_user_id":2,"time":"2024-01-01T10:00:00Z"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -642,6 +1086,7 @@ func TestDealsService_FollowersChangelog(t *testing.T) {
 		DealID(7),
 		WithDealFollowersChangelogPageSize(1),
 		WithDealFollowersChangelogCursor("c1"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "followers-changelog")),
 	)
 	if err != nil {
 		t.Fatalf("FollowersChangelog error: %v", err)
@@ -651,6 +1096,77 @@ func TestDealsService_FollowersChangelog(t *testing.T) {
 	}
 	if len(changelog) != 1 || changelog[0].FollowerUserID != 2 {
 		t.Fatalf("unexpected changelog: %#v", changelog)
+	}
+}
+
+func TestDealsService_FollowersChangelogPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.FollowersChangelogPager(DealID(7), WithDealFollowersChangelogCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, entry := range pager.Items() {
+			ids = append(ids, entry.FollowerUserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachFollowersChangelog(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1},{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Deals.ForEachFollowersChangelog(context.Background(), DealID(7), func(entry FollowerChangelog) error {
+		ids = append(ids, entry.FollowerUserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowersChangelog error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }
 
@@ -677,6 +1193,9 @@ func TestDealsService_ListProducts(t *testing.T) {
 		if got := q.Get("sort_direction"); got != "desc" {
 			t.Fatalf("unexpected sort_direction: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "deal-products" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":10,"deal_id":7,"product_id":3,"name":"Widget"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -694,6 +1213,7 @@ func TestDealsService_ListProducts(t *testing.T) {
 		WithDealProductsCursor("c1"),
 		WithDealProductsSortBy(DealProductSortByAddTime),
 		WithDealProductsSortDirection(SortDesc),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "deal-products")),
 	)
 	if err != nil {
 		t.Fatalf("ListProducts error: %v", err)
@@ -703,6 +1223,77 @@ func TestDealsService_ListProducts(t *testing.T) {
 	}
 	if len(products) != 1 || products[0].ID != 10 {
 		t.Fatalf("unexpected products: %#v", products)
+	}
+}
+
+func TestDealsService_ListProductsPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.ListProductsPager(DealID(7), WithDealProductsCursor("start"))
+	var ids []DealProductAttachmentID
+	for pager.Next(context.Background()) {
+		for _, product := range pager.Items() {
+			ids = append(ids, product.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachProducts(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/7/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []DealProductAttachmentID
+	err := client.Deals.ForEachProducts(context.Background(), DealID(7), func(product DealProduct) error {
+		ids = append(ids, product.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachProducts error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }
 
@@ -726,6 +1317,15 @@ func TestDealsService_ListProductsAcrossDeals(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := q.Get("sort_by"); got != "deal_id" {
+			t.Fatalf("unexpected sort_by: %q", got)
+		}
+		if got := q.Get("sort_direction"); got != "asc" {
+			t.Fatalf("unexpected sort_direction: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "deals-products" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":12,"deal_id":1,"product_id":9,"name":"Bulk"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -741,6 +1341,9 @@ func TestDealsService_ListProductsAcrossDeals(t *testing.T) {
 		[]DealID{1, 2},
 		WithDealsProductsPageSize(1),
 		WithDealsProductsCursor("c1"),
+		WithDealsProductsSortBy(DealProductSortByDealID),
+		WithDealsProductsSortDirection(SortAsc),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "deals-products")),
 	)
 	if err != nil {
 		t.Fatalf("ListProductsAcrossDeals error: %v", err)
@@ -750,6 +1353,83 @@ func TestDealsService_ListProductsAcrossDeals(t *testing.T) {
 	}
 	if len(products) != 1 || products[0].ID != 12 {
 		t.Fatalf("unexpected products: %#v", products)
+	}
+}
+
+func TestDealsService_ListProductsAcrossDealsPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+			t.Fatalf("unexpected deal_ids: %#v", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.ListProductsAcrossDealsPager([]DealID{1, 2}, WithDealsProductsCursor("start"))
+	var ids []DealProductAttachmentID
+	for pager.Next(context.Background()) {
+		for _, product := range pager.Items() {
+			ids = append(ids, product.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachProductsAcrossDeals(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+			t.Fatalf("unexpected deal_ids: %#v", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []DealProductAttachmentID
+	err := client.Deals.ForEachProductsAcrossDeals(context.Background(), []DealID{1, 2}, func(product DealProduct) error {
+		ids = append(ids, product.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachProductsAcrossDeals error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }
 
@@ -763,6 +1443,9 @@ func TestDealsService_AddProduct(t *testing.T) {
 		if r.URL.Path != "/deals/7/products" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "add-product" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -770,14 +1453,41 @@ func TestDealsService_AddProduct(t *testing.T) {
 		if payload["product_id"] != float64(9) {
 			t.Fatalf("unexpected product_id: %#v", payload["product_id"])
 		}
+		if payload["product_variation_id"] != float64(10) {
+			t.Fatalf("unexpected product_variation_id: %#v", payload["product_variation_id"])
+		}
 		if payload["item_price"] != float64(199) {
 			t.Fatalf("unexpected item_price: %#v", payload["item_price"])
 		}
 		if payload["quantity"] != float64(2) {
 			t.Fatalf("unexpected quantity: %#v", payload["quantity"])
 		}
+		if payload["discount"] != float64(5) {
+			t.Fatalf("unexpected discount: %#v", payload["discount"])
+		}
 		if payload["discount_type"] != "percentage" {
 			t.Fatalf("unexpected discount_type: %#v", payload["discount_type"])
+		}
+		if payload["comments"] != "Launch bundle" {
+			t.Fatalf("unexpected comments: %#v", payload["comments"])
+		}
+		if payload["tax"] != float64(20) {
+			t.Fatalf("unexpected tax: %#v", payload["tax"])
+		}
+		if payload["tax_method"] != "exclusive" {
+			t.Fatalf("unexpected tax_method: %#v", payload["tax_method"])
+		}
+		if payload["is_enabled"] != true {
+			t.Fatalf("unexpected is_enabled: %#v", payload["is_enabled"])
+		}
+		if payload["billing_frequency"] != "monthly" {
+			t.Fatalf("unexpected billing_frequency: %#v", payload["billing_frequency"])
+		}
+		if payload["billing_frequency_cycles"] != float64(3) {
+			t.Fatalf("unexpected billing_frequency_cycles: %#v", payload["billing_frequency_cycles"])
+		}
+		if payload["billing_start_date"] != "2024-07-01" {
+			t.Fatalf("unexpected billing_start_date: %#v", payload["billing_start_date"])
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":15,"deal_id":7,"product_id":9}}`))
@@ -793,9 +1503,19 @@ func TestDealsService_AddProduct(t *testing.T) {
 		context.Background(),
 		DealID(7),
 		WithDealProductProductID(ProductID(9)),
+		WithDealProductVariationID(ProductVariationID(10)),
 		WithDealProductItemPrice(199),
 		WithDealProductQuantity(2),
+		WithDealProductDiscount(5),
 		WithDealProductDiscountType(DealProductDiscountTypePercentage),
+		WithDealProductComments("Launch bundle"),
+		WithDealProductTax(20),
+		WithDealProductTaxMethod(DealProductTaxMethodExclusive),
+		WithDealProductIsEnabled(true),
+		WithDealProductBillingFrequency(BillingFrequencyMonthly),
+		WithDealProductBillingFrequencyCycles(3),
+		WithDealProductBillingStartDate("2024-07-01"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "add-product")),
 	)
 	if err != nil {
 		t.Fatalf("AddProduct error: %v", err)
@@ -814,6 +1534,9 @@ func TestDealsService_AddProducts(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/products/bulk" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-products" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -852,6 +1575,7 @@ func TestDealsService_AddProducts(t *testing.T) {
 				WithDealProductQuantity(2),
 			),
 		},
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "add-products")),
 	)
 	if err != nil {
 		t.Fatalf("AddProducts error: %v", err)
@@ -870,6 +1594,9 @@ func TestDealsService_UpdateProduct(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/products/15" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-product" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -893,6 +1620,7 @@ func TestDealsService_UpdateProduct(t *testing.T) {
 		DealID(7),
 		DealProductAttachmentID(15),
 		WithDealProductItemPrice(250),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "update-product")),
 	)
 	if err != nil {
 		t.Fatalf("UpdateProduct error: %v", err)
@@ -912,6 +1640,9 @@ func TestDealsService_DeleteProduct(t *testing.T) {
 		if r.URL.Path != "/deals/7/products/15" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-product" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":15}}`))
 	}))
@@ -922,7 +1653,12 @@ func TestDealsService_DeleteProduct(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	result, err := client.Deals.DeleteProduct(context.Background(), DealID(7), DealProductAttachmentID(15))
+	result, err := client.Deals.DeleteProduct(
+		context.Background(),
+		DealID(7),
+		DealProductAttachmentID(15),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete-product")),
+	)
 	if err != nil {
 		t.Fatalf("DeleteProduct error: %v", err)
 	}
@@ -944,6 +1680,9 @@ func TestDealsService_DeleteProducts(t *testing.T) {
 		if got := r.URL.Query().Get("ids"); got != "15,16" {
 			t.Fatalf("unexpected ids: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-products" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"ids":[15,16]}}`))
 	}))
@@ -958,6 +1697,7 @@ func TestDealsService_DeleteProducts(t *testing.T) {
 		context.Background(),
 		DealID(7),
 		WithDealProductAttachmentIDs(DealProductAttachmentID(15), DealProductAttachmentID(16)),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete-products")),
 	)
 	if err != nil {
 		t.Fatalf("DeleteProducts error: %v", err)
@@ -977,6 +1717,9 @@ func TestDealsService_ListAdditionalDiscounts(t *testing.T) {
 		if r.URL.Path != "/deals/7/discounts" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "discounts" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":"11111111-1111-1111-1111-111111111111","deal_id":7,"amount":10,"type":"amount"}]}`))
 	}))
@@ -987,7 +1730,11 @@ func TestDealsService_ListAdditionalDiscounts(t *testing.T) {
 		t.Fatalf("NewClient error: %v", err)
 	}
 
-	discounts, err := client.Deals.ListAdditionalDiscounts(context.Background(), DealID(7))
+	discounts, err := client.Deals.ListAdditionalDiscounts(
+		context.Background(),
+		DealID(7),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "discounts")),
+	)
 	if err != nil {
 		t.Fatalf("ListAdditionalDiscounts error: %v", err)
 	}
@@ -1005,6 +1752,9 @@ func TestDealsService_AddAdditionalDiscount(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/discounts" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-discount" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -1032,6 +1782,7 @@ func TestDealsService_AddAdditionalDiscount(t *testing.T) {
 		WithAdditionalDiscountAmount(10),
 		WithAdditionalDiscountType(AdditionalDiscountTypeAmount),
 		WithAdditionalDiscountDescription("Promo"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "add-discount")),
 	)
 	if err != nil {
 		t.Fatalf("AddAdditionalDiscount error: %v", err)
@@ -1051,6 +1802,9 @@ func TestDealsService_UpdateAdditionalDiscount(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/discounts/"+discountID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-discount" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -1074,6 +1828,7 @@ func TestDealsService_UpdateAdditionalDiscount(t *testing.T) {
 		DealID(7),
 		AdditionalDiscountID(discountID),
 		WithAdditionalDiscountAmount(15),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "update-discount")),
 	)
 	if err != nil {
 		t.Fatalf("UpdateAdditionalDiscount error: %v", err)
@@ -1094,6 +1849,9 @@ func TestDealsService_DeleteAdditionalDiscount(t *testing.T) {
 		if r.URL.Path != "/deals/7/discounts/"+discountID {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-discount" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":"` + discountID + `"}}`))
 	}))
@@ -1108,6 +1866,7 @@ func TestDealsService_DeleteAdditionalDiscount(t *testing.T) {
 		context.Background(),
 		DealID(7),
 		AdditionalDiscountID(discountID),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete-discount")),
 	)
 	if err != nil {
 		t.Fatalf("DeleteAdditionalDiscount error: %v", err)
@@ -1134,6 +1893,18 @@ func TestDealsService_ListInstallments(t *testing.T) {
 		if got := q.Get("limit"); got != "1" {
 			t.Fatalf("unexpected limit: %q", got)
 		}
+		if got := q.Get("cursor"); got != "c1" {
+			t.Fatalf("unexpected cursor: %q", got)
+		}
+		if got := q.Get("sort_by"); got != "billing_date" {
+			t.Fatalf("unexpected sort_by: %q", got)
+		}
+		if got := q.Get("sort_direction"); got != "desc" {
+			t.Fatalf("unexpected sort_direction: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "installments" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":5,"deal_id":1,"amount":20,"billing_date":"2024-01-10","description":"Installment"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -1148,6 +1919,10 @@ func TestDealsService_ListInstallments(t *testing.T) {
 		context.Background(),
 		[]DealID{1, 2},
 		WithInstallmentsPageSize(1),
+		WithInstallmentsCursor("c1"),
+		WithInstallmentsSortBy(InstallmentSortByBillingDate),
+		WithInstallmentsSortDirection(SortDesc),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "installments")),
 	)
 	if err != nil {
 		t.Fatalf("ListInstallments error: %v", err)
@@ -1160,6 +1935,83 @@ func TestDealsService_ListInstallments(t *testing.T) {
 	}
 }
 
+func TestDealsService_ListInstallmentsPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/installments" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+			t.Fatalf("unexpected deal_ids: %#v", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Deals.ListInstallmentsPager([]DealID{1, 2}, WithInstallmentsCursor("start"))
+	var ids []InstallmentID
+	for pager.Next(context.Background()) {
+		for _, installment := range pager.Items() {
+			ids = append(ids, installment.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestDealsService_ForEachInstallments(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/deals/installments" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+			t.Fatalf("unexpected deal_ids: %#v", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []InstallmentID
+	err := client.Deals.ForEachInstallments(context.Background(), []DealID{1, 2}, func(installment Installment) error {
+		ids = append(ids, installment.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachInstallments error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestDealsService_AddInstallment(t *testing.T) {
 	t.Parallel()
 
@@ -1169,6 +2021,9 @@ func TestDealsService_AddInstallment(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/installments" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "add-installment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -1199,6 +2054,7 @@ func TestDealsService_AddInstallment(t *testing.T) {
 		WithInstallmentAmount(20),
 		WithInstallmentBillingDate("2024-01-10"),
 		WithInstallmentDescription("Installment"),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "add-installment")),
 	)
 	if err != nil {
 		t.Fatalf("AddInstallment error: %v", err)
@@ -1217,6 +2073,9 @@ func TestDealsService_UpdateInstallment(t *testing.T) {
 		}
 		if r.URL.Path != "/deals/7/installments/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update-installment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -1240,6 +2099,7 @@ func TestDealsService_UpdateInstallment(t *testing.T) {
 		DealID(7),
 		InstallmentID(5),
 		WithInstallmentAmount(25),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "update-installment")),
 	)
 	if err != nil {
 		t.Fatalf("UpdateInstallment error: %v", err)
@@ -1259,6 +2119,9 @@ func TestDealsService_DeleteInstallment(t *testing.T) {
 		if r.URL.Path != "/deals/7/installments/5" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "delete-installment" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":5}}`))
 	}))
@@ -1273,6 +2136,7 @@ func TestDealsService_DeleteInstallment(t *testing.T) {
 		context.Background(),
 		DealID(7),
 		InstallmentID(5),
+		WithDealRequestOptions(pipedrive.WithHeader("X-Test", "delete-installment")),
 	)
 	if err != nil {
 		t.Fatalf("DeleteInstallment error: %v", err)

--- a/pipedrive/v2/options_line_coverage_test.go
+++ b/pipedrive/v2/options_line_coverage_test.go
@@ -1,0 +1,415 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func requireOneRequestOption(t *testing.T, name string, opts []pipedrive.RequestOption) {
+	t.Helper()
+
+	if len(opts) != 1 {
+		t.Fatalf("%s request options count = %d, want 1", name, len(opts))
+	}
+}
+
+func TestProductRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithProductRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var get getProductOptions
+	opt.applyGetProduct(&get)
+	requireOneRequestOption(t, "get", get.requestOptions)
+
+	var list listProductsOptions
+	opt.applyListProducts(&list)
+	requireOneRequestOption(t, "list", list.requestOptions)
+
+	var create createProductOptions
+	opt.applyCreateProduct(&create)
+	requireOneRequestOption(t, "create", create.requestOptions)
+
+	var update updateProductOptions
+	opt.applyUpdateProduct(&update)
+	requireOneRequestOption(t, "update", update.requestOptions)
+
+	var deleteProduct deleteProductOptions
+	opt.applyDeleteProduct(&deleteProduct)
+	requireOneRequestOption(t, "delete", deleteProduct.requestOptions)
+
+	var search searchProductsOptions
+	opt.applySearchProducts(&search)
+	requireOneRequestOption(t, "search", search.requestOptions)
+
+	var duplicate duplicateProductOptions
+	opt.applyDuplicateProduct(&duplicate)
+	requireOneRequestOption(t, "duplicate", duplicate.requestOptions)
+
+	var listVariations listProductVariationsOptions
+	opt.applyListProductVariations(&listVariations)
+	requireOneRequestOption(t, "list variations", listVariations.requestOptions)
+
+	var createVariation createProductVariationOptions
+	opt.applyCreateProductVariation(&createVariation)
+	requireOneRequestOption(t, "create variation", createVariation.requestOptions)
+
+	var updateVariation updateProductVariationOptions
+	opt.applyUpdateProductVariation(&updateVariation)
+	requireOneRequestOption(t, "update variation", updateVariation.requestOptions)
+
+	var deleteVariation deleteProductVariationOptions
+	opt.applyDeleteProductVariation(&deleteVariation)
+	requireOneRequestOption(t, "delete variation", deleteVariation.requestOptions)
+
+	var getImage getProductImageOptions
+	opt.applyGetProductImage(&getImage)
+	requireOneRequestOption(t, "get image", getImage.requestOptions)
+
+	var uploadImage uploadProductImageOptions
+	opt.applyUploadProductImage(&uploadImage)
+	requireOneRequestOption(t, "upload image", uploadImage.requestOptions)
+
+	var updateImage updateProductImageOptions
+	opt.applyUpdateProductImage(&updateImage)
+	requireOneRequestOption(t, "update image", updateImage.requestOptions)
+
+	var deleteImage deleteProductImageOptions
+	opt.applyDeleteProductImage(&deleteImage)
+	requireOneRequestOption(t, "delete image", deleteImage.requestOptions)
+
+	var followers getProductFollowersOptions
+	opt.applyGetProductFollowers(&followers)
+	requireOneRequestOption(t, "followers", followers.requestOptions)
+
+	var addFollower addProductFollowerOptions
+	opt.applyAddProductFollower(&addFollower)
+	requireOneRequestOption(t, "add follower", addFollower.requestOptions)
+
+	var deleteFollower deleteProductFollowerOptions
+	opt.applyDeleteProductFollower(&deleteFollower)
+	requireOneRequestOption(t, "delete follower", deleteFollower.requestOptions)
+
+	var changelog getProductFollowersChangelogOptions
+	opt.applyGetProductFollowersChangelog(&changelog)
+	requireOneRequestOption(t, "followers changelog", changelog.requestOptions)
+}
+
+func TestProductOptionsIgnoreEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	list := newListProductsOptions([]ListProductsOption{
+		nil,
+		WithProductsIDs(),
+		WithProductsPageSize(0),
+		WithProductsCursor(""),
+		WithProductsCustomFields(),
+	})
+	if list.params.Ids != nil || list.params.Limit != nil || list.params.Cursor != nil || list.params.CustomFields != nil {
+		t.Fatalf("expected empty list params, got %#v", list.params)
+	}
+
+	search := newSearchProductsOptions([]SearchProductsOption{
+		nil,
+		WithProductSearchFields(),
+		WithProductSearchPageSize(0),
+		WithProductSearchCursor(""),
+	})
+	if search.params.Fields != nil || search.params.Limit != nil || search.params.Cursor != nil {
+		t.Fatalf("expected empty search params, got %#v", search.params)
+	}
+
+	variations := newListProductVariationsOptions([]ListProductVariationsOption{
+		nil,
+		WithProductVariationsPageSize(0),
+		WithProductVariationsCursor(""),
+	})
+	if variations.params.Limit != nil || variations.params.Cursor != nil {
+		t.Fatalf("expected empty variation params, got %#v", variations.params)
+	}
+
+	followers := newGetProductFollowersOptions([]GetProductFollowersOption{
+		nil,
+		WithProductFollowersPageSize(0),
+		WithProductFollowersCursor(""),
+	})
+	if followers.params.Limit != nil || followers.params.Cursor != nil {
+		t.Fatalf("expected empty follower params, got %#v", followers.params)
+	}
+
+	changelog := newGetProductFollowersChangelogOptions([]GetProductFollowersChangelogOption{
+		nil,
+		WithProductFollowersChangelogPageSize(0),
+		WithProductFollowersChangelogCursor(""),
+	})
+	if changelog.params.Limit != nil || changelog.params.Cursor != nil {
+		t.Fatalf("expected empty changelog params, got %#v", changelog.params)
+	}
+
+	create := newCreateProductOptions([]CreateProductOption{nil, WithProductPrices()})
+	if len(create.payload.prices) != 0 {
+		t.Fatalf("expected no product prices, got %#v", create.payload.prices)
+	}
+
+	variationCreate := newCreateProductVariationOptions([]CreateProductVariationOption{nil, WithProductVariationPrices()})
+	if len(variationCreate.payload.prices) != 0 {
+		t.Fatalf("expected no variation prices, got %#v", variationCreate.payload.prices)
+	}
+
+	if _, _, err := (productImagePayload{}).toMultipart(); err == nil {
+		t.Fatal("expected missing product image file error")
+	}
+
+	_ = newGetProductOptions([]GetProductOption{nil})
+	_ = newUpdateProductOptions([]UpdateProductOption{nil})
+	_ = newDeleteProductOptions([]DeleteProductOption{nil})
+	_ = newDuplicateProductOptions([]DuplicateProductOption{nil})
+	_ = newGetProductImageOptions([]GetProductImageOption{nil})
+	_ = newUploadProductImageOptions([]UploadProductImageOption{nil})
+	_ = newUpdateProductImageOptions([]UpdateProductImageOption{nil})
+	_ = newDeleteProductImageOptions([]DeleteProductImageOption{nil})
+	_ = newUpdateProductVariationOptions([]UpdateProductVariationOption{nil})
+	_ = newDeleteProductVariationOptions([]DeleteProductVariationOption{nil})
+	_ = newAddProductFollowerOptions([]AddProductFollowerOption{nil})
+	_ = newDeleteProductFollowerOptions([]DeleteProductFollowerOption{nil})
+}
+
+func TestPersonRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithPersonRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var get getPersonOptions
+	opt.applyGetPerson(&get)
+	requireOneRequestOption(t, "get", get.requestOptions)
+
+	var list listPersonsOptions
+	opt.applyListPersons(&list)
+	requireOneRequestOption(t, "list", list.requestOptions)
+
+	var create createPersonOptions
+	opt.applyCreatePerson(&create)
+	requireOneRequestOption(t, "create", create.requestOptions)
+
+	var update updatePersonOptions
+	opt.applyUpdatePerson(&update)
+	requireOneRequestOption(t, "update", update.requestOptions)
+
+	var deletePerson deletePersonOptions
+	opt.applyDeletePerson(&deletePerson)
+	requireOneRequestOption(t, "delete", deletePerson.requestOptions)
+
+	var search searchPersonsOptions
+	opt.applySearchPersons(&search)
+	requireOneRequestOption(t, "search", search.requestOptions)
+
+	var followers getPersonFollowersOptions
+	opt.applyGetPersonFollowers(&followers)
+	requireOneRequestOption(t, "followers", followers.requestOptions)
+
+	var addFollower addPersonFollowerOptions
+	opt.applyAddPersonFollower(&addFollower)
+	requireOneRequestOption(t, "add follower", addFollower.requestOptions)
+
+	var deleteFollower deletePersonFollowerOptions
+	opt.applyDeletePersonFollower(&deleteFollower)
+	requireOneRequestOption(t, "delete follower", deleteFollower.requestOptions)
+
+	var changelog getPersonFollowersChangelogOptions
+	opt.applyGetPersonFollowersChangelog(&changelog)
+	requireOneRequestOption(t, "followers changelog", changelog.requestOptions)
+
+	var picture getPersonPictureOptions
+	opt.applyGetPersonPicture(&picture)
+	requireOneRequestOption(t, "picture", picture.requestOptions)
+}
+
+func TestPersonOptionsIgnoreEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	get := newGetPersonOptions([]GetPersonOption{
+		nil,
+		WithPersonIncludeFields(),
+		WithPersonCustomFields(),
+	})
+	if get.params.IncludeFields != nil || get.params.CustomFields != nil {
+		t.Fatalf("expected empty get params, got %#v", get.params)
+	}
+
+	list := newListPersonsOptions([]ListPersonsOption{
+		nil,
+		WithPersonsIncludeFields(),
+		WithPersonsCustomFields(),
+		WithPersonsIDs(),
+		WithPersonsPageSize(0),
+		WithPersonsCursor(""),
+	})
+	if list.params.IncludeFields != nil || list.params.CustomFields != nil || list.params.Ids != nil || list.params.Limit != nil || list.params.Cursor != nil {
+		t.Fatalf("expected empty list params, got %#v", list.params)
+	}
+
+	search := newSearchPersonsOptions([]SearchPersonsOption{
+		nil,
+		WithPersonSearchFields(),
+		WithPersonSearchIncludeFields(),
+		WithPersonSearchPageSize(0),
+		WithPersonSearchCursor(""),
+	})
+	if search.params.Fields != nil || search.params.IncludeFields != nil || search.params.Limit != nil || search.params.Cursor != nil {
+		t.Fatalf("expected empty search params, got %#v", search.params)
+	}
+
+	create := newCreatePersonOptions([]CreatePersonOption{
+		nil,
+		WithPersonEmails(),
+		WithPersonPhones(),
+		WithPersonLabelIDs(),
+	})
+	if len(create.payload.emails) != 0 || len(create.payload.phones) != 0 || len(create.payload.labelIDs) != 0 {
+		t.Fatalf("expected empty person payload, got %#v", create.payload)
+	}
+
+	followers := newGetPersonFollowersOptions([]GetPersonFollowersOption{
+		nil,
+		WithPersonFollowersPageSize(0),
+		WithPersonFollowersCursor(""),
+	})
+	if followers.params.Limit != nil || followers.params.Cursor != nil {
+		t.Fatalf("expected empty follower params, got %#v", followers.params)
+	}
+
+	changelog := newGetPersonFollowersChangelogOptions([]GetPersonFollowersChangelogOption{
+		nil,
+		WithPersonFollowersChangelogPageSize(0),
+		WithPersonFollowersChangelogCursor(""),
+	})
+	if changelog.params.Limit != nil || changelog.params.Cursor != nil {
+		t.Fatalf("expected empty changelog params, got %#v", changelog.params)
+	}
+
+	_ = newUpdatePersonOptions([]UpdatePersonOption{nil})
+	_ = newDeletePersonOptions([]DeletePersonOption{nil})
+	_ = newAddPersonFollowerOptions([]AddPersonFollowerOption{nil})
+	_ = newDeletePersonFollowerOptions([]DeletePersonFollowerOption{nil})
+	_ = newGetPersonPictureOptions([]GetPersonPictureOption{nil})
+}
+
+func TestOrganizationRequestOptionsApplyAllTargets(t *testing.T) {
+	t.Parallel()
+
+	opt := WithOrganizationRequestOptions(pipedrive.WithHeader("X-Test", "1"))
+
+	var get getOrganizationOptions
+	opt.applyGetOrganization(&get)
+	requireOneRequestOption(t, "get", get.requestOptions)
+
+	var list listOrganizationsOptions
+	opt.applyListOrganizations(&list)
+	requireOneRequestOption(t, "list", list.requestOptions)
+
+	var create createOrganizationOptions
+	opt.applyCreateOrganization(&create)
+	requireOneRequestOption(t, "create", create.requestOptions)
+
+	var update updateOrganizationOptions
+	opt.applyUpdateOrganization(&update)
+	requireOneRequestOption(t, "update", update.requestOptions)
+
+	var deleteOrganization deleteOrganizationOptions
+	opt.applyDeleteOrganization(&deleteOrganization)
+	requireOneRequestOption(t, "delete", deleteOrganization.requestOptions)
+
+	var search searchOrganizationsOptions
+	opt.applySearchOrganizations(&search)
+	requireOneRequestOption(t, "search", search.requestOptions)
+
+	var followers getOrganizationFollowersOptions
+	opt.applyGetOrganizationFollowers(&followers)
+	requireOneRequestOption(t, "followers", followers.requestOptions)
+
+	var addFollower addOrganizationFollowerOptions
+	opt.applyAddOrganizationFollower(&addFollower)
+	requireOneRequestOption(t, "add follower", addFollower.requestOptions)
+
+	var deleteFollower deleteOrganizationFollowerOptions
+	opt.applyDeleteOrganizationFollower(&deleteFollower)
+	requireOneRequestOption(t, "delete follower", deleteFollower.requestOptions)
+
+	var changelog getOrganizationFollowersChangelogOptions
+	opt.applyGetOrganizationFollowersChangelog(&changelog)
+	requireOneRequestOption(t, "followers changelog", changelog.requestOptions)
+}
+
+func TestOrganizationOptionsIgnoreEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	get := newGetOrganizationOptions([]GetOrganizationOption{
+		nil,
+		WithOrganizationIncludeFields(),
+		WithOrganizationCustomFields(),
+	})
+	if get.params.IncludeFields != nil || get.params.CustomFields != nil {
+		t.Fatalf("expected empty get params, got %#v", get.params)
+	}
+
+	until := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	listWithUntil := newListOrganizationsOptions([]ListOrganizationsOption{WithOrganizationsUpdatedUntil(until)})
+	if listWithUntil.params.UpdatedUntil == nil {
+		t.Fatal("expected updated_until option to be set")
+	}
+
+	list := newListOrganizationsOptions([]ListOrganizationsOption{
+		nil,
+		WithOrganizationsIncludeFields(),
+		WithOrganizationsCustomFields(),
+		WithOrganizationsIDs(),
+		WithOrganizationsPageSize(0),
+		WithOrganizationsCursor(""),
+	})
+	if list.params.IncludeFields != nil || list.params.CustomFields != nil || list.params.Ids != nil || list.params.Limit != nil || list.params.Cursor != nil {
+		t.Fatalf("expected empty list params, got %#v", list.params)
+	}
+
+	search := newSearchOrganizationsOptions([]SearchOrganizationsOption{
+		nil,
+		WithOrganizationSearchFields(),
+		WithOrganizationSearchPageSize(0),
+		WithOrganizationSearchCursor(""),
+	})
+	if search.params.Fields != nil || search.params.Limit != nil || search.params.Cursor != nil {
+		t.Fatalf("expected empty search params, got %#v", search.params)
+	}
+
+	create := newCreateOrganizationOptions([]CreateOrganizationOption{
+		nil,
+		WithOrganizationLabelIDs(),
+	})
+	if len(create.payload.labelIDs) != 0 {
+		t.Fatalf("expected empty organization label IDs, got %#v", create.payload.labelIDs)
+	}
+
+	followers := newGetOrganizationFollowersOptions([]GetOrganizationFollowersOption{
+		nil,
+		WithOrganizationFollowersPageSize(0),
+		WithOrganizationFollowersCursor(""),
+	})
+	if followers.params.Limit != nil || followers.params.Cursor != nil {
+		t.Fatalf("expected empty follower params, got %#v", followers.params)
+	}
+
+	changelog := newGetOrganizationFollowersChangelogOptions([]GetOrganizationFollowersChangelogOption{
+		nil,
+		WithOrganizationFollowersChangelogPageSize(0),
+		WithOrganizationFollowersChangelogCursor(""),
+	})
+	if changelog.params.Limit != nil || changelog.params.Cursor != nil {
+		t.Fatalf("expected empty changelog params, got %#v", changelog.params)
+	}
+
+	_ = newUpdateOrganizationOptions([]UpdateOrganizationOption{nil})
+	_ = newDeleteOrganizationOptions([]DeleteOrganizationOption{nil})
+	_ = newAddOrganizationFollowerOptions([]AddOrganizationFollowerOption{nil})
+	_ = newDeleteOrganizationFollowerOptions([]DeleteOrganizationFollowerOption{nil})
+}

--- a/pipedrive/v2/organization_fields_test.go
+++ b/pipedrive/v2/organization_fields_test.go
@@ -164,3 +164,101 @@ func TestOrganizationFieldsService_AddOptions(t *testing.T) {
 		t.Fatalf("unexpected options: %#v", options)
 	}
 }
+
+func TestOrganizationFieldsService_Get(t *testing.T) {
+	t.Parallel()
+
+	runFieldGetTest(t, "/organizationFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.OrganizationFields.Get(
+			ctx,
+			"cf_1",
+			WithOrganizationFieldIncludeFields(FieldIncludeField("ui_visibility"), FieldIncludeField("important_fields")),
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+		)
+	})
+}
+
+func TestOrganizationFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	runFieldListPagerTest(t, "/organizationFields", func(client *Client) *pipedrive.CursorPager[Field] {
+		return client.OrganizationFields.ListPager(WithOrganizationFieldsPageSize(2), WithOrganizationFieldsCursor("start"))
+	})
+}
+
+func TestOrganizationFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	runFieldForEachTest(t, "/organizationFields", func(ctx context.Context, client *Client, fn func(Field) error) error {
+		return client.OrganizationFields.ForEach(ctx, fn)
+	})
+}
+
+func TestOrganizationFieldsService_Update(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateTest(t, "/organizationFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.OrganizationFields.Update(
+			ctx,
+			"cf_1",
+			WithOrganizationFieldName("Priority updated"),
+			WithOrganizationFieldType(FieldTypeVarchar),
+			WithOrganizationFieldDescription("Updated description"),
+			WithOrganizationFieldUIVisibility(map[string]interface{}{"add": true}),
+			WithOrganizationFieldImportantFields(map[string]interface{}{"pipeline_id": 1}),
+			WithOrganizationFieldRequiredFields(map[string]interface{}{"stage_id": 2}),
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+		)
+	})
+}
+
+func TestOrganizationFieldsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteTest(t, "/organizationFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.OrganizationFields.Delete(
+			ctx,
+			"cf_1",
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+		)
+	})
+}
+
+func TestOrganizationFieldsService_AddOptionsWithRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldAddOptionsRequestOptionsTest(t, "/organizationFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.OrganizationFields.AddOptions(
+			ctx,
+			"cf_1",
+			[]string{"Critical"},
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "add-options")),
+		)
+	})
+}
+
+func TestOrganizationFieldsService_UpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateOptionsTest(t, "/organizationFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.OrganizationFields.UpdateOptions(
+			ctx,
+			"cf_1",
+			[]FieldOptionUpdate{{ID: 1, Label: "Critical"}},
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "update-options")),
+		)
+	})
+}
+
+func TestOrganizationFieldsService_DeleteOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteOptionsTest(t, "/organizationFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.OrganizationFields.DeleteOptions(
+			ctx,
+			"cf_1",
+			[]int{1, 2},
+			WithOrganizationFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete-options")),
+		)
+	})
+}

--- a/pipedrive/v2/organizations_test.go
+++ b/pipedrive/v2/organizations_test.go
@@ -253,6 +253,77 @@ func TestOrganizationsService_ListFollowers(t *testing.T) {
 	}
 }
 
+func TestOrganizationsService_ListFollowersPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Organizations.ListFollowersPager(OrganizationID(5), WithOrganizationFollowersCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, follower := range pager.Items() {
+			ids = append(ids, follower.UserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestOrganizationsService_ForEachFollowers(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"user_id":1},{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Organizations.ForEachFollowers(context.Background(), OrganizationID(5), func(follower Follower) error {
+		ids = append(ids, follower.UserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowers error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestOrganizationsService_AddFollower(t *testing.T) {
 	t.Parallel()
 
@@ -288,6 +359,29 @@ func TestOrganizationsService_AddFollower(t *testing.T) {
 	}
 	if follower.UserID != 7 {
 		t.Fatalf("unexpected follower: %#v", follower)
+	}
+}
+
+func TestOrganizationsService_DeleteFollower(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5/followers/7" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"user_id":7}}`))
+	})
+
+	result, err := client.Organizations.DeleteFollower(context.Background(), OrganizationID(5), UserID(7))
+	if err != nil {
+		t.Fatalf("DeleteFollower error: %v", err)
+	}
+	if result.UserID != 7 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 
@@ -332,5 +426,267 @@ func TestOrganizationsService_FollowersChangelog(t *testing.T) {
 	}
 	if len(changelog) != 1 || changelog[0].FollowerUserID != 2 {
 		t.Fatalf("unexpected changelog: %#v", changelog)
+	}
+}
+
+func TestOrganizationsService_FollowersChangelogPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Organizations.FollowersChangelogPager(OrganizationID(5), WithOrganizationFollowersChangelogCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, entry := range pager.Items() {
+			ids = append(ids, entry.FollowerUserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestOrganizationsService_ForEachFollowersChangelog(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1},{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Organizations.ForEachFollowersChangelog(context.Background(), OrganizationID(5), func(entry FollowerChangelog) error {
+		ids = append(ids, entry.FollowerUserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowersChangelog error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestOrganizationsService_Get(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("include_fields"); got != "people_count,notes_count" {
+			t.Fatalf("unexpected include_fields: %q", got)
+		}
+		if got := r.URL.Query().Get("custom_fields"); got != "cf_1,cf_2" {
+			t.Fatalf("unexpected custom_fields: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5,"name":"Acme"}}`))
+	})
+
+	org, err := client.Organizations.Get(
+		context.Background(),
+		OrganizationID(5),
+		WithOrganizationIncludeFields(OrganizationIncludeFieldPeopleCount, OrganizationIncludeFieldNotesCount),
+		WithOrganizationCustomFields("cf_1", "cf_2"),
+		WithOrganizationRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if org.ID != 5 || org.Name != "Acme" {
+		t.Fatalf("unexpected org: %#v", org)
+	}
+}
+
+func TestOrganizationsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Organizations.ListPager(WithOrganizationsPageSize(2), WithOrganizationsCursor("start"))
+	var ids []OrganizationID
+	for pager.Next(context.Background()) {
+		for _, org := range pager.Items() {
+			ids = append(ids, org.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestOrganizationsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []OrganizationID
+	err := client.Organizations.ForEach(context.Background(), func(org Organization) error {
+		ids = append(ids, org.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestOrganizationsService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["name"] != "Updated" {
+			t.Fatalf("unexpected name: %#v", payload["name"])
+		}
+		if payload["visible_to"] != float64(3) {
+			t.Fatalf("unexpected visible_to: %#v", payload["visible_to"])
+		}
+		labels, ok := payload["label_ids"].([]interface{})
+		if !ok || len(labels) != 2 || labels[0] != float64(10) || labels[1] != float64(11) {
+			t.Fatalf("unexpected label_ids: %#v", payload["label_ids"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5,"name":"Updated"}}`))
+	})
+
+	org, err := client.Organizations.Update(
+		context.Background(),
+		OrganizationID(5),
+		WithOrganizationName("Updated"),
+		WithOrganizationLabelIDs(10, 11),
+		WithOrganizationVisibleTo(3),
+		WithOrganizationRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if org.ID != 5 || org.Name != "Updated" {
+		t.Fatalf("unexpected org: %#v", org)
+	}
+}
+
+func TestOrganizationsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/organizations/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5}}`))
+	})
+
+	result, err := client.Organizations.Delete(
+		context.Background(),
+		OrganizationID(5),
+		WithOrganizationRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if result.ID != 5 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/pipedrive/v2/person_fields_test.go
+++ b/pipedrive/v2/person_fields_test.go
@@ -164,3 +164,101 @@ func TestPersonFieldsService_AddOptions(t *testing.T) {
 		t.Fatalf("unexpected options: %#v", options)
 	}
 }
+
+func TestPersonFieldsService_Get(t *testing.T) {
+	t.Parallel()
+
+	runFieldGetTest(t, "/personFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.PersonFields.Get(
+			ctx,
+			"cf_1",
+			WithPersonFieldIncludeFields(FieldIncludeField("ui_visibility"), FieldIncludeField("important_fields")),
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+		)
+	})
+}
+
+func TestPersonFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	runFieldListPagerTest(t, "/personFields", func(client *Client) *pipedrive.CursorPager[Field] {
+		return client.PersonFields.ListPager(WithPersonFieldsPageSize(2), WithPersonFieldsCursor("start"))
+	})
+}
+
+func TestPersonFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	runFieldForEachTest(t, "/personFields", func(ctx context.Context, client *Client, fn func(Field) error) error {
+		return client.PersonFields.ForEach(ctx, fn)
+	})
+}
+
+func TestPersonFieldsService_Update(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateTest(t, "/personFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.PersonFields.Update(
+			ctx,
+			"cf_1",
+			WithPersonFieldName("Priority updated"),
+			WithPersonFieldType(FieldTypeVarchar),
+			WithPersonFieldDescription("Updated description"),
+			WithPersonFieldUIVisibility(map[string]interface{}{"add": true}),
+			WithPersonFieldImportantFields(map[string]interface{}{"pipeline_id": 1}),
+			WithPersonFieldRequiredFields(map[string]interface{}{"stage_id": 2}),
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+		)
+	})
+}
+
+func TestPersonFieldsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteTest(t, "/personFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.PersonFields.Delete(
+			ctx,
+			"cf_1",
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+		)
+	})
+}
+
+func TestPersonFieldsService_AddOptionsWithRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldAddOptionsRequestOptionsTest(t, "/personFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.PersonFields.AddOptions(
+			ctx,
+			"cf_1",
+			[]string{"Critical"},
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "add-options")),
+		)
+	})
+}
+
+func TestPersonFieldsService_UpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateOptionsTest(t, "/personFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.PersonFields.UpdateOptions(
+			ctx,
+			"cf_1",
+			[]FieldOptionUpdate{{ID: 1, Label: "Critical"}},
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "update-options")),
+		)
+	})
+}
+
+func TestPersonFieldsService_DeleteOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteOptionsTest(t, "/personFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.PersonFields.DeleteOptions(
+			ctx,
+			"cf_1",
+			[]int{1, 2},
+			WithPersonFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete-options")),
+		)
+	})
+}

--- a/pipedrive/v2/persons_test.go
+++ b/pipedrive/v2/persons_test.go
@@ -324,6 +324,77 @@ func TestPersonsService_ListFollowers(t *testing.T) {
 	}
 }
 
+func TestPersonsService_ListFollowersPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Persons.ListFollowersPager(PersonID(5), WithPersonFollowersCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, follower := range pager.Items() {
+			ids = append(ids, follower.UserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPersonsService_ForEachFollowers(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"user_id":1},{"user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Persons.ForEachFollowers(context.Background(), PersonID(5), func(follower Follower) error {
+		ids = append(ids, follower.UserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowers error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestPersonsService_AddFollower(t *testing.T) {
 	t.Parallel()
 
@@ -359,6 +430,29 @@ func TestPersonsService_AddFollower(t *testing.T) {
 	}
 	if follower.UserID != 7 {
 		t.Fatalf("unexpected follower: %#v", follower)
+	}
+}
+
+func TestPersonsService_DeleteFollower(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/5/followers/7" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"user_id":7}}`))
+	})
+
+	result, err := client.Persons.DeleteFollower(context.Background(), PersonID(5), UserID(7))
+	if err != nil {
+		t.Fatalf("DeleteFollower error: %v", err)
+	}
+	if result.UserID != 7 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 
@@ -406,6 +500,77 @@ func TestPersonsService_FollowersChangelog(t *testing.T) {
 	}
 }
 
+func TestPersonsService_FollowersChangelogPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Persons.FollowersChangelogPager(PersonID(5), WithPersonFollowersChangelogCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, entry := range pager.Items() {
+			ids = append(ids, entry.FollowerUserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPersonsService_ForEachFollowersChangelog(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"follower_user_id":1},{"follower_user_id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Persons.ForEachFollowersChangelog(context.Background(), PersonID(5), func(entry FollowerChangelog) error {
+		ids = append(ids, entry.FollowerUserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowersChangelog error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestPersonsService_GetPicture(t *testing.T) {
 	t.Parallel()
 
@@ -433,5 +598,167 @@ func TestPersonsService_GetPicture(t *testing.T) {
 	}
 	if picture.ID != 9 || picture.ItemID == nil || *picture.ItemID != 5 {
 		t.Fatalf("unexpected picture: %#v", picture)
+	}
+}
+
+func TestPersonsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Persons.ListPager(WithPersonsPageSize(2), WithPersonsCursor("start"))
+	var ids []PersonID
+	for pager.Next(context.Background()) {
+		for _, person := range pager.Items() {
+			ids = append(ids, person.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPersonsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []PersonID
+	err := client.Persons.ForEach(context.Background(), func(person Person) error {
+		ids = append(ids, person.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPersonsService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/12" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["name"] != "Ada Updated" {
+			t.Fatalf("unexpected name: %#v", payload["name"])
+		}
+		if payload["visible_to"] != float64(3) {
+			t.Fatalf("unexpected visible_to: %#v", payload["visible_to"])
+		}
+		phones, ok := payload["phones"].([]interface{})
+		if !ok || len(phones) != 1 {
+			t.Fatalf("unexpected phones: %#v", payload["phones"])
+		}
+		phone, ok := phones[0].(map[string]interface{})
+		if !ok || phone["value"] != "+123" {
+			t.Fatalf("unexpected phone: %#v", phones[0])
+		}
+		labels, ok := payload["label_ids"].([]interface{})
+		if !ok || len(labels) != 2 || labels[0] != float64(10) || labels[1] != float64(11) {
+			t.Fatalf("unexpected label_ids: %#v", payload["label_ids"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":12,"name":"Ada Updated"}}`))
+	})
+
+	person, err := client.Persons.Update(
+		context.Background(),
+		PersonID(12),
+		WithPersonName("Ada Updated"),
+		WithPersonPhones(LabeledValue{Value: "+123", Primary: true, Label: "mobile"}),
+		WithPersonLabelIDs(10, 11),
+		WithPersonVisibleTo(3),
+		WithPersonRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if person.ID != 12 || person.Name != "Ada Updated" {
+		t.Fatalf("unexpected person: %#v", person)
+	}
+}
+
+func TestPersonsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/persons/12" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":12}}`))
+	})
+
+	result, err := client.Persons.Delete(
+		context.Background(),
+		PersonID(12),
+		WithPersonRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if result.ID != 12 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/pipedrive/v2/pipelines_test.go
+++ b/pipedrive/v2/pipelines_test.go
@@ -33,6 +33,9 @@ func TestPipelinesService_List(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":1,"name":"Pipeline"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -49,6 +52,7 @@ func TestPipelinesService_List(t *testing.T) {
 		WithPipelinesSortDirection(SortDesc),
 		WithPipelinesPageSize(2),
 		WithPipelinesCursor("c1"),
+		WithPipelineRequestOptions(pipedrive.WithHeader("X-Test", "list")),
 	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
@@ -70,6 +74,9 @@ func TestPipelinesService_Create(t *testing.T) {
 		}
 		if r.URL.Path != "/pipelines" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -95,11 +102,188 @@ func TestPipelinesService_Create(t *testing.T) {
 		context.Background(),
 		WithPipelineName("Sales"),
 		WithPipelineDealProbabilityEnabled(true),
+		WithPipelineRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
 	if pipeline.ID != 5 || pipeline.Name != "Sales" {
 		t.Fatalf("unexpected pipeline: %#v", pipeline)
+	}
+}
+
+func TestPipelinesService_Get(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/pipelines/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5,"name":"Sales"}}`))
+	})
+
+	pipeline, err := client.Pipelines.Get(
+		context.Background(),
+		PipelineID(5),
+		WithPipelineRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if pipeline.ID != 5 || pipeline.Name != "Sales" {
+		t.Fatalf("unexpected pipeline: %#v", pipeline)
+	}
+}
+
+func TestPipelinesService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/pipelines" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Pipelines.ListPager(WithPipelinesPageSize(2), WithPipelinesCursor("start"))
+	var ids []PipelineID
+	for pager.Next(context.Background()) {
+		for _, pipeline := range pager.Items() {
+			ids = append(ids, pipeline.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPipelinesService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/pipelines" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []PipelineID
+	err := client.Pipelines.ForEach(context.Background(), func(pipeline Pipeline) error {
+		ids = append(ids, pipeline.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestPipelinesService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/pipelines/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["name"] != "Updated" {
+			t.Fatalf("unexpected name: %#v", payload["name"])
+		}
+		if payload["is_deal_probability_enabled"] != false {
+			t.Fatalf("unexpected is_deal_probability_enabled: %#v", payload["is_deal_probability_enabled"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5,"name":"Updated"}}`))
+	})
+
+	pipeline, err := client.Pipelines.Update(
+		context.Background(),
+		PipelineID(5),
+		WithPipelineName("Updated"),
+		WithPipelineDealProbabilityEnabled(false),
+		WithPipelineRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if pipeline.ID != 5 || pipeline.Name != "Updated" {
+		t.Fatalf("unexpected pipeline: %#v", pipeline)
+	}
+}
+
+func TestPipelinesService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/pipelines/5" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":5}}`))
+	})
+
+	result, err := client.Pipelines.Delete(
+		context.Background(),
+		PipelineID(5),
+		WithPipelineRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if result.ID != 5 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/pipedrive/v2/product_fields_test.go
+++ b/pipedrive/v2/product_fields_test.go
@@ -164,3 +164,101 @@ func TestProductFieldsService_AddOptions(t *testing.T) {
 		t.Fatalf("unexpected options: %#v", options)
 	}
 }
+
+func TestProductFieldsService_Get(t *testing.T) {
+	t.Parallel()
+
+	runFieldGetTest(t, "/productFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.ProductFields.Get(
+			ctx,
+			"cf_1",
+			WithProductFieldIncludeFields(FieldIncludeField("ui_visibility"), FieldIncludeField("important_fields")),
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+		)
+	})
+}
+
+func TestProductFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	runFieldListPagerTest(t, "/productFields", func(client *Client) *pipedrive.CursorPager[Field] {
+		return client.ProductFields.ListPager(WithProductFieldsPageSize(2), WithProductFieldsCursor("start"))
+	})
+}
+
+func TestProductFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	runFieldForEachTest(t, "/productFields", func(ctx context.Context, client *Client, fn func(Field) error) error {
+		return client.ProductFields.ForEach(ctx, fn)
+	})
+}
+
+func TestProductFieldsService_Update(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateTest(t, "/productFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.ProductFields.Update(
+			ctx,
+			"cf_1",
+			WithProductFieldName("Priority updated"),
+			WithProductFieldType(FieldTypeVarchar),
+			WithProductFieldDescription("Updated description"),
+			WithProductFieldUIVisibility(map[string]interface{}{"add": true}),
+			WithProductFieldImportantFields(map[string]interface{}{"pipeline_id": 1}),
+			WithProductFieldRequiredFields(map[string]interface{}{"stage_id": 2}),
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+		)
+	})
+}
+
+func TestProductFieldsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteTest(t, "/productFields/cf_1", func(ctx context.Context, client *Client) (*Field, error) {
+		return client.ProductFields.Delete(
+			ctx,
+			"cf_1",
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+		)
+	})
+}
+
+func TestProductFieldsService_AddOptionsWithRequestOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldAddOptionsRequestOptionsTest(t, "/productFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.ProductFields.AddOptions(
+			ctx,
+			"cf_1",
+			[]string{"Critical"},
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "add-options")),
+		)
+	})
+}
+
+func TestProductFieldsService_UpdateOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldUpdateOptionsTest(t, "/productFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.ProductFields.UpdateOptions(
+			ctx,
+			"cf_1",
+			[]FieldOptionUpdate{{ID: 1, Label: "Critical"}},
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "update-options")),
+		)
+	})
+}
+
+func TestProductFieldsService_DeleteOptions(t *testing.T) {
+	t.Parallel()
+
+	runFieldDeleteOptionsTest(t, "/productFields/cf_1/options", func(ctx context.Context, client *Client) ([]FieldOption, error) {
+		return client.ProductFields.DeleteOptions(
+			ctx,
+			"cf_1",
+			[]int{1, 2},
+			WithProductFieldRequestOptions(pipedrive.WithHeader("X-Test", "delete-options")),
+		)
+	})
+}

--- a/pipedrive/v2/products_test.go
+++ b/pipedrive/v2/products_test.go
@@ -51,6 +51,9 @@ func TestProductsService_List(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":1,"name":"Product"}],"additional_data":{"next_cursor":null}}`))
@@ -72,6 +75,7 @@ func TestProductsService_List(t *testing.T) {
 		WithProductsCustomFields("cf_1"),
 		WithProductsPageSize(2),
 		WithProductsCursor("c1"),
+		WithProductRequestOptions(pipedrive.WithHeader("X-Test", "list")),
 	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
@@ -134,6 +138,199 @@ func TestProductsService_Create(t *testing.T) {
 	}
 	if product.ID != 9 || product.Name != "Widget" {
 		t.Fatalf("unexpected product: %#v", product)
+	}
+}
+
+func TestProductsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Products.ListPager(WithProductsPageSize(2), WithProductsCursor("start"))
+	var ids []ProductID
+	for pager.Next(context.Background()) {
+		for _, product := range pager.Items() {
+			ids = append(ids, product.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestProductsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []ProductID
+	err := client.Products.ForEach(context.Background(), func(product Product) error {
+		ids = append(ids, product.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestProductsService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/9" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["name"] != "Widget updated" {
+			t.Fatalf("unexpected name: %#v", payload["name"])
+		}
+		if payload["code"] != "W-2" {
+			t.Fatalf("unexpected code: %#v", payload["code"])
+		}
+		if payload["description"] != "Updated description" {
+			t.Fatalf("unexpected description: %#v", payload["description"])
+		}
+		if payload["unit"] != "box" {
+			t.Fatalf("unexpected unit: %#v", payload["unit"])
+		}
+		if payload["tax"] != float64(24) {
+			t.Fatalf("unexpected tax: %#v", payload["tax"])
+		}
+		if payload["category"] != float64(12) {
+			t.Fatalf("unexpected category: %#v", payload["category"])
+		}
+		if payload["owner_id"] != float64(5) {
+			t.Fatalf("unexpected owner_id: %#v", payload["owner_id"])
+		}
+		if payload["is_linkable"] != true {
+			t.Fatalf("unexpected is_linkable: %#v", payload["is_linkable"])
+		}
+		if payload["visible_to"] != float64(3) {
+			t.Fatalf("unexpected visible_to: %#v", payload["visible_to"])
+		}
+		prices, ok := payload["prices"].([]interface{})
+		if !ok || len(prices) != 1 {
+			t.Fatalf("unexpected prices: %#v", payload["prices"])
+		}
+		price, ok := prices[0].(map[string]interface{})
+		if !ok || price["currency"] != "USD" || price["price"] != float64(12.5) {
+			t.Fatalf("unexpected price: %#v", prices[0])
+		}
+		if payload["billing_frequency"] != "monthly" {
+			t.Fatalf("unexpected billing_frequency: %#v", payload["billing_frequency"])
+		}
+		if payload["billing_frequency_cycles"] != float64(3) {
+			t.Fatalf("unexpected billing_frequency_cycles: %#v", payload["billing_frequency_cycles"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":9,"name":"Widget updated"}}`))
+	})
+
+	product, err := client.Products.Update(
+		context.Background(),
+		ProductID(9),
+		WithProductName("Widget updated"),
+		WithProductCode("W-2"),
+		WithProductDescription("Updated description"),
+		WithProductUnit("box"),
+		WithProductTax(24),
+		WithProductCategory(12),
+		WithProductOwnerID(UserID(5)),
+		WithProductLinkable(true),
+		WithProductVisibleTo(3),
+		WithProductPrices(ProductPrice{Currency: "USD", Price: 12.5}),
+		WithProductBillingFrequency(BillingFrequencyMonthly),
+		WithProductBillingFrequencyCycles(3),
+		WithProductRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if product.ID != 9 || product.Name != "Widget updated" {
+		t.Fatalf("unexpected product: %#v", product)
+	}
+}
+
+func TestProductsService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/9" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":9}}`))
+	})
+
+	result, err := client.Products.Delete(
+		context.Background(),
+		ProductID(9),
+		WithProductRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if result.ID != 9 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }
 
@@ -338,6 +535,80 @@ func TestProductsService_ListVariations(t *testing.T) {
 	}
 }
 
+func TestProductsService_ListVariationsPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/variations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":10}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":11}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Products.ListVariationsPager(ProductID(5), WithProductVariationsPageSize(2), WithProductVariationsCursor("start"))
+	var ids []ProductVariationID
+	for pager.Next(context.Background()) {
+		for _, variation := range pager.Items() {
+			ids = append(ids, variation.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 10 || ids[1] != 11 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestProductsService_ForEachVariations(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/variations" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":10},{"id":11}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []ProductVariationID
+	err := client.Products.ForEachVariations(context.Background(), ProductID(5), func(variation ProductVariation) error {
+		ids = append(ids, variation.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachVariations error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 10 || ids[1] != 11 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestProductsService_CreateVariation(t *testing.T) {
 	t.Parallel()
 
@@ -510,6 +781,80 @@ func TestProductsService_ListFollowers(t *testing.T) {
 	}
 }
 
+func TestProductsService_ListFollowersPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":7}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":8}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Products.ListFollowersPager(ProductID(5), WithProductFollowersPageSize(2), WithProductFollowersCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, follower := range pager.Items() {
+			ids = append(ids, follower.UserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 7 || ids[1] != 8 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestProductsService_ForEachFollowers(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"user_id":7},{"user_id":8}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Products.ForEachFollowers(context.Background(), ProductID(5), func(follower Follower) error {
+		ids = append(ids, follower.UserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowers error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 7 || ids[1] != 8 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
 func TestProductsService_AddFollower(t *testing.T) {
 	t.Parallel()
 
@@ -620,6 +965,80 @@ func TestProductsService_FollowersChangelog(t *testing.T) {
 	}
 	if len(changelog) != 1 || changelog[0].FollowerUserID != 2 {
 		t.Fatalf("unexpected changelog: %#v", changelog)
+	}
+}
+
+func TestProductsService_FollowersChangelogPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"action":"added","follower_user_id":7}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"action":"removed","follower_user_id":8}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Products.FollowersChangelogPager(ProductID(5), WithProductFollowersChangelogPageSize(2), WithProductFollowersChangelogCursor("start"))
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, event := range pager.Items() {
+			ids = append(ids, event.FollowerUserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 7 || ids[1] != 8 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestProductsService_ForEachFollowersChangelog(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/products/5/followers/changelog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"action":"added","follower_user_id":7},{"action":"removed","follower_user_id":8}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Products.ForEachFollowersChangelog(context.Background(), ProductID(5), func(event FollowerChangelog) error {
+		ids = append(ids, event.FollowerUserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowersChangelog error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 7 || ids[1] != 8 {
+		t.Fatalf("unexpected ids: %v", ids)
 	}
 }
 

--- a/pipedrive/v2/stages_test.go
+++ b/pipedrive/v2/stages_test.go
@@ -36,6 +36,9 @@ func TestStagesService_List(t *testing.T) {
 		if got := q.Get("cursor"); got != "c1" {
 			t.Fatalf("unexpected cursor: %q", got)
 		}
+		if got := r.Header.Get("X-Test"); got != "list" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":10,"name":"Stage"}],"additional_data":{"next_cursor":null}}`))
 	}))
@@ -53,6 +56,7 @@ func TestStagesService_List(t *testing.T) {
 		WithStagesSortDirection(SortAsc),
 		WithStagesPageSize(1),
 		WithStagesCursor("c1"),
+		WithStageRequestOptions(pipedrive.WithHeader("X-Test", "list")),
 	)
 	if err != nil {
 		t.Fatalf("List error: %v", err)
@@ -75,6 +79,9 @@ func TestStagesService_Create(t *testing.T) {
 		if r.URL.Path != "/stages" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.Header.Get("X-Test"); got != "create" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode body: %v", err)
@@ -87,6 +94,12 @@ func TestStagesService_Create(t *testing.T) {
 		}
 		if payload["deal_probability"] != float64(25) {
 			t.Fatalf("unexpected deal_probability: %v", payload["deal_probability"])
+		}
+		if payload["is_deal_rot_enabled"] != true {
+			t.Fatalf("unexpected is_deal_rot_enabled: %v", payload["is_deal_rot_enabled"])
+		}
+		if payload["days_to_rotten"] != float64(14) {
+			t.Fatalf("unexpected days_to_rotten: %v", payload["days_to_rotten"])
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"id":11,"name":"Qualified"}}`))
@@ -103,11 +116,202 @@ func TestStagesService_Create(t *testing.T) {
 		WithStageName("Qualified"),
 		WithStagePipelineID(2),
 		WithStageDealProbability(25),
+		WithStageDealRotEnabled(true),
+		WithStageDaysToRotten(14),
+		WithStageRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
 	if stage.ID != 11 || stage.Name != "Qualified" {
 		t.Fatalf("unexpected stage: %#v", stage)
+	}
+}
+
+func TestStagesService_Get(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/stages/11" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "get" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":11,"name":"Qualified"}}`))
+	})
+
+	stage, err := client.Stages.Get(
+		context.Background(),
+		StageID(11),
+		WithStageRequestOptions(pipedrive.WithHeader("X-Test", "get")),
+	)
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if stage.ID != 11 || stage.Name != "Qualified" {
+		t.Fatalf("unexpected stage: %#v", stage)
+	}
+}
+
+func TestStagesService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/stages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Stages.ListPager(WithStagesPageSize(2), WithStagesCursor("start"))
+	var ids []StageID
+	for pager.Next(context.Background()) {
+		for _, stage := range pager.Items() {
+			ids = append(ids, stage.ID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestStagesService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/stages" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []StageID
+	err := client.Stages.ForEach(context.Background(), func(stage Stage) error {
+		ids = append(ids, stage.ID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 1 || ids[1] != 2 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestStagesService_Update(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/stages/11" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "update" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if payload["name"] != "Updated" {
+			t.Fatalf("unexpected name: %#v", payload["name"])
+		}
+		if payload["pipeline_id"] != float64(2) {
+			t.Fatalf("unexpected pipeline_id: %#v", payload["pipeline_id"])
+		}
+		if payload["deal_probability"] != float64(35) {
+			t.Fatalf("unexpected deal_probability: %#v", payload["deal_probability"])
+		}
+		if payload["is_deal_rot_enabled"] != false {
+			t.Fatalf("unexpected is_deal_rot_enabled: %#v", payload["is_deal_rot_enabled"])
+		}
+		if payload["days_to_rotten"] != float64(21) {
+			t.Fatalf("unexpected days_to_rotten: %#v", payload["days_to_rotten"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":11,"name":"Updated"}}`))
+	})
+
+	stage, err := client.Stages.Update(
+		context.Background(),
+		StageID(11),
+		WithStageName("Updated"),
+		WithStagePipelineID(2),
+		WithStageDealProbability(35),
+		WithStageDealRotEnabled(false),
+		WithStageDaysToRotten(21),
+		WithStageRequestOptions(pipedrive.WithHeader("X-Test", "update")),
+	)
+	if err != nil {
+		t.Fatalf("Update error: %v", err)
+	}
+	if stage.ID != 11 || stage.Name != "Updated" {
+		t.Fatalf("unexpected stage: %#v", stage)
+	}
+}
+
+func TestStagesService_Delete(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/stages/11" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("X-Test"); got != "delete" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"id":11}}`))
+	})
+
+	result, err := client.Stages.Delete(
+		context.Background(),
+		StageID(11),
+		WithStageRequestOptions(pipedrive.WithHeader("X-Test", "delete")),
+	)
+	if err != nil {
+		t.Fatalf("Delete error: %v", err)
+	}
+	if result.ID != 11 {
+		t.Fatalf("unexpected result: %#v", result)
 	}
 }

--- a/pipedrive/v2/test_helpers_test.go
+++ b/pipedrive/v2/test_helpers_test.go
@@ -1,0 +1,25 @@
+package v2
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(pipedrive.Config{
+		BaseURL:    srv.URL,
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+	return client
+}

--- a/pipedrive/v2/users_test.go
+++ b/pipedrive/v2/users_test.go
@@ -56,3 +56,85 @@ func TestUsersService_ListFollowers(t *testing.T) {
 		t.Fatalf("unexpected followers: %#v", followers)
 	}
 }
+
+func TestUsersService_ListFollowersPager(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/users/7/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "2" {
+			t.Fatalf("unexpected limit: %q", got)
+		}
+		if got := r.Header.Get("X-Test"); got != "pager" {
+			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		switch calls {
+		case 1:
+			if got := r.URL.Query().Get("cursor"); got != "start" {
+				t.Fatalf("unexpected first cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":3}],"additional_data":{"next_cursor":"next"}}`))
+		case 2:
+			if got := r.URL.Query().Get("cursor"); got != "next" {
+				t.Fatalf("unexpected second cursor: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"user_id":4}],"additional_data":{"next_cursor":null}}`))
+		default:
+			t.Fatalf("unexpected call count: %d", calls)
+		}
+	})
+
+	pager := client.Users.ListFollowersPager(
+		UserID(7),
+		WithUserFollowersPageSize(2),
+		WithUserFollowersCursor("start"),
+		WithUserFollowersRequestOptions(pipedrive.WithHeader("X-Test", "pager")),
+	)
+	var ids []UserID
+	for pager.Next(context.Background()) {
+		for _, follower := range pager.Items() {
+			ids = append(ids, follower.UserID)
+		}
+	}
+	if err := pager.Err(); err != nil {
+		t.Fatalf("pager error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 3 || ids[1] != 4 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+func TestUsersService_ForEachFollowers(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/users/7/followers" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"user_id":3},{"user_id":4}],"additional_data":{"next_cursor":null}}`))
+	})
+
+	var ids []UserID
+	err := client.Users.ForEachFollowers(context.Background(), UserID(7), func(follower Follower) error {
+		ids = append(ids, follower.UserID)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachFollowers error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != 3 || ids[1] != 4 {
+		t.Fatalf("unexpected ids: %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary

- Raises package-level coverage for the public SDK packages `pipedrive`, `pipedrive/v1`, and `pipedrive/v2` above 80%.
- Adds focused core SDK unit tests for auth, errors, retry helpers, raw client error handling, and response-size limits.
- Expands v2 and v1 service coverage with `httptest`, including field services, pager/foreach helpers, option branches, and high-value CRUD flows.
- Adds CI upload of the SDK-only Go coverage profile to Coveralls.

## Validation

- `go test -coverprofile=/tmp/pipedrive-go.cover -covermode=count ./pipedrive ./pipedrive/v1 ./pipedrive/v2`
- `go test ./...`

No breaking changes.