### PR TITLE
chore(docs): reference v1.0.9 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The repository prefers Go 1.26.5 locally via the `toolchain` directive in
 To pin a specific version:
 
 ```sh
-go get github.com/juhokoskela/pipedrive-go@v1.0.8
+go get github.com/juhokoskela/pipedrive-go@v1.0.9
 ```
 
 ## Quickstart (API token)


### PR DESCRIPTION
## Summary

- Update the pinned installation example from `v1.0.8` to the newly published `v1.0.9` release.
- Keep the README aligned with the latest stable module tag.

Validated with `git diff --check`; this is a documentation-only one-line change.

Breaking changes: none.