### PR TITLE
feat(api): sync Pipedrive specs and complete v2 parity

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -1,0 +1,39 @@
+name: Upstream OpenAPI drift
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-openapi-drift
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache: true
+
+      - name: Pin toolchain to installed version
+        run: echo "GOTOOLCHAIN=local" >> "$GITHUB_ENV"
+
+      - name: Refresh specifications
+        run: make update-specs
+
+      - name: Regenerate clients and endpoint documentation
+        run: |
+          make generate
+          make docs
+
+      - name: Check for upstream drift
+        run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,15 @@ docs:
 
 .PHONY: update-specs
 update-specs:
-	mkdir -p openapi/upstream
-	curl -L -o openapi/upstream/v1.yaml $(OPENAPI_V1_URL)
-	curl -L -o openapi/upstream/v2.yaml $(OPENAPI_V2_URL)
+	@set -eu; \
+		mkdir -p openapi/upstream; \
+		tmp_v1="$$(mktemp)"; \
+		tmp_v2="$$(mktemp)"; \
+		trap 'rm -f "$$tmp_v1" "$$tmp_v2"' EXIT; \
+		curl --fail --show-error --silent --location --output "$$tmp_v1" "$(OPENAPI_V1_URL)"; \
+		curl --fail --show-error --silent --location --output "$$tmp_v2" "$(OPENAPI_V2_URL)"; \
+		mv "$$tmp_v1" openapi/upstream/v1.yaml; \
+		mv "$$tmp_v2" openapi/upstream/v2.yaml
 
 .PHONY: derive-v1-legacy
 derive-v1-legacy:

--- a/docs/endpoints-v1-legacy.md
+++ b/docs/endpoints-v1-legacy.md
@@ -2,7 +2,7 @@
 
 Generated from `openapi/derived/v1-legacy.yaml` by `cmd/endpoint-docs`. Do not edit manually.
 
-Total operations: 177
+Total operations: 160
 
 | Method | Path | Summary | Operation ID |
 | --- | --- | --- | --- |
@@ -132,19 +132,7 @@ Total operations: 177
 | GET | `/products/{id}/deals` | Get deals where a product is attached to | `getProductDeals` |
 | GET | `/products/{id}/files` | List files attached to a product | `getProductFiles` |
 | GET | `/products/{id}/permittedUsers` | List permitted users | `getProductUsers` |
-| GET | `/projectTemplates` | Get all project templates | `getProjectTemplates` |
-| GET | `/projectTemplates/{id}` | Get details of a template | `getProjectTemplate` |
-| GET | `/projects` | Get all projects | `getProjects` |
-| POST | `/projects` | Add a project | `addProject` |
-| GET | `/projects/boards` | Get all project boards | `getProjectsBoards` |
-| GET | `/projects/boards/{id}` | Get details of a board | `getProjectsBoard` |
-| GET | `/projects/phases` | Get project phases | `getProjectsPhases` |
-| GET | `/projects/phases/{id}` | Get details of a phase | `getProjectsPhase` |
-| GET | `/projects/{id}` | Get details of a project | `getProject` |
-| PUT | `/projects/{id}` | Update a project | `updateProject` |
-| DELETE | `/projects/{id}` | Delete a project | `deleteProject` |
 | GET | `/projects/{id}/activities` | Returns project activities | `getProjectActivities` |
-| POST | `/projects/{id}/archive` | Archive a project | `archiveProject` |
 | GET | `/projects/{id}/groups` | Returns project groups | `getProjectGroups` |
 | GET | `/projects/{id}/plan` | Returns project plan | `getProjectPlan` |
 | PUT | `/projects/{id}/plan/activities/{activityId}` | Update activity in project plan | `putProjectPlanActivity` |
@@ -164,11 +152,6 @@ Total operations: 177
 | GET | `/roles/{id}/settings` | List role settings | `getRoleSettings` |
 | POST | `/roles/{id}/settings` | Add or update role setting | `addOrUpdateRoleSetting` |
 | GET | `/stages/{id}/deals` | Get deals in a stage | `getStageDeals` |
-| GET | `/tasks` | Get all tasks | `getTasks` |
-| POST | `/tasks` | Add a task | `addTask` |
-| GET | `/tasks/{id}` | Get details of a task | `getTask` |
-| PUT | `/tasks/{id}` | Update a task | `updateTask` |
-| DELETE | `/tasks/{id}` | Delete a task | `deleteTask` |
 | GET | `/userConnections` | Get all user connections | `getUserConnections` |
 | GET | `/userSettings` | List settings of an authorized user | `getUserSettings` |
 | GET | `/users` | Get all users | `getUsers` |

--- a/docs/endpoints-v2.md
+++ b/docs/endpoints-v2.md
@@ -2,7 +2,7 @@
 
 Generated from `openapi/upstream/v2.yaml` by `cmd/endpoint-docs`. Do not edit manually.
 
-Total operations: 123
+Total operations: 158
 
 | Method | Path | Summary | Operation ID |
 | --- | --- | --- | --- |
@@ -13,6 +13,11 @@ Total operations: 123
 | DELETE | `/activities/{id}` | Delete an activity | `deleteActivity` |
 | GET | `/activityFields` | Get all activity fields | `getActivityFields` |
 | GET | `/activityFields/{field_code}` | Get one activity field | `getActivityField` |
+| GET | `/boards` | Get all project boards | `getProjectsBoards` |
+| POST | `/boards` | Add a project board | `addProjectBoard` |
+| GET | `/boards/{id}` | Get details of a project board | `getProjectsBoard` |
+| PATCH | `/boards/{id}` | Update a project board | `updateProjectBoard` |
+| DELETE | `/boards/{id}` | Delete a project board | `deleteProjectBoard` |
 | GET | `/dealFields` | Get all deal fields | `getDealFields` |
 | POST | `/dealFields` | Create one deal field | `addDealField` |
 | GET | `/dealFields/{field_code}` | Get one deal field | `getDealField` |
@@ -91,6 +96,11 @@ Total operations: 123
 | GET | `/persons/{id}/followers/changelog` | List followers changelog of a person | `getPersonFollowersChangelog` |
 | DELETE | `/persons/{id}/followers/{follower_id}` | Delete a follower from a person | `deletePersonFollower` |
 | GET | `/persons/{id}/picture` | Get picture of a person | `getPersonPicture` |
+| GET | `/phases` | Get project phases | `getProjectsPhases` |
+| POST | `/phases` | Add a project phase | `addProjectPhase` |
+| GET | `/phases/{id}` | Get details of a project phase | `getProjectsPhase` |
+| PATCH | `/phases/{id}` | Update a project phase | `updateProjectPhase` |
+| DELETE | `/phases/{id}` | Delete a project phase | `deleteProjectPhase` |
 | GET | `/pipelines` | Get all pipelines | `getPipelines` |
 | POST | `/pipelines` | Add a new pipeline | `addPipeline` |
 | GET | `/pipelines/{id}` | Get one pipeline | `getPipeline` |
@@ -123,10 +133,35 @@ Total operations: 123
 | POST | `/products/{id}/variations` | Add a product variation | `addProductVariation` |
 | PATCH | `/products/{id}/variations/{product_variation_id}` | Update a product variation | `updateProductVariation` |
 | DELETE | `/products/{id}/variations/{product_variation_id}` | Delete a product variation | `deleteProductVariation` |
+| GET | `/projectFields` | Get all project fields | `getProjectFields` |
+| POST | `/projectFields` | Create one project field | `addProjectField` |
+| GET | `/projectFields/{field_code}` | Get one project field | `getProjectField` |
+| PATCH | `/projectFields/{field_code}` | Update one project field | `updateProjectField` |
+| DELETE | `/projectFields/{field_code}` | Delete one project field | `deleteProjectField` |
+| POST | `/projectFields/{field_code}/options` | Add project field options in bulk | `addProjectFieldOptions` |
+| PATCH | `/projectFields/{field_code}/options` | Update project field options in bulk | `updateProjectFieldOptions` |
+| DELETE | `/projectFields/{field_code}/options` | Delete project field options in bulk | `deleteProjectFieldOptions` |
+| GET | `/projectTemplates` | Get all project templates | `getProjectTemplates` |
+| GET | `/projectTemplates/{id}` | Get details of a template | `getProjectTemplate` |
+| GET | `/projects` | Get all projects | `getProjects` |
+| POST | `/projects` | Add a project | `addProject` |
+| GET | `/projects/archived` | Get all archived projects | `getArchivedProjects` |
+| GET | `/projects/search` | Search projects | `searchProjects` |
+| GET | `/projects/{id}` | Get details of a project | `getProject` |
+| PATCH | `/projects/{id}` | Update a project | `updateProject` |
+| DELETE | `/projects/{id}` | Delete a project | `deleteProject` |
+| POST | `/projects/{id}/archive` | Archive a project | `archiveProject` |
+| GET | `/projects/{id}/changelog` | List updates about project field values | `getProjectChangelog` |
+| GET | `/projects/{id}/permittedUsers` | List permitted users | `getProjectUsers` |
 | GET | `/stages` | Get all stages | `getStages` |
 | POST | `/stages` | Add a new stage | `addStage` |
 | GET | `/stages/{id}` | Get one stage | `getStage` |
 | PATCH | `/stages/{id}` | Update stage details | `updateStage` |
 | DELETE | `/stages/{id}` | Delete a stage | `deleteStage` |
+| GET | `/tasks` | Get all tasks | `getTasks` |
+| POST | `/tasks` | Add a task | `addTask` |
+| GET | `/tasks/{id}` | Get details of a task | `getTask` |
+| PATCH | `/tasks/{id}` | Update a task | `updateTask` |
+| DELETE | `/tasks/{id}` | Delete a task | `deleteTask` |
 | GET | `/users/{id}/followers` | List followers of a user | `getUserFollowers` |
 

--- a/internal/gen/v1/openapi.gen.go
+++ b/internal/gen/v1/openapi.gen.go
@@ -179,6 +179,12 @@ const (
 	GetArchivedDealsTimelineParamsExcludeDealsN1 GetArchivedDealsTimelineParamsExcludeDeals = 1
 )
 
+// Defines values for GetDealMailMessagesParamsIncludeBody.
+const (
+	GetDealMailMessagesParamsIncludeBodyN0 GetDealMailMessagesParamsIncludeBody = 0
+	GetDealMailMessagesParamsIncludeBodyN1 GetDealMailMessagesParamsIncludeBody = 1
+)
+
 // Defines values for AddFileAndLinkItFormdataBodyFileType.
 const (
 	Gdoc    AddFileAndLinkItFormdataBodyFileType = "gdoc"
@@ -450,6 +456,12 @@ const (
 	GetNotesParamsPinnedToProjectFlagN1 GetNotesParamsPinnedToProjectFlag = 1
 )
 
+// Defines values for GetNotesParamsPinnedToTaskFlag.
+const (
+	GetNotesParamsPinnedToTaskFlagN0 GetNotesParamsPinnedToTaskFlag = 0
+	GetNotesParamsPinnedToTaskFlagN1 GetNotesParamsPinnedToTaskFlag = 1
+)
+
 // Defines values for AddNoteJSONBodyPinnedToDealFlag.
 const (
 	AddNoteJSONBodyPinnedToDealFlagN0 AddNoteJSONBodyPinnedToDealFlag = 0
@@ -478,6 +490,12 @@ const (
 const (
 	AddNoteJSONBodyPinnedToProjectFlagN0 AddNoteJSONBodyPinnedToProjectFlag = 0
 	AddNoteJSONBodyPinnedToProjectFlagN1 AddNoteJSONBodyPinnedToProjectFlag = 1
+)
+
+// Defines values for AddNoteJSONBodyPinnedToTaskFlag.
+const (
+	AddNoteJSONBodyPinnedToTaskFlagN0 AddNoteJSONBodyPinnedToTaskFlag = 0
+	AddNoteJSONBodyPinnedToTaskFlagN1 AddNoteJSONBodyPinnedToTaskFlag = 1
 )
 
 // Defines values for UpdateNoteJSONBodyPinnedToDealFlag.
@@ -510,6 +528,12 @@ const (
 	UpdateNoteJSONBodyPinnedToProjectFlagN1 UpdateNoteJSONBodyPinnedToProjectFlag = 1
 )
 
+// Defines values for UpdateNoteJSONBodyPinnedToTaskFlag.
+const (
+	UpdateNoteJSONBodyPinnedToTaskFlagN0 UpdateNoteJSONBodyPinnedToTaskFlag = 0
+	UpdateNoteJSONBodyPinnedToTaskFlagN1 UpdateNoteJSONBodyPinnedToTaskFlag = 1
+)
+
 // Defines values for GetTokensFormdataBodyGrantType.
 const (
 	GetTokensFormdataBodyGrantTypeAuthorizationCode GetTokensFormdataBodyGrantType = "authorization_code"
@@ -534,6 +558,12 @@ const (
 	UpdateOrganizationRelationshipJSONBodyTypeRelated UpdateOrganizationRelationshipJSONBodyType = "related"
 )
 
+// Defines values for GetOrganizationMailMessagesParamsIncludeBody.
+const (
+	GetOrganizationMailMessagesParamsIncludeBodyN0 GetOrganizationMailMessagesParamsIncludeBody = 0
+	GetOrganizationMailMessagesParamsIncludeBodyN1 GetOrganizationMailMessagesParamsIncludeBody = 1
+)
+
 // Defines values for GetPermissionSetsParamsApp.
 const (
 	GetPermissionSetsParamsAppAccountSettings GetPermissionSetsParamsApp = "account_settings"
@@ -541,6 +571,12 @@ const (
 	GetPermissionSetsParamsAppGlobal          GetPermissionSetsParamsApp = "global"
 	GetPermissionSetsParamsAppProjects        GetPermissionSetsParamsApp = "projects"
 	GetPermissionSetsParamsAppSales           GetPermissionSetsParamsApp = "sales"
+)
+
+// Defines values for GetPersonMailMessagesParamsIncludeBody.
+const (
+	GetPersonMailMessagesParamsIncludeBodyN0 GetPersonMailMessagesParamsIncludeBody = 0
+	GetPersonMailMessagesParamsIncludeBodyN1 GetPersonMailMessagesParamsIncludeBody = 1
 )
 
 // Defines values for GetPipelineDealsParamsEveryone.
@@ -603,24 +639,6 @@ const (
 	GetStageDealsParamsEveryoneN1 GetStageDealsParamsEveryone = 1
 )
 
-// Defines values for GetTasksParamsDone.
-const (
-	GetTasksParamsDoneN0 GetTasksParamsDone = 0
-	GetTasksParamsDoneN1 GetTasksParamsDone = 1
-)
-
-// Defines values for AddTaskJSONBodyDone.
-const (
-	AddTaskJSONBodyDoneN0 AddTaskJSONBodyDone = 0
-	AddTaskJSONBodyDoneN1 AddTaskJSONBodyDone = 1
-)
-
-// Defines values for UpdateTaskJSONBodyDone.
-const (
-	UpdateTaskJSONBodyDoneN0 UpdateTaskJSONBodyDone = 0
-	UpdateTaskJSONBodyDoneN1 UpdateTaskJSONBodyDone = 1
-)
-
 // Defines values for AddUserJSONBodyAccessApp.
 const (
 	AddUserJSONBodyAccessAppAccountSettings AddUserJSONBodyAccessApp = "account_settings"
@@ -633,8 +651,8 @@ const (
 
 // Defines values for FindUsersByNameParamsSearchByEmail.
 const (
-	FindUsersByNameParamsSearchByEmailN0 FindUsersByNameParamsSearchByEmail = 0
-	FindUsersByNameParamsSearchByEmailN1 FindUsersByNameParamsSearchByEmail = 1
+	N0 FindUsersByNameParamsSearchByEmail = 0
+	N1 FindUsersByNameParamsSearchByEmail = 1
 )
 
 // Defines values for AddWebhookJSONBodyEventAction.
@@ -1009,7 +1027,13 @@ type GetDealMailMessagesParams struct {
 
 	// Limit Items shown per page
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// IncludeBody Whether to include the mail message body content in the response. `0` = Don't include, `1` = Include.
+	IncludeBody *GetDealMailMessagesParamsIncludeBody `form:"include_body,omitempty" json:"include_body,omitempty"`
 }
+
+// GetDealMailMessagesParamsIncludeBody defines parameters for GetDealMailMessages.
+type GetDealMailMessagesParamsIncludeBody float32
 
 // MergeDealsJSONBody defines parameters for MergeDeals.
 type MergeDealsJSONBody struct {
@@ -1075,6 +1099,9 @@ type AddFileMultipartBody struct {
 
 	// ProductId The ID of the product to associate file(s) with
 	ProductId *int `json:"product_id,omitempty"`
+
+	// ProjectId The ID of the project to associate file(s) with
+	ProjectId *int `json:"project_id,omitempty"`
 }
 
 // AddFileAndLinkItFormdataBody defines parameters for AddFileAndLinkIt.
@@ -1161,8 +1188,20 @@ type AddFilterJSONBody struct {
 	Type AddFilterJSONBodyType `json:"type"`
 }
 
+// AddFilterParams defines parameters for AddFilter.
+type AddFilterParams struct {
+	// IncludeFieldCode If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name
+	IncludeFieldCode *bool `form:"include_field_code,omitempty" json:"include_field_code,omitempty"`
+}
+
 // AddFilterJSONBodyType defines parameters for AddFilter.
 type AddFilterJSONBodyType string
+
+// GetFilterParams defines parameters for GetFilter.
+type GetFilterParams struct {
+	// IncludeFieldCode If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name
+	IncludeFieldCode *bool `form:"include_field_code,omitempty" json:"include_field_code,omitempty"`
+}
 
 // UpdateFilterJSONBody defines parameters for UpdateFilter.
 type UpdateFilterJSONBody struct {
@@ -1171,6 +1210,12 @@ type UpdateFilterJSONBody struct {
 
 	// Name The name of the filter
 	Name *string `json:"name,omitempty"`
+}
+
+// UpdateFilterParams defines parameters for UpdateFilter.
+type UpdateFilterParams struct {
+	// IncludeFieldCode If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name
+	IncludeFieldCode *bool `form:"include_field_code,omitempty" json:"include_field_code,omitempty"`
 }
 
 // AddGoalJSONBody defines parameters for AddGoal.
@@ -1640,6 +1685,9 @@ type GetNotesParams struct {
 	// ProjectId The ID of the project which notes to fetch. If omitted, notes about all projects will be returned.
 	ProjectId *int `form:"project_id,omitempty" json:"project_id,omitempty"`
 
+	// TaskId The ID of the task which notes to fetch. If omitted, notes about all tasks will be returned.
+	TaskId *int `form:"task_id,omitempty" json:"task_id,omitempty"`
+
 	// Start Pagination start
 	Start *int `form:"start,omitempty" json:"start,omitempty"`
 
@@ -1672,6 +1720,9 @@ type GetNotesParams struct {
 
 	// PinnedToProjectFlag If set, the results are filtered by note to project pinning state
 	PinnedToProjectFlag *GetNotesParamsPinnedToProjectFlag `form:"pinned_to_project_flag,omitempty" json:"pinned_to_project_flag,omitempty"`
+
+	// PinnedToTaskFlag If set, the results are filtered by note to task pinning state
+	PinnedToTaskFlag *GetNotesParamsPinnedToTaskFlag `form:"pinned_to_task_flag,omitempty" json:"pinned_to_task_flag,omitempty"`
 }
 
 // GetNotesParamsPinnedToLeadFlag defines parameters for GetNotes.
@@ -1689,6 +1740,9 @@ type GetNotesParamsPinnedToPersonFlag float32
 // GetNotesParamsPinnedToProjectFlag defines parameters for GetNotes.
 type GetNotesParamsPinnedToProjectFlag float32
 
+// GetNotesParamsPinnedToTaskFlag defines parameters for GetNotes.
+type GetNotesParamsPinnedToTaskFlag float32
+
 // AddNoteJSONBody defines parameters for AddNote.
 type AddNoteJSONBody struct {
 	// AddTime The optional creation date & time of the note in UTC. Can be set in the past or in the future. Format: YYYY-MM-DD HH:MM:SS
@@ -1697,16 +1751,16 @@ type AddNoteJSONBody struct {
 	// Content The content of the note in HTML format. Subject to sanitization on the back-end.
 	Content string `json:"content"`
 
-	// DealId The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id`) is specified.
+	// DealId The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id/task_id`) is specified.
 	DealId *int `json:"deal_id,omitempty"`
 
-	// LeadId The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id`) is specified.
+	// LeadId The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id/task_id`) is specified.
 	LeadId *openapi_types.UUID `json:"lead_id,omitempty"`
 
-	// OrgId The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id`) is specified.
+	// OrgId The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id/task_id`) is specified.
 	OrgId *int `json:"org_id,omitempty"`
 
-	// PersonId The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id`) is specified.
+	// PersonId The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id/task_id`) is specified.
 	PersonId *int `json:"person_id,omitempty"`
 
 	// PinnedToDealFlag If set, the results are filtered by note to deal pinning state (`deal_id` is also required)
@@ -1724,8 +1778,14 @@ type AddNoteJSONBody struct {
 	// PinnedToProjectFlag If set, the results are filtered by note to project pinning state (`project_id` is also required)
 	PinnedToProjectFlag *AddNoteJSONBodyPinnedToProjectFlag `json:"pinned_to_project_flag,omitempty"`
 
-	// ProjectId The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id`) is specified.
+	// PinnedToTaskFlag If set, the results are filtered by note to task pinning state (`task_id` is also required)
+	PinnedToTaskFlag *AddNoteJSONBodyPinnedToTaskFlag `json:"pinned_to_task_flag,omitempty"`
+
+	// ProjectId The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/task_id`) is specified.
 	ProjectId *int `json:"project_id,omitempty"`
+
+	// TaskId The ID of the task the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/project_id`) is specified.
+	TaskId *int `json:"task_id,omitempty"`
 
 	// UserId The ID of the user who will be marked as the author of the note. Only an admin can change the author.
 	UserId               *int                   `json:"user_id,omitempty"`
@@ -1746,6 +1806,9 @@ type AddNoteJSONBodyPinnedToPersonFlag float32
 
 // AddNoteJSONBodyPinnedToProjectFlag defines parameters for AddNote.
 type AddNoteJSONBodyPinnedToProjectFlag float32
+
+// AddNoteJSONBodyPinnedToTaskFlag defines parameters for AddNote.
+type AddNoteJSONBodyPinnedToTaskFlag float32
 
 // UpdateNoteJSONBody defines parameters for UpdateNote.
 type UpdateNoteJSONBody struct {
@@ -1782,8 +1845,14 @@ type UpdateNoteJSONBody struct {
 	// PinnedToProjectFlag If set, the results are filtered by note to project pinning state (`project_id` is also required)
 	PinnedToProjectFlag *UpdateNoteJSONBodyPinnedToProjectFlag `json:"pinned_to_project_flag,omitempty"`
 
+	// PinnedToTaskFlag If set, the results are filtered by note to task pinning state (`task_id` is also required)
+	PinnedToTaskFlag *UpdateNoteJSONBodyPinnedToTaskFlag `json:"pinned_to_task_flag,omitempty"`
+
 	// ProjectId The ID of the project the note will be attached to
 	ProjectId *int `json:"project_id,omitempty"`
+
+	// TaskId The ID of the task the note will be attached to
+	TaskId *int `json:"task_id,omitempty"`
 
 	// UserId The ID of the user who will be marked as the author of the note. Only an admin can change the author.
 	UserId *int `json:"user_id,omitempty"`
@@ -1803,6 +1872,9 @@ type UpdateNoteJSONBodyPinnedToPersonFlag float32
 
 // UpdateNoteJSONBodyPinnedToProjectFlag defines parameters for UpdateNote.
 type UpdateNoteJSONBodyPinnedToProjectFlag float32
+
+// UpdateNoteJSONBodyPinnedToTaskFlag defines parameters for UpdateNote.
+type UpdateNoteJSONBodyPinnedToTaskFlag float32
 
 // GetNoteCommentsParams defines parameters for GetNoteComments.
 type GetNoteCommentsParams struct {
@@ -1973,7 +2045,13 @@ type GetOrganizationMailMessagesParams struct {
 
 	// Limit Items shown per page
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// IncludeBody Whether to include the mail message body content in the response. `0` = Don't include, `1` = Include.
+	IncludeBody *GetOrganizationMailMessagesParamsIncludeBody `form:"include_body,omitempty" json:"include_body,omitempty"`
 }
+
+// GetOrganizationMailMessagesParamsIncludeBody defines parameters for GetOrganizationMailMessages.
+type GetOrganizationMailMessagesParamsIncludeBody float32
 
 // MergeOrganizationsJSONBody defines parameters for MergeOrganizations.
 type MergeOrganizationsJSONBody struct {
@@ -2048,7 +2126,13 @@ type GetPersonMailMessagesParams struct {
 
 	// Limit Items shown per page
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// IncludeBody Whether to include the mail message body content in the response. `0` = Don't include, `1` = Include.
+	IncludeBody *GetPersonMailMessagesParamsIncludeBody `form:"include_body,omitempty" json:"include_body,omitempty"`
 }
+
+// GetPersonMailMessagesParamsIncludeBody defines parameters for GetPersonMailMessages.
+type GetPersonMailMessagesParamsIncludeBody float32
 
 // MergePersonsJSONBody defines parameters for MergePersons.
 type MergePersonsJSONBody struct {
@@ -2171,123 +2255,6 @@ type GetProductFilesParams struct {
 
 	// Sort Supported fields: `id`, `update_time`
 	Sort *string `form:"sort,omitempty" json:"sort,omitempty"`
-}
-
-// GetProjectTemplatesParams defines parameters for GetProjectTemplates.
-type GetProjectTemplatesParams struct {
-	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
-
-	// Limit For pagination, the limit of entries to be returned. If not provided, up to 500 items will be returned.
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-}
-
-// GetProjectsParams defines parameters for GetProjects.
-type GetProjectsParams struct {
-	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
-
-	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned.
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// FilterId The ID of the filter to use
-	FilterId *int `form:"filter_id,omitempty" json:"filter_id,omitempty"`
-
-	// Status If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.
-	Status *string `form:"status,omitempty" json:"status,omitempty"`
-
-	// PhaseId If supplied, only projects in specified phase are returned
-	PhaseId *int `form:"phase_id,omitempty" json:"phase_id,omitempty"`
-
-	// IncludeArchived If supplied with `true` then archived projects are also included in the response. By default only not archived projects are returned.
-	IncludeArchived *bool `form:"include_archived,omitempty" json:"include_archived,omitempty"`
-}
-
-// AddProjectJSONBody defines parameters for AddProject.
-type AddProjectJSONBody struct {
-	// BoardId The ID of the board this project is associated with
-	BoardId *float32 `json:"board_id,omitempty"`
-
-	// DealIds An array of IDs of the deals this project is associated with
-	DealIds *[]int `json:"deal_ids,omitempty"`
-
-	// Description The description of the project
-	Description *string `json:"description,omitempty"`
-
-	// EndDate The end date of the project. Format: YYYY-MM-DD.
-	EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-	// Labels An array of IDs of the labels this project has
-	Labels *[]int `json:"labels,omitempty"`
-
-	// OrgId The ID of the organization this project is associated with
-	OrgId *float32 `json:"org_id,omitempty"`
-
-	// OwnerId The ID of a project owner
-	OwnerId *float32 `json:"owner_id,omitempty"`
-
-	// PersonId The ID of the person this project is associated with
-	PersonId *float32 `json:"person_id,omitempty"`
-
-	// PhaseId The ID of the phase this project is associated with
-	PhaseId *float32 `json:"phase_id,omitempty"`
-
-	// StartDate The start date of the project. Format: YYYY-MM-DD.
-	StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-	// Status The status of the project
-	Status *string `json:"status,omitempty"`
-
-	// TemplateId The ID of the template the project will be based on
-	TemplateId *float32 `json:"template_id,omitempty"`
-
-	// Title The title of the project
-	Title string `json:"title"`
-}
-
-// GetProjectsPhasesParams defines parameters for GetProjectsPhases.
-type GetProjectsPhasesParams struct {
-	// BoardId ID of the board for which phases are requested
-	BoardId int `form:"board_id" json:"board_id"`
-}
-
-// UpdateProjectJSONBody defines parameters for UpdateProject.
-type UpdateProjectJSONBody struct {
-	// BoardId The ID of the board this project is associated with
-	BoardId *float32 `json:"board_id,omitempty"`
-
-	// DealIds An array of IDs of the deals this project is associated with
-	DealIds *[]int `json:"deal_ids,omitempty"`
-
-	// Description The description of the project
-	Description *string `json:"description,omitempty"`
-
-	// EndDate The end date of the project. Format: YYYY-MM-DD.
-	EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-	// Labels An array of IDs of the labels this project has
-	Labels *[]int `json:"labels,omitempty"`
-
-	// OrgId The ID of the organization this project is associated with
-	OrgId *float32 `json:"org_id,omitempty"`
-
-	// OwnerId The ID of a project owner
-	OwnerId *float32 `json:"owner_id,omitempty"`
-
-	// PersonId The ID of the person this project is associated with
-	PersonId *float32 `json:"person_id,omitempty"`
-
-	// PhaseId The ID of the phase this project is associated with
-	PhaseId *float32 `json:"phase_id,omitempty"`
-
-	// StartDate The start date of the project. Format: YYYY-MM-DD.
-	StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-	// Status The status of the project
-	Status *string `json:"status,omitempty"`
-
-	// Title The title of the project
-	Title *string `json:"title,omitempty"`
 }
 
 // PutProjectPlanActivityJSONBody defines parameters for PutProjectPlanActivity.
@@ -2421,91 +2388,18 @@ type GetStageDealsParams struct {
 // GetStageDealsParamsEveryone defines parameters for GetStageDeals.
 type GetStageDealsParamsEveryone float32
 
-// GetTasksParams defines parameters for GetTasks.
-type GetTasksParams struct {
-	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
-	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
-
-	// Limit For pagination, the limit of entries to be returned. If not provided, up to 500 items will be returned.
-	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
-
-	// AssigneeId If supplied, only tasks that are assigned to this user are returned
-	AssigneeId *int `form:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-
-	// ProjectId If supplied, only tasks that are assigned to this project are returned
-	ProjectId *int `form:"project_id,omitempty" json:"project_id,omitempty"`
-
-	// ParentTaskId If `null` is supplied then only parent tasks are returned. If integer is supplied then only subtasks of a specific task are returned. By default all tasks are returned.
-	ParentTaskId *int `form:"parent_task_id,omitempty" json:"parent_task_id,omitempty"`
-
-	// Done Whether the task is done or not. `0` = Not done, `1` = Done. If not omitted then returns both done and not done tasks.
-	Done *GetTasksParamsDone `form:"done,omitempty" json:"done,omitempty"`
-}
-
-// GetTasksParamsDone defines parameters for GetTasks.
-type GetTasksParamsDone float32
-
-// AddTaskJSONBody defines parameters for AddTask.
-type AddTaskJSONBody struct {
-	// AssigneeId The ID of the user who will be the assignee of the task
-	AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-	// Description The description of the task
-	Description *string `json:"description,omitempty"`
-
-	// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-	Done *AddTaskJSONBodyDone `json:"done,omitempty"`
-
-	// DueDate The due date of the task. Format: YYYY-MM-DD.
-	DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-	// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-	ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-	// ProjectId The ID of a project
-	ProjectId float32 `json:"project_id"`
-
-	// Title The title of the task
-	Title string `json:"title"`
-}
-
-// AddTaskJSONBodyDone defines parameters for AddTask.
-type AddTaskJSONBodyDone float32
-
-// UpdateTaskJSONBody defines parameters for UpdateTask.
-type UpdateTaskJSONBody struct {
-	// AssigneeId The ID of the user who will be the assignee of the task
-	AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-	// Description The description of the task
-	Description *string `json:"description,omitempty"`
-
-	// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-	Done *UpdateTaskJSONBodyDone `json:"done,omitempty"`
-
-	// DueDate The due date of the task. Format: YYYY-MM-DD.
-	DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-	// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-	ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-	// ProjectId The ID of the project this task is associated with
-	ProjectId *float32 `json:"project_id,omitempty"`
-
-	// Title The title of the task
-	Title *string `json:"title,omitempty"`
-}
-
-// UpdateTaskJSONBodyDone defines parameters for UpdateTask.
-type UpdateTaskJSONBodyDone float32
-
 // AddUserJSONBody defines parameters for AddUser.
 type AddUserJSONBody struct {
 	// Access The access given to the user. Each item in the array represents access to a specific app. Optionally may include either admin flag or permission set ID to specify which access to give within the app. If both are omitted, the default access for the corresponding app will be used. It requires structure as follows: `[{ app: 'sales', permission_set_id: '62cc4d7f-4038-4352-abf3-a8c1c822b631' }, { app: 'global', admin: true }, { app: 'account_settings' }]`
 	Access *[]struct {
-		Admin           *bool                    `json:"admin,omitempty"`
-		App             AddUserJSONBodyAccessApp `json:"app"`
-		PermissionSetId *string                  `json:"permission_set_id,omitempty"`
+		// Admin Whether the user has admin access or not
+		Admin *bool `json:"admin,omitempty"`
+
+		// App The granular app access level
+		App AddUserJSONBodyAccessApp `json:"app"`
+
+		// PermissionSetId The ID of the permission set
+		PermissionSetId *string `json:"permission_set_id,omitempty"`
 	} `json:"access,omitempty"`
 
 	// ActiveFlag Whether the user is active or not. `false` = Not activated, `true` = Activated
@@ -2692,12 +2586,6 @@ type MergePersonsJSONRequestBody MergePersonsJSONBody
 // AddPersonPictureMultipartRequestBody defines body for AddPersonPicture for multipart/form-data ContentType.
 type AddPersonPictureMultipartRequestBody AddPersonPictureMultipartBody
 
-// AddProjectJSONRequestBody defines body for AddProject for application/json ContentType.
-type AddProjectJSONRequestBody AddProjectJSONBody
-
-// UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
-type UpdateProjectJSONRequestBody UpdateProjectJSONBody
-
 // PutProjectPlanActivityJSONRequestBody defines body for PutProjectPlanActivity for application/json ContentType.
 type PutProjectPlanActivityJSONRequestBody PutProjectPlanActivityJSONBody
 
@@ -2721,12 +2609,6 @@ type UpdateRolePipelinesJSONRequestBody UpdateRolePipelinesJSONBody
 
 // AddOrUpdateRoleSettingJSONRequestBody defines body for AddOrUpdateRoleSetting for application/json ContentType.
 type AddOrUpdateRoleSettingJSONRequestBody AddOrUpdateRoleSettingJSONBody
-
-// AddTaskJSONRequestBody defines body for AddTask for application/json ContentType.
-type AddTaskJSONRequestBody AddTaskJSONBody
-
-// UpdateTaskJSONRequestBody defines body for UpdateTask for application/json ContentType.
-type UpdateTaskJSONRequestBody UpdateTaskJSONBody
 
 // AddUserJSONRequestBody defines body for AddUser for application/json ContentType.
 type AddUserJSONRequestBody AddUserJSONBody
@@ -2850,12 +2732,28 @@ func (a *AddNoteJSONBody) UnmarshalJSON(b []byte) error {
 		delete(object, "pinned_to_project_flag")
 	}
 
+	if raw, found := object["pinned_to_task_flag"]; found {
+		err = json.Unmarshal(raw, &a.PinnedToTaskFlag)
+		if err != nil {
+			return fmt.Errorf("error reading 'pinned_to_task_flag': %w", err)
+		}
+		delete(object, "pinned_to_task_flag")
+	}
+
 	if raw, found := object["project_id"]; found {
 		err = json.Unmarshal(raw, &a.ProjectId)
 		if err != nil {
 			return fmt.Errorf("error reading 'project_id': %w", err)
 		}
 		delete(object, "project_id")
+	}
+
+	if raw, found := object["task_id"]; found {
+		err = json.Unmarshal(raw, &a.TaskId)
+		if err != nil {
+			return fmt.Errorf("error reading 'task_id': %w", err)
+		}
+		delete(object, "task_id")
 	}
 
 	if raw, found := object["user_id"]; found {
@@ -2960,10 +2858,24 @@ func (a AddNoteJSONBody) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if a.PinnedToTaskFlag != nil {
+		object["pinned_to_task_flag"], err = json.Marshal(a.PinnedToTaskFlag)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'pinned_to_task_flag': %w", err)
+		}
+	}
+
 	if a.ProjectId != nil {
 		object["project_id"], err = json.Marshal(a.ProjectId)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'project_id': %w", err)
+		}
+	}
+
+	if a.TaskId != nil {
+		object["task_id"], err = json.Marshal(a.TaskId)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'task_id': %w", err)
 		}
 	}
 
@@ -3200,9 +3112,9 @@ type ClientInterface interface {
 	GetFilters(ctx context.Context, params *GetFiltersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// AddFilterWithBody request with any body
-	AddFilterWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	AddFilterWithBody(ctx context.Context, params *AddFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	AddFilter(ctx context.Context, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	AddFilter(ctx context.Context, params *AddFilterParams, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFilterHelpers request
 	GetFilterHelpers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3211,12 +3123,12 @@ type ClientInterface interface {
 	DeleteFilter(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFilter request
-	GetFilter(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetFilter(ctx context.Context, id int, params *GetFilterParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UpdateFilterWithBody request with any body
-	UpdateFilterWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateFilterWithBody(ctx context.Context, id int, params *UpdateFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpdateFilter(ctx context.Context, id int, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateFilter(ctx context.Context, id int, params *UpdateFilterParams, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// AddGoalWithBody request with any body
 	AddGoalWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3502,48 +3414,8 @@ type ClientInterface interface {
 	// GetProductUsers request
 	GetProductUsers(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetProjectTemplates request
-	GetProjectTemplates(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjectTemplate request
-	GetProjectTemplate(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjects request
-	GetProjects(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// AddProjectWithBody request with any body
-	AddProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	AddProject(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjectsBoards request
-	GetProjectsBoards(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjectsBoard request
-	GetProjectsBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjectsPhases request
-	GetProjectsPhases(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProjectsPhase request
-	GetProjectsPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// DeleteProject request
-	DeleteProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetProject request
-	GetProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// UpdateProjectWithBody request with any body
-	UpdateProjectWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	UpdateProject(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// GetProjectActivities request
 	GetProjectActivities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// ArchiveProject request
-	ArchiveProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetProjectGroups request
 	GetProjectGroups(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3617,25 +3489,6 @@ type ClientInterface interface {
 
 	// GetStageDeals request
 	GetStageDeals(ctx context.Context, id int, params *GetStageDealsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetTasks request
-	GetTasks(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// AddTaskWithBody request with any body
-	AddTaskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	AddTask(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// DeleteTask request
-	DeleteTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetTask request
-	GetTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// UpdateTaskWithBody request with any body
-	UpdateTaskWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	UpdateTask(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetUserConnections request
 	GetUserConnections(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4298,8 +4151,8 @@ func (c *Client) GetFilters(ctx context.Context, params *GetFiltersParams, reqEd
 	return c.Client.Do(req)
 }
 
-func (c *Client) AddFilterWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddFilterRequestWithBody(c.Server, contentType, body)
+func (c *Client) AddFilterWithBody(ctx context.Context, params *AddFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddFilterRequestWithBody(c.Server, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4310,8 +4163,8 @@ func (c *Client) AddFilterWithBody(ctx context.Context, contentType string, body
 	return c.Client.Do(req)
 }
 
-func (c *Client) AddFilter(ctx context.Context, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddFilterRequest(c.Server, body)
+func (c *Client) AddFilter(ctx context.Context, params *AddFilterParams, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddFilterRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4346,8 +4199,8 @@ func (c *Client) DeleteFilter(ctx context.Context, id int, reqEditors ...Request
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetFilter(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetFilterRequest(c.Server, id)
+func (c *Client) GetFilter(ctx context.Context, id int, params *GetFilterParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetFilterRequest(c.Server, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -4358,8 +4211,8 @@ func (c *Client) GetFilter(ctx context.Context, id int, reqEditors ...RequestEdi
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateFilterWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateFilterRequestWithBody(c.Server, id, contentType, body)
+func (c *Client) UpdateFilterWithBody(ctx context.Context, id int, params *UpdateFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFilterRequestWithBody(c.Server, id, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4370,8 +4223,8 @@ func (c *Client) UpdateFilterWithBody(ctx context.Context, id int, contentType s
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateFilter(ctx context.Context, id int, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateFilterRequest(c.Server, id, body)
+func (c *Client) UpdateFilter(ctx context.Context, id int, params *UpdateFilterParams, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFilterRequest(c.Server, id, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -5606,176 +5459,8 @@ func (c *Client) GetProductUsers(ctx context.Context, id int, reqEditors ...Requ
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetProjectTemplates(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectTemplatesRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjectTemplate(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectTemplateRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjects(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectsRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) AddProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddProjectRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) AddProject(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddProjectRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjectsBoards(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectsBoardsRequest(c.Server)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjectsBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectsBoardRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjectsPhases(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectsPhasesRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProjectsPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectsPhaseRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DeleteProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteProjectRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetProjectRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateProjectWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateProjectRequestWithBody(c.Server, id, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateProject(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateProjectRequest(c.Server, id, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) GetProjectActivities(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetProjectActivitiesRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ArchiveProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewArchiveProjectRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -6100,90 +5785,6 @@ func (c *Client) AddOrUpdateRoleSetting(ctx context.Context, id int, body AddOrU
 
 func (c *Client) GetStageDeals(ctx context.Context, id int, params *GetStageDealsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetStageDealsRequest(c.Server, id, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetTasks(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetTasksRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) AddTaskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddTaskRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) AddTask(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAddTaskRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) DeleteTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteTaskRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetTaskRequest(c.Server, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateTaskWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateTaskRequestWithBody(c.Server, id, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateTask(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateTaskRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7938,6 +7539,22 @@ func NewGetDealMailMessagesRequest(server string, id int, params *GetDealMailMes
 
 		}
 
+		if params.IncludeBody != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_body", runtime.ParamLocationQuery, *params.IncludeBody); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -8696,18 +8313,18 @@ func NewGetFiltersRequest(server string, params *GetFiltersParams) (*http.Reques
 }
 
 // NewAddFilterRequest calls the generic AddFilter builder with application/json body
-func NewAddFilterRequest(server string, body AddFilterJSONRequestBody) (*http.Request, error) {
+func NewAddFilterRequest(server string, params *AddFilterParams, body AddFilterJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewAddFilterRequestWithBody(server, "application/json", bodyReader)
+	return NewAddFilterRequestWithBody(server, params, "application/json", bodyReader)
 }
 
 // NewAddFilterRequestWithBody generates requests for AddFilter with any type of body
-func NewAddFilterRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+func NewAddFilterRequestWithBody(server string, params *AddFilterParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -8723,6 +8340,28 @@ func NewAddFilterRequestWithBody(server string, contentType string, body io.Read
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.IncludeFieldCode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_field_code", runtime.ParamLocationQuery, *params.IncludeFieldCode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -8797,7 +8436,7 @@ func NewDeleteFilterRequest(server string, id int) (*http.Request, error) {
 }
 
 // NewGetFilterRequest generates requests for GetFilter
-func NewGetFilterRequest(server string, id int) (*http.Request, error) {
+func NewGetFilterRequest(server string, id int, params *GetFilterParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8820,6 +8459,28 @@ func NewGetFilterRequest(server string, id int) (*http.Request, error) {
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.IncludeFieldCode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_field_code", runtime.ParamLocationQuery, *params.IncludeFieldCode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -8831,18 +8492,18 @@ func NewGetFilterRequest(server string, id int) (*http.Request, error) {
 }
 
 // NewUpdateFilterRequest calls the generic UpdateFilter builder with application/json body
-func NewUpdateFilterRequest(server string, id int, body UpdateFilterJSONRequestBody) (*http.Request, error) {
+func NewUpdateFilterRequest(server string, id int, params *UpdateFilterParams, body UpdateFilterJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewUpdateFilterRequestWithBody(server, id, "application/json", bodyReader)
+	return NewUpdateFilterRequestWithBody(server, id, params, "application/json", bodyReader)
 }
 
 // NewUpdateFilterRequestWithBody generates requests for UpdateFilter with any type of body
-func NewUpdateFilterRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+func NewUpdateFilterRequestWithBody(server string, id int, params *UpdateFilterParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -8865,6 +8526,28 @@ func NewUpdateFilterRequestWithBody(server string, id int, contentType string, b
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.IncludeFieldCode != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_field_code", runtime.ParamLocationQuery, *params.IncludeFieldCode); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("PUT", queryURL.String(), body)
@@ -10947,6 +10630,22 @@ func NewGetNotesRequest(server string, params *GetNotesParams) (*http.Request, e
 
 		}
 
+		if params.TaskId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "task_id", runtime.ParamLocationQuery, *params.TaskId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Start != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "start", runtime.ParamLocationQuery, *params.Start); err != nil {
@@ -11110,6 +10809,22 @@ func NewGetNotesRequest(server string, params *GetNotesParams) (*http.Request, e
 		if params.PinnedToProjectFlag != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pinned_to_project_flag", runtime.ParamLocationQuery, *params.PinnedToProjectFlag); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PinnedToTaskFlag != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "pinned_to_task_flag", runtime.ParamLocationQuery, *params.PinnedToTaskFlag); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -12315,6 +12030,22 @@ func NewGetOrganizationMailMessagesRequest(server string, id int, params *GetOrg
 
 		}
 
+		if params.IncludeBody != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_body", runtime.ParamLocationQuery, *params.IncludeBody); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -12919,6 +12650,22 @@ func NewGetPersonMailMessagesRequest(server string, id int, params *GetPersonMai
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeBody != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_body", runtime.ParamLocationQuery, *params.IncludeBody); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -13749,529 +13496,6 @@ func NewGetProductUsersRequest(server string, id int) (*http.Request, error) {
 	return req, nil
 }
 
-// NewGetProjectTemplatesRequest generates requests for GetProjectTemplates
-func NewGetProjectTemplatesRequest(server string, params *GetProjectTemplatesParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projectTemplates")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Cursor != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectTemplateRequest generates requests for GetProjectTemplate
-func NewGetProjectTemplateRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projectTemplates/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectsRequest generates requests for GetProjects
-func NewGetProjectsRequest(server string, params *GetProjectsParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Cursor != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.FilterId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "filter_id", runtime.ParamLocationQuery, *params.FilterId); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Status != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.PhaseId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "phase_id", runtime.ParamLocationQuery, *params.PhaseId); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.IncludeArchived != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_archived", runtime.ParamLocationQuery, *params.IncludeArchived); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewAddProjectRequest calls the generic AddProject builder with application/json body
-func NewAddProjectRequest(server string, body AddProjectJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewAddProjectRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewAddProjectRequestWithBody generates requests for AddProject with any type of body
-func NewAddProjectRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewGetProjectsBoardsRequest generates requests for GetProjectsBoards
-func NewGetProjectsBoardsRequest(server string) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/boards")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectsBoardRequest generates requests for GetProjectsBoard
-func NewGetProjectsBoardRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/boards/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectsPhasesRequest generates requests for GetProjectsPhases
-func NewGetProjectsPhasesRequest(server string, params *GetProjectsPhasesParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/phases")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "board_id", runtime.ParamLocationQuery, params.BoardId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectsPhaseRequest generates requests for GetProjectsPhase
-func NewGetProjectsPhaseRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/phases/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewDeleteProjectRequest generates requests for DeleteProject
-func NewDeleteProjectRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetProjectRequest generates requests for GetProject
-func NewGetProjectRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewUpdateProjectRequest calls the generic UpdateProject builder with application/json body
-func NewUpdateProjectRequest(server string, id int, body UpdateProjectJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateProjectRequestWithBody(server, id, "application/json", bodyReader)
-}
-
-// NewUpdateProjectRequestWithBody generates requests for UpdateProject with any type of body
-func NewUpdateProjectRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewGetProjectActivitiesRequest generates requests for GetProjectActivities
 func NewGetProjectActivitiesRequest(server string, id int) (*http.Request, error) {
 	var err error
@@ -14299,40 +13523,6 @@ func NewGetProjectActivitiesRequest(server string, id int) (*http.Request, error
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewArchiveProjectRequest generates requests for ArchiveProject
-func NewArchiveProjectRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/projects/%s/archive", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -15333,290 +14523,6 @@ func NewGetStageDealsRequest(server string, id int, params *GetStageDealsParams)
 	return req, nil
 }
 
-// NewGetTasksRequest generates requests for GetTasks
-func NewGetTasksRequest(server string, params *GetTasksParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/tasks")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-		queryValues := queryURL.Query()
-
-		if params.Cursor != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Limit != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.AssigneeId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_id", runtime.ParamLocationQuery, *params.AssigneeId); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.ProjectId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "project_id", runtime.ParamLocationQuery, *params.ProjectId); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.ParentTaskId != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "parent_task_id", runtime.ParamLocationQuery, *params.ParentTaskId); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		if params.Done != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "done", runtime.ParamLocationQuery, *params.Done); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
-				}
-			}
-
-		}
-
-		queryURL.RawQuery = queryValues.Encode()
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewAddTaskRequest calls the generic AddTask builder with application/json body
-func NewAddTaskRequest(server string, body AddTaskJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewAddTaskRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewAddTaskRequestWithBody generates requests for AddTask with any type of body
-func NewAddTaskRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/tasks")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewDeleteTaskRequest generates requests for DeleteTask
-func NewDeleteTaskRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetTaskRequest generates requests for GetTask
-func NewGetTaskRequest(server string, id int) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewUpdateTaskRequest calls the generic UpdateTask builder with application/json body
-func NewUpdateTaskRequest(server string, id int, body UpdateTaskJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateTaskRequestWithBody(server, id, "application/json", bodyReader)
-}
-
-// NewUpdateTaskRequestWithBody generates requests for UpdateTask with any type of body
-func NewUpdateTaskRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewGetUserConnectionsRequest generates requests for GetUserConnections
 func NewGetUserConnectionsRequest(server string) (*http.Request, error) {
 	var err error
@@ -16335,9 +15241,9 @@ type ClientWithResponsesInterface interface {
 	GetFiltersWithResponse(ctx context.Context, params *GetFiltersParams, reqEditors ...RequestEditorFn) (*GetFiltersResponse, error)
 
 	// AddFilterWithBodyWithResponse request with any body
-	AddFilterWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddFilterResponse, error)
+	AddFilterWithBodyWithResponse(ctx context.Context, params *AddFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddFilterResponse, error)
 
-	AddFilterWithResponse(ctx context.Context, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*AddFilterResponse, error)
+	AddFilterWithResponse(ctx context.Context, params *AddFilterParams, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*AddFilterResponse, error)
 
 	// GetFilterHelpersWithResponse request
 	GetFilterHelpersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetFilterHelpersResponse, error)
@@ -16346,12 +15252,12 @@ type ClientWithResponsesInterface interface {
 	DeleteFilterWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteFilterResponse, error)
 
 	// GetFilterWithResponse request
-	GetFilterWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetFilterResponse, error)
+	GetFilterWithResponse(ctx context.Context, id int, params *GetFilterParams, reqEditors ...RequestEditorFn) (*GetFilterResponse, error)
 
 	// UpdateFilterWithBodyWithResponse request with any body
-	UpdateFilterWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error)
+	UpdateFilterWithBodyWithResponse(ctx context.Context, id int, params *UpdateFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error)
 
-	UpdateFilterWithResponse(ctx context.Context, id int, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error)
+	UpdateFilterWithResponse(ctx context.Context, id int, params *UpdateFilterParams, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error)
 
 	// AddGoalWithBodyWithResponse request with any body
 	AddGoalWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddGoalResponse, error)
@@ -16637,48 +15543,8 @@ type ClientWithResponsesInterface interface {
 	// GetProductUsersWithResponse request
 	GetProductUsersWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProductUsersResponse, error)
 
-	// GetProjectTemplatesWithResponse request
-	GetProjectTemplatesWithResponse(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*GetProjectTemplatesResponse, error)
-
-	// GetProjectTemplateWithResponse request
-	GetProjectTemplateWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectTemplateResponse, error)
-
-	// GetProjectsWithResponse request
-	GetProjectsWithResponse(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*GetProjectsResponse, error)
-
-	// AddProjectWithBodyWithResponse request with any body
-	AddProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectResponse, error)
-
-	AddProjectWithResponse(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectResponse, error)
-
-	// GetProjectsBoardsWithResponse request
-	GetProjectsBoardsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetProjectsBoardsResponse, error)
-
-	// GetProjectsBoardWithResponse request
-	GetProjectsBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsBoardResponse, error)
-
-	// GetProjectsPhasesWithResponse request
-	GetProjectsPhasesWithResponse(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*GetProjectsPhasesResponse, error)
-
-	// GetProjectsPhaseWithResponse request
-	GetProjectsPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsPhaseResponse, error)
-
-	// DeleteProjectWithResponse request
-	DeleteProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectResponse, error)
-
-	// GetProjectWithResponse request
-	GetProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectResponse, error)
-
-	// UpdateProjectWithBodyWithResponse request with any body
-	UpdateProjectWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
-
-	UpdateProjectWithResponse(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
-
 	// GetProjectActivitiesWithResponse request
 	GetProjectActivitiesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectActivitiesResponse, error)
-
-	// ArchiveProjectWithResponse request
-	ArchiveProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*ArchiveProjectResponse, error)
 
 	// GetProjectGroupsWithResponse request
 	GetProjectGroupsWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectGroupsResponse, error)
@@ -16752,25 +15618,6 @@ type ClientWithResponsesInterface interface {
 
 	// GetStageDealsWithResponse request
 	GetStageDealsWithResponse(ctx context.Context, id int, params *GetStageDealsParams, reqEditors ...RequestEditorFn) (*GetStageDealsResponse, error)
-
-	// GetTasksWithResponse request
-	GetTasksWithResponse(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*GetTasksResponse, error)
-
-	// AddTaskWithBodyWithResponse request with any body
-	AddTaskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddTaskResponse, error)
-
-	AddTaskWithResponse(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*AddTaskResponse, error)
-
-	// DeleteTaskWithResponse request
-	DeleteTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteTaskResponse, error)
-
-	// GetTaskWithResponse request
-	GetTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetTaskResponse, error)
-
-	// UpdateTaskWithBodyWithResponse request with any body
-	UpdateTaskWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error)
-
-	UpdateTaskWithResponse(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error)
 
 	// GetUserConnectionsWithResponse request
 	GetUserConnectionsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetUserConnectionsResponse, error)
@@ -19208,6 +18055,9 @@ type GetDealMailMessagesResponse struct {
 					Name *string `json:"name,omitempty"`
 				} `json:"bcc,omitempty"`
 
+				// Body The mail message body content. Only present when `include_body=1` is passed.
+				Body *string `json:"body,omitempty"`
+
 				// BodyUrl The mail message body URL
 				BodyUrl *string `json:"body_url,omitempty"`
 
@@ -19690,9 +18540,14 @@ type GetDealParticipantsResponse struct {
 			AddedByUserId *struct {
 				Data *struct {
 					Access *[]struct {
-						Admin           *bool                                                 `json:"admin,omitempty"`
-						App             *GetDealParticipants200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
-						PermissionSetId *string                                               `json:"permission_set_id,omitempty"`
+						// Admin Whether the user has admin access or not
+						Admin *bool `json:"admin,omitempty"`
+
+						// App The granular app access level
+						App *GetDealParticipants200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
+
+						// PermissionSetId The ID of the permission set
+						PermissionSetId *string `json:"permission_set_id,omitempty"`
 					} `json:"access,omitempty"`
 
 					// Activated Boolean that indicates whether the user is activated
@@ -20153,9 +19008,14 @@ type AddDealParticipantResponse struct {
 			AddedByUserId *struct {
 				Data *struct {
 					Access *[]struct {
-						Admin           *bool                                                `json:"admin,omitempty"`
-						App             *AddDealParticipant200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
-						PermissionSetId *string                                              `json:"permission_set_id,omitempty"`
+						// Admin Whether the user has admin access or not
+						Admin *bool `json:"admin,omitempty"`
+
+						// App The granular app access level
+						App *AddDealParticipant200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
+
+						// PermissionSetId The ID of the permission set
+						PermissionSetId *string `json:"permission_set_id,omitempty"`
 					} `json:"access,omitempty"`
 
 					// Activated Boolean that indicates whether the user is activated
@@ -20774,6 +19634,12 @@ type GetFilesResponse struct {
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
 
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
+
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
 
@@ -20885,6 +19751,12 @@ type AddFileResponse struct {
 
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
+
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
 
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
@@ -20998,6 +19870,12 @@ type AddFileAndLinkItResponse struct {
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
 
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
+
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
 
@@ -21109,6 +19987,12 @@ type LinkFileToItemResponse struct {
 
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
+
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
 
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
@@ -21252,6 +20136,12 @@ type GetFileResponse struct {
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
 
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
+
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
 
@@ -21364,6 +20254,12 @@ type UpdateFileResponse struct {
 			// ProductName The name of the product associated with the file
 			ProductName *string `json:"product_name,omitempty"`
 
+			// ProjectId The ID of the project to associate the file with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// ProjectName The name of the project associated with the file
+			ProjectName *string `json:"project_name,omitempty"`
+
 			// RemoteId The ID of the remote item
 			RemoteId *string `json:"remote_id,omitempty"`
 
@@ -21467,32 +20363,44 @@ type GetFiltersResponse struct {
 			// AddTime The date and time when the filter was added
 			AddTime *string `json:"add_time,omitempty"`
 
-			// CustomViewId Used by Pipedrive webapp
-			CustomViewId *int `json:"custom_view_id,omitempty"`
+			// CustomViewId The custom view ID linked to the filter
+			CustomViewId *int `json:"custom_view_id"`
+
+			// FilterCode The system code of the filter
+			FilterCode *string `json:"filter_code"`
 
 			// Id The ID of the filter
 			Id *int `json:"id,omitempty"`
 
+			// IsEditable Whether the filter can be edited by the requesting user
+			IsEditable *bool `json:"is_editable,omitempty"`
+
+			// LastUsedTime The date and time when the filter was last used
+			LastUsedTime *string `json:"last_used_time"`
+
 			// Name The name of the filter
 			Name *string `json:"name,omitempty"`
 
-			// Type The type of the item
-			Type *string `json:"type,omitempty"`
+			// TemporaryFlag Whether the filter is temporary
+			TemporaryFlag *bool                  `json:"temporary_flag"`
+			Type          *GetFilters200DataType `json:"type,omitempty"`
 
 			// UpdateTime The date and time when the filter was updated
-			UpdateTime *string `json:"update_time,omitempty"`
+			UpdateTime *string `json:"update_time"`
 
 			// UserId The owner of the filter
 			UserId *int `json:"user_id,omitempty"`
 
-			// VisibleTo The visibility group ID of who can see then filter
-			VisibleTo *int `json:"visible_to,omitempty"`
+			// VisibleTo The visibility group ID of who can see the filter
+			VisibleTo *GetFilters200DataVisibleTo `json:"visible_to,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
 		Success *bool `json:"success,omitempty"`
 	}
 }
+type GetFilters200DataType string
+type GetFilters200DataVisibleTo string
 
 // Status returns HTTPResponse.Status
 func (r GetFiltersResponse) Status() string {
@@ -21515,43 +20423,88 @@ type AddFilterResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Data *struct {
-			// ActiveFlag The activity flag of the created filter
+			// ActiveFlag The activity flag of the filter
 			ActiveFlag *bool `json:"active_flag,omitempty"`
 
-			// AddTime The add time of the created filter
+			// AddTime The date and time when the filter was added
 			AddTime *string `json:"add_time,omitempty"`
 
-			// Conditions The created filter conditions object
-			Conditions *map[string]interface{} `json:"conditions,omitempty"`
+			// Conditions The conditions object of a filter
+			Conditions *struct {
+				// Conditions The condition groups
+				Conditions *[]struct {
+					// Conditions The individual conditions in this group
+					Conditions *[]struct {
+						// ExtraValue An extra value for conditions that require two values
+						ExtraValue *string `json:"extra_value"`
 
-			// CustomViewId The custom view ID of the created filter
-			CustomViewId *int `json:"custom_view_id,omitempty"`
+						// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+						FieldCode *string `json:"field_code"`
 
-			// Id The ID of the created filter
+						// FieldId The ID of the field
+						FieldId *string `json:"field_id,omitempty"`
+
+						// JsonValueFlag Whether the value is JSON-encoded
+						JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+						// Object The type of entity the condition applies to (e.g. "deal", "person")
+						Object *string `json:"object,omitempty"`
+
+						// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+						Operator *string `json:"operator,omitempty"`
+
+						// Value The value of the condition
+						Value *string `json:"value"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The logical operator joining conditions within this group
+					Glue *AddFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// Glue The top-level glue is always "and"
+				Glue *AddFilter200DataConditionsGlue `json:"glue,omitempty"`
+			} `json:"conditions,omitempty"`
+
+			// CustomViewId The custom view ID linked to the filter
+			CustomViewId *int `json:"custom_view_id"`
+
+			// FilterCode The system code of the filter
+			FilterCode *string `json:"filter_code"`
+
+			// Id The ID of the filter
 			Id *int `json:"id,omitempty"`
 
-			// Name The name of the created filter
+			// IsEditable Whether the filter can be edited by the requesting user
+			IsEditable *bool `json:"is_editable,omitempty"`
+
+			// LastUsedTime The date and time when the filter was last used
+			LastUsedTime *string `json:"last_used_time"`
+
+			// Name The name of the filter
 			Name *string `json:"name,omitempty"`
 
-			// TemporaryFlag If the created filter is temporary or not
-			TemporaryFlag *bool                 `json:"temporary_flag,omitempty"`
+			// TemporaryFlag Whether the filter is temporary
+			TemporaryFlag *bool                 `json:"temporary_flag"`
 			Type          *AddFilter200DataType `json:"type,omitempty"`
 
-			// UpdateTime The update time of the created filter
-			UpdateTime *string `json:"update_time,omitempty"`
+			// UpdateTime The date and time when the filter was last updated
+			UpdateTime *string `json:"update_time"`
 
-			// UserId The user ID of the created filter
+			// UserId The user ID of the filter owner
 			UserId *int `json:"user_id,omitempty"`
 
-			// VisibleTo The visibility group ID of the created filter
-			VisibleTo *int `json:"visible_to,omitempty"`
+			// VisibleTo The visibility group ID of the filter
+			VisibleTo *AddFilter200DataVisibleTo `json:"visible_to,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
 		Success *bool `json:"success,omitempty"`
 	}
 }
+type AddFilter200DataConditionsConditionsGlue string
+type AddFilter200DataConditionsGlue string
 type AddFilter200DataType string
+type AddFilter200DataVisibleTo string
 
 // Status returns HTTPResponse.Status
 func (r AddFilterResponse) Status() string {
@@ -21625,7 +20578,7 @@ type GetFilterResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		// Data The filter object
+		// Data The filter object including conditions
 		Data *struct {
 			// ActiveFlag The active flag of the filter
 			ActiveFlag *bool `json:"active_flag,omitempty"`
@@ -21633,32 +20586,82 @@ type GetFilterResponse struct {
 			// AddTime The date and time when the filter was added
 			AddTime *string `json:"add_time,omitempty"`
 
-			// CustomViewId Used by Pipedrive webapp
-			CustomViewId *int `json:"custom_view_id,omitempty"`
+			// Conditions The conditions object of a filter
+			Conditions *struct {
+				// Conditions The condition groups
+				Conditions *[]struct {
+					// Conditions The individual conditions in this group
+					Conditions *[]struct {
+						// ExtraValue An extra value for conditions that require two values
+						ExtraValue *string `json:"extra_value"`
+
+						// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+						FieldCode *string `json:"field_code"`
+
+						// FieldId The ID of the field
+						FieldId *string `json:"field_id,omitempty"`
+
+						// JsonValueFlag Whether the value is JSON-encoded
+						JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+						// Object The type of entity the condition applies to (e.g. "deal", "person")
+						Object *string `json:"object,omitempty"`
+
+						// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+						Operator *string `json:"operator,omitempty"`
+
+						// Value The value of the condition
+						Value *string `json:"value"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The logical operator joining conditions within this group
+					Glue *GetFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// Glue The top-level glue is always "and"
+				Glue *GetFilter200DataConditionsGlue `json:"glue,omitempty"`
+			} `json:"conditions,omitempty"`
+
+			// CustomViewId The custom view ID linked to the filter
+			CustomViewId *int `json:"custom_view_id"`
+
+			// FilterCode The system code of the filter
+			FilterCode *string `json:"filter_code"`
 
 			// Id The ID of the filter
 			Id *int `json:"id,omitempty"`
 
+			// IsEditable Whether the filter can be edited by the requesting user
+			IsEditable *bool `json:"is_editable,omitempty"`
+
+			// LastUsedTime The date and time when the filter was last used
+			LastUsedTime *string `json:"last_used_time"`
+
 			// Name The name of the filter
 			Name *string `json:"name,omitempty"`
 
-			// Type The type of the item
-			Type *string `json:"type,omitempty"`
+			// TemporaryFlag Whether the filter is temporary
+			TemporaryFlag *bool                 `json:"temporary_flag"`
+			Type          *GetFilter200DataType `json:"type,omitempty"`
 
 			// UpdateTime The date and time when the filter was updated
-			UpdateTime *string `json:"update_time,omitempty"`
+			UpdateTime *string `json:"update_time"`
 
 			// UserId The owner of the filter
 			UserId *int `json:"user_id,omitempty"`
 
-			// VisibleTo The visibility group ID of who can see then filter
-			VisibleTo *int `json:"visible_to,omitempty"`
+			// VisibleTo The visibility group ID of who can see the filter
+			VisibleTo *GetFilter200DataVisibleTo `json:"visible_to,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
 		Success *bool `json:"success,omitempty"`
 	}
 }
+type GetFilter200DataConditionsConditionsGlue string
+type GetFilter200DataConditionsGlue string
+type GetFilter200DataType string
+type GetFilter200DataVisibleTo string
 
 // Status returns HTTPResponse.Status
 func (r GetFilterResponse) Status() string {
@@ -21681,43 +20684,88 @@ type UpdateFilterResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Data *struct {
-			// ActiveFlag The activity flag of the created filter
+			// ActiveFlag The activity flag of the filter
 			ActiveFlag *bool `json:"active_flag,omitempty"`
 
-			// AddTime The add time of the created filter
+			// AddTime The date and time when the filter was added
 			AddTime *string `json:"add_time,omitempty"`
 
-			// Conditions The created filter conditions object
-			Conditions *map[string]interface{} `json:"conditions,omitempty"`
+			// Conditions The conditions object of a filter
+			Conditions *struct {
+				// Conditions The condition groups
+				Conditions *[]struct {
+					// Conditions The individual conditions in this group
+					Conditions *[]struct {
+						// ExtraValue An extra value for conditions that require two values
+						ExtraValue *string `json:"extra_value"`
 
-			// CustomViewId The custom view ID of the created filter
-			CustomViewId *int `json:"custom_view_id,omitempty"`
+						// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+						FieldCode *string `json:"field_code"`
 
-			// Id The ID of the created filter
+						// FieldId The ID of the field
+						FieldId *string `json:"field_id,omitempty"`
+
+						// JsonValueFlag Whether the value is JSON-encoded
+						JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+						// Object The type of entity the condition applies to (e.g. "deal", "person")
+						Object *string `json:"object,omitempty"`
+
+						// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+						Operator *string `json:"operator,omitempty"`
+
+						// Value The value of the condition
+						Value *string `json:"value"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The logical operator joining conditions within this group
+					Glue *UpdateFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// Glue The top-level glue is always "and"
+				Glue *UpdateFilter200DataConditionsGlue `json:"glue,omitempty"`
+			} `json:"conditions,omitempty"`
+
+			// CustomViewId The custom view ID linked to the filter
+			CustomViewId *int `json:"custom_view_id"`
+
+			// FilterCode The system code of the filter
+			FilterCode *string `json:"filter_code"`
+
+			// Id The ID of the filter
 			Id *int `json:"id,omitempty"`
 
-			// Name The name of the created filter
+			// IsEditable Whether the filter can be edited by the requesting user
+			IsEditable *bool `json:"is_editable,omitempty"`
+
+			// LastUsedTime The date and time when the filter was last used
+			LastUsedTime *string `json:"last_used_time"`
+
+			// Name The name of the filter
 			Name *string `json:"name,omitempty"`
 
-			// TemporaryFlag If the created filter is temporary or not
-			TemporaryFlag *bool                    `json:"temporary_flag,omitempty"`
+			// TemporaryFlag Whether the filter is temporary
+			TemporaryFlag *bool                    `json:"temporary_flag"`
 			Type          *UpdateFilter200DataType `json:"type,omitempty"`
 
-			// UpdateTime The update time of the created filter
-			UpdateTime *string `json:"update_time,omitempty"`
+			// UpdateTime The date and time when the filter was last updated
+			UpdateTime *string `json:"update_time"`
 
-			// UserId The user ID of the created filter
+			// UserId The user ID of the filter owner
 			UserId *int `json:"user_id,omitempty"`
 
-			// VisibleTo The visibility group ID of the created filter
-			VisibleTo *int `json:"visible_to,omitempty"`
+			// VisibleTo The visibility group ID of the filter
+			VisibleTo *UpdateFilter200DataVisibleTo `json:"visible_to,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
 		Success *bool `json:"success,omitempty"`
 	}
 }
+type UpdateFilter200DataConditionsConditionsGlue string
+type UpdateFilter200DataConditionsGlue string
 type UpdateFilter200DataType string
+type UpdateFilter200DataVisibleTo string
 
 // Status returns HTTPResponse.Status
 func (r UpdateFilterResponse) Status() string {
@@ -23474,6 +22522,9 @@ type GetMailMessageResponse struct {
 				Name *string `json:"name,omitempty"`
 			} `json:"bcc,omitempty"`
 
+			// Body The mail message body content. Only present when `include_body=1` is passed.
+			Body *string `json:"body,omitempty"`
+
 			// BodyUrl The mail message body URL
 			BodyUrl *string `json:"body_url,omitempty"`
 
@@ -24777,6 +23828,9 @@ type GetNotesResponse struct {
 			// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 			PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+			// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+			PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 			// Project The project the note is attached to
 			Project *struct {
 				// Title The title of the project the note is attached to
@@ -24785,6 +23839,15 @@ type GetNotesResponse struct {
 
 			// ProjectId The ID of the project the note is attached to
 			ProjectId *int `json:"project_id,omitempty"`
+
+			// Task The task the note is attached to
+			Task *struct {
+				// Title The title of the task the note is attached to
+				Title *string `json:"title,omitempty"`
+			} `json:"task,omitempty"`
+
+			// TaskId The ID of the task the note is attached to
+			TaskId *int `json:"task_id,omitempty"`
 
 			// UpdateTime The last updated date and time of the note
 			UpdateTime *string `json:"update_time,omitempty"`
@@ -24891,6 +23954,9 @@ type AddNoteResponse struct {
 			// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 			PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+			// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+			PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 			// Project The project the note is attached to
 			Project *struct {
 				// Title The title of the project the note is attached to
@@ -24899,6 +23965,15 @@ type AddNoteResponse struct {
 
 			// ProjectId The ID of the project the note is attached to
 			ProjectId *int `json:"project_id,omitempty"`
+
+			// Task The task the note is attached to
+			Task *struct {
+				// Title The title of the task the note is attached to
+				Title *string `json:"title,omitempty"`
+			} `json:"task,omitempty"`
+
+			// TaskId The ID of the task the note is attached to
+			TaskId *int `json:"task_id,omitempty"`
 
 			// UpdateTime The last updated date and time of the note
 			UpdateTime *string `json:"update_time,omitempty"`
@@ -25033,6 +24108,9 @@ type GetNoteResponse struct {
 			// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 			PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+			// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+			PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 			// Project The project the note is attached to
 			Project *struct {
 				// Title The title of the project the note is attached to
@@ -25041,6 +24119,15 @@ type GetNoteResponse struct {
 
 			// ProjectId The ID of the project the note is attached to
 			ProjectId *int `json:"project_id,omitempty"`
+
+			// Task The task the note is attached to
+			Task *struct {
+				// Title The title of the task the note is attached to
+				Title *string `json:"title,omitempty"`
+			} `json:"task,omitempty"`
+
+			// TaskId The ID of the task the note is attached to
+			TaskId *int `json:"task_id,omitempty"`
 
 			// UpdateTime The last updated date and time of the note
 			UpdateTime *string `json:"update_time,omitempty"`
@@ -25147,6 +24234,9 @@ type UpdateNoteResponse struct {
 			// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 			PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+			// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+			PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 			// Project The project the note is attached to
 			Project *struct {
 				// Title The title of the project the note is attached to
@@ -25155,6 +24245,15 @@ type UpdateNoteResponse struct {
 
 			// ProjectId The ID of the project the note is attached to
 			ProjectId *int `json:"project_id,omitempty"`
+
+			// Task The task the note is attached to
+			Task *struct {
+				// Title The title of the task the note is attached to
+				Title *string `json:"title,omitempty"`
+			} `json:"task,omitempty"`
+
+			// TaskId The ID of the task the note is attached to
+			TaskId *int `json:"task_id,omitempty"`
 
 			// UpdateTime The last updated date and time of the note
 			UpdateTime *string `json:"update_time,omitempty"`
@@ -26396,6 +25495,9 @@ type GetOrganizationMailMessagesResponse struct {
 					Name *string `json:"name,omitempty"`
 				} `json:"bcc,omitempty"`
 
+				// Body The mail message body content. Only present when `include_body=1` is passed.
+				Body *string `json:"body,omitempty"`
+
 				// BodyUrl The mail message body URL
 				BodyUrl *string `json:"body_url,omitempty"`
 
@@ -27196,6 +26298,9 @@ type GetPersonMailMessagesResponse struct {
 					// Name Name of the mail participant
 					Name *string `json:"name,omitempty"`
 				} `json:"bcc,omitempty"`
+
+				// Body The mail message body content. Only present when `include_body=1` is passed.
+				Body *string `json:"body,omitempty"`
 
 				// BodyUrl The mail message body URL
 				BodyUrl *string `json:"body_url,omitempty"`
@@ -29044,620 +28149,6 @@ func (r GetProductUsersResponse) StatusCode() int {
 	return 0
 }
 
-type GetProjectTemplatesResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		// AdditionalData The additional data of the list
-		AdditionalData *struct {
-			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-			NextCursor *string `json:"next_cursor,omitempty"`
-		} `json:"additional_data,omitempty"`
-		Data *[]struct {
-			// AddTime The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// Description The description of a template
-			Description *string `json:"description,omitempty"`
-
-			// Id The ID of a template
-			Id *float32 `json:"id,omitempty"`
-
-			// OwnerId The ID of a template owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// ProjectsBoardId The ID of the project board this template is associated with
-			ProjectsBoardId *float32 `json:"projects_board_id,omitempty"`
-
-			// Title The title of a template
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectTemplatesResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectTemplatesResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectTemplateResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// Description The description of a template
-			Description *string `json:"description,omitempty"`
-
-			// Id The ID of a template
-			Id *float32 `json:"id,omitempty"`
-
-			// OwnerId The ID of a template owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// ProjectsBoardId The ID of the project board this template is associated with
-			ProjectsBoardId *float32 `json:"projects_board_id,omitempty"`
-
-			// Title The title of a template
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectTemplateResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectTemplateResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectsResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		// AdditionalData The additional data of the list
-		AdditionalData *struct {
-			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-			NextCursor *string `json:"next_cursor,omitempty"`
-		} `json:"additional_data,omitempty"`
-		Data *[]struct {
-			// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-			ArchiveTime *string `json:"archive_time,omitempty"`
-
-			// BoardId The ID of the board this project is associated with
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// DealIds An array of IDs of the deals this project is associated with
-			DealIds *[]int `json:"deal_ids,omitempty"`
-
-			// Description The description of the project
-			Description *string `json:"description,omitempty"`
-
-			// EndDate The end date of the project. Format: YYYY-MM-DD.
-			EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-			// Id The ID of the project, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// Labels An array of IDs of the labels this project has
-			Labels *[]int `json:"labels,omitempty"`
-
-			// OrgId The ID of the organization this project is associated with
-			OrgId *float32 `json:"org_id,omitempty"`
-
-			// OwnerId The ID of a project owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// PersonId The ID of the person this project is associated with
-			PersonId *float32 `json:"person_id,omitempty"`
-
-			// PhaseId The ID of the phase this project is associated with
-			PhaseId *float32 `json:"phase_id,omitempty"`
-
-			// StartDate The start date of the project. Format: YYYY-MM-DD.
-			StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-			// Status The status of the project
-			Status *string `json:"status,omitempty"`
-
-			// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-			// Title The title of the project
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectsResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type AddProjectResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-			ArchiveTime *string `json:"archive_time,omitempty"`
-
-			// BoardId The ID of the board this project is associated with
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// DealIds An array of IDs of the deals this project is associated with
-			DealIds *[]int `json:"deal_ids,omitempty"`
-
-			// Description The description of the project
-			Description *string `json:"description,omitempty"`
-
-			// EndDate The end date of the project. Format: YYYY-MM-DD.
-			EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-			// Id The ID of the project, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// Labels An array of IDs of the labels this project has
-			Labels *[]int `json:"labels,omitempty"`
-
-			// OrgId The ID of the organization this project is associated with
-			OrgId *float32 `json:"org_id,omitempty"`
-
-			// OwnerId The ID of a project owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// PersonId The ID of the person this project is associated with
-			PersonId *float32 `json:"person_id,omitempty"`
-
-			// PhaseId The ID of the phase this project is associated with
-			PhaseId *float32 `json:"phase_id,omitempty"`
-
-			// StartDate The start date of the project. Format: YYYY-MM-DD.
-			StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-			// Status The status of the project
-			Status *string `json:"status,omitempty"`
-
-			// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-			// Title The title of the project
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r AddProjectResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r AddProjectResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectsBoardsResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *[]struct {
-			// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// Id The ID of the project board
-			Id *int `json:"id,omitempty"`
-
-			// Name Name of a project board
-			Name *string `json:"name,omitempty"`
-
-			// OrderNr The order of a board
-			OrderNr *float32 `json:"order_nr,omitempty"`
-
-			// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectsBoardsResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectsBoardsResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectsBoardResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// Id The ID of the project board
-			Id *int `json:"id,omitempty"`
-
-			// Name Name of a project board
-			Name *string `json:"name,omitempty"`
-
-			// OrderNr The order of a board
-			OrderNr *float32 `json:"order_nr,omitempty"`
-
-			// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectsBoardResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectsBoardResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectsPhasesResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *[]struct {
-			// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// BoardId The ID of the project board this phase is linked to
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// Id The ID of the project phase
-			Id *int `json:"id,omitempty"`
-
-			// Name Name of a project phase
-			Name *string `json:"name,omitempty"`
-
-			// OrderNr The order of a phase
-			OrderNr *float32 `json:"order_nr,omitempty"`
-
-			// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectsPhasesResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectsPhasesResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectsPhaseResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// BoardId The ID of the project board this phase is linked to
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// Id The ID of the project phase
-			Id *int `json:"id,omitempty"`
-
-			// Name Name of a project phase
-			Name *string `json:"name,omitempty"`
-
-			// OrderNr The order of a phase
-			OrderNr *float32 `json:"order_nr,omitempty"`
-
-			// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectsPhaseResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectsPhaseResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type DeleteProjectResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			Data *struct {
-				// Id The ID of the project that was deleted
-				Id *int `json:"id,omitempty"`
-			} `json:"data,omitempty"`
-
-			// Success If the request was successful or not
-			Success *bool `json:"success,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r DeleteProjectResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DeleteProjectResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetProjectResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-			ArchiveTime *string `json:"archive_time,omitempty"`
-
-			// BoardId The ID of the board this project is associated with
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// DealIds An array of IDs of the deals this project is associated with
-			DealIds *[]int `json:"deal_ids,omitempty"`
-
-			// Description The description of the project
-			Description *string `json:"description,omitempty"`
-
-			// EndDate The end date of the project. Format: YYYY-MM-DD.
-			EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-			// Id The ID of the project, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// Labels An array of IDs of the labels this project has
-			Labels *[]int `json:"labels,omitempty"`
-
-			// OrgId The ID of the organization this project is associated with
-			OrgId *float32 `json:"org_id,omitempty"`
-
-			// OwnerId The ID of a project owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// PersonId The ID of the person this project is associated with
-			PersonId *float32 `json:"person_id,omitempty"`
-
-			// PhaseId The ID of the phase this project is associated with
-			PhaseId *float32 `json:"phase_id,omitempty"`
-
-			// StartDate The start date of the project. Format: YYYY-MM-DD.
-			StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-			// Status The status of the project
-			Status *string `json:"status,omitempty"`
-
-			// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-			// Title The title of the project
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r GetProjectResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetProjectResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type UpdateProjectResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-			ArchiveTime *string `json:"archive_time,omitempty"`
-
-			// BoardId The ID of the board this project is associated with
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// DealIds An array of IDs of the deals this project is associated with
-			DealIds *[]int `json:"deal_ids,omitempty"`
-
-			// Description The description of the project
-			Description *string `json:"description,omitempty"`
-
-			// EndDate The end date of the project. Format: YYYY-MM-DD.
-			EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-			// Id The ID of the project, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// Labels An array of IDs of the labels this project has
-			Labels *[]int `json:"labels,omitempty"`
-
-			// OrgId The ID of the organization this project is associated with
-			OrgId *float32 `json:"org_id,omitempty"`
-
-			// OwnerId The ID of a project owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// PersonId The ID of the person this project is associated with
-			PersonId *float32 `json:"person_id,omitempty"`
-
-			// PhaseId The ID of the phase this project is associated with
-			PhaseId *float32 `json:"phase_id,omitempty"`
-
-			// StartDate The start date of the project. Format: YYYY-MM-DD.
-			StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-			// Status The status of the project
-			Status *string `json:"status,omitempty"`
-
-			// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-			// Title The title of the project
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r UpdateProjectResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r UpdateProjectResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type GetProjectActivitiesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -29790,83 +28281,6 @@ func (r GetProjectActivitiesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetProjectActivitiesResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type ArchiveProjectResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-			ArchiveTime *string `json:"archive_time,omitempty"`
-
-			// BoardId The ID of the board this project is associated with
-			BoardId *float32 `json:"board_id,omitempty"`
-
-			// DealIds An array of IDs of the deals this project is associated with
-			DealIds *[]int `json:"deal_ids,omitempty"`
-
-			// Description The description of the project
-			Description *string `json:"description,omitempty"`
-
-			// EndDate The end date of the project. Format: YYYY-MM-DD.
-			EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-			// Id The ID of the project, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// Labels An array of IDs of the labels this project has
-			Labels *[]int `json:"labels,omitempty"`
-
-			// OrgId The ID of the organization this project is associated with
-			OrgId *float32 `json:"org_id,omitempty"`
-
-			// OwnerId The ID of a project owner
-			OwnerId *float32 `json:"owner_id,omitempty"`
-
-			// PersonId The ID of the person this project is associated with
-			PersonId *float32 `json:"person_id,omitempty"`
-
-			// PhaseId The ID of the phase this project is associated with
-			PhaseId *float32 `json:"phase_id,omitempty"`
-
-			// StartDate The start date of the project. Format: YYYY-MM-DD.
-			StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-			// Status The status of the project
-			Status *string `json:"status,omitempty"`
-
-			// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-			// Title The title of the project
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r ArchiveProjectResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r ArchiveProjectResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -30035,8 +28449,11 @@ type GetProjectTasksResponse struct {
 			// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
 			AddTime *string `json:"add_time,omitempty"`
 
-			// AssigneeId The ID of the user who will be the assignee of the task
+			// AssigneeId The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.
 			AssigneeId *float32 `json:"assignee_id,omitempty"`
+
+			// AssigneeIds The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.
+			AssigneeIds *[]float32 `json:"assignee_ids,omitempty"`
 
 			// CreatorId The creator of a task
 			CreatorId *float32 `json:"creator_id,omitempty"`
@@ -30678,30 +29095,42 @@ type GetRecents200Data4 struct {
 		// AddTime The date and time when the filter was added
 		AddTime *string `json:"add_time,omitempty"`
 
-		// CustomViewId Used by Pipedrive webapp
-		CustomViewId *int `json:"custom_view_id,omitempty"`
+		// CustomViewId The custom view ID linked to the filter
+		CustomViewId *int `json:"custom_view_id"`
+
+		// FilterCode The system code of the filter
+		FilterCode *string `json:"filter_code"`
 
 		// Id The ID of the filter
 		Id *int `json:"id,omitempty"`
 
+		// IsEditable Whether the filter can be edited by the requesting user
+		IsEditable *bool `json:"is_editable,omitempty"`
+
+		// LastUsedTime The date and time when the filter was last used
+		LastUsedTime *string `json:"last_used_time"`
+
 		// Name The name of the filter
 		Name *string `json:"name,omitempty"`
 
-		// Type The type of the item
-		Type *string `json:"type,omitempty"`
+		// TemporaryFlag Whether the filter is temporary
+		TemporaryFlag *bool                       `json:"temporary_flag"`
+		Type          *GetRecents200Data4DataType `json:"type,omitempty"`
 
 		// UpdateTime The date and time when the filter was updated
-		UpdateTime *string `json:"update_time,omitempty"`
+		UpdateTime *string `json:"update_time"`
 
 		// UserId The owner of the filter
 		UserId *int `json:"user_id,omitempty"`
 
-		// VisibleTo The visibility group ID of who can see then filter
-		VisibleTo *int `json:"visible_to,omitempty"`
+		// VisibleTo The visibility group ID of who can see the filter
+		VisibleTo *GetRecents200Data4DataVisibleTo `json:"visible_to,omitempty"`
 	} `json:"data,omitempty"`
 	Id   *int                    `json:"id,omitempty"`
 	Item *GetRecents200Data4Item `json:"item,omitempty"`
 }
+type GetRecents200Data4DataType string
+type GetRecents200Data4DataVisibleTo string
 type GetRecents200Data4Item string
 type GetRecents200Data5 struct {
 	Data *struct {
@@ -30762,6 +29191,9 @@ type GetRecents200Data5 struct {
 		// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 		PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+		// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+		PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 		// Project The project the note is attached to
 		Project *struct {
 			// Title The title of the project the note is attached to
@@ -30770,6 +29202,15 @@ type GetRecents200Data5 struct {
 
 		// ProjectId The ID of the project the note is attached to
 		ProjectId *int `json:"project_id,omitempty"`
+
+		// Task The task the note is attached to
+		Task *struct {
+			// Title The title of the task the note is attached to
+			Title *string `json:"title,omitempty"`
+		} `json:"task,omitempty"`
+
+		// TaskId The ID of the task the note is attached to
+		TaskId *int `json:"task_id,omitempty"`
 
 		// UpdateTime The last updated date and time of the note
 		UpdateTime *string `json:"update_time,omitempty"`
@@ -31296,9 +29737,14 @@ type GetRecents200Data10Item string
 type GetRecents200Data11 struct {
 	Data *struct {
 		Access *[]struct {
-			Admin           *bool                             `json:"admin,omitempty"`
-			App             *GetRecents200Data11DataAccessApp `json:"app,omitempty"`
-			PermissionSetId *string                           `json:"permission_set_id,omitempty"`
+			// Admin Whether the user has admin access or not
+			Admin *bool `json:"admin,omitempty"`
+
+			// App The granular app access level
+			App *GetRecents200Data11DataAccessApp `json:"app,omitempty"`
+
+			// PermissionSetId The ID of the permission set
+			PermissionSetId *string `json:"permission_set_id,omitempty"`
 		} `json:"access,omitempty"`
 
 		// Activated Boolean that indicates whether the user is activated
@@ -32171,296 +30617,6 @@ func (r GetStageDealsResponse) StatusCode() int {
 	return 0
 }
 
-type GetTasksResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		// AdditionalData The additional data of the list
-		AdditionalData *struct {
-			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-			NextCursor *string `json:"next_cursor,omitempty"`
-		} `json:"additional_data,omitempty"`
-		Data *[]struct {
-			// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// AssigneeId The ID of the user who will be the assignee of the task
-			AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-			// CreatorId The creator of a task
-			CreatorId *float32 `json:"creator_id,omitempty"`
-
-			// Description The description of the task
-			Description *string `json:"description,omitempty"`
-
-			// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-			Done *GetTasks200DataDone `json:"done,omitempty"`
-
-			// DueDate The due date of the task. Format: YYYY-MM-DD.
-			DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-			// Id The ID of the task, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-			// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-			ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-			// ProjectId The ID of the project this task is associated with
-			ProjectId *float32 `json:"project_id,omitempty"`
-
-			// Title The title of the task
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-type GetTasks200DataDone float32
-
-// Status returns HTTPResponse.Status
-func (r GetTasksResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetTasksResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type AddTaskResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON201      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// AssigneeId The ID of the user who will be the assignee of the task
-			AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-			// CreatorId The creator of a task
-			CreatorId *float32 `json:"creator_id,omitempty"`
-
-			// Description The description of the task
-			Description *string `json:"description,omitempty"`
-
-			// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-			Done *AddTask201DataDone `json:"done,omitempty"`
-
-			// DueDate The due date of the task. Format: YYYY-MM-DD.
-			DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-			// Id The ID of the task, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-			// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-			ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-			// ProjectId The ID of the project this task is associated with
-			ProjectId *float32 `json:"project_id,omitempty"`
-
-			// Title The title of the task
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-type AddTask201DataDone float32
-
-// Status returns HTTPResponse.Status
-func (r AddTaskResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r AddTaskResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type DeleteTaskResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			Data *struct {
-				// Id The ID of the task that was deleted
-				Id *int `json:"id,omitempty"`
-			} `json:"data,omitempty"`
-
-			// Success If the request was successful or not
-			Success *bool `json:"success,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-
-// Status returns HTTPResponse.Status
-func (r DeleteTaskResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DeleteTaskResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetTaskResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// AssigneeId The ID of the user who will be the assignee of the task
-			AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-			// CreatorId The creator of a task
-			CreatorId *float32 `json:"creator_id,omitempty"`
-
-			// Description The description of the task
-			Description *string `json:"description,omitempty"`
-
-			// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-			Done *GetTask200DataDone `json:"done,omitempty"`
-
-			// DueDate The due date of the task. Format: YYYY-MM-DD.
-			DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-			// Id The ID of the task, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-			// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-			ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-			// ProjectId The ID of the project this task is associated with
-			ProjectId *float32 `json:"project_id,omitempty"`
-
-			// Title The title of the task
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-type GetTask200DataDone float32
-
-// Status returns HTTPResponse.Status
-func (r GetTaskResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetTaskResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type UpdateTaskResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		AdditionalData *map[string]interface{} `json:"additional_data"`
-		Data           *struct {
-			// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			AddTime *string `json:"add_time,omitempty"`
-
-			// AssigneeId The ID of the user who will be the assignee of the task
-			AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-			// CreatorId The creator of a task
-			CreatorId *float32 `json:"creator_id,omitempty"`
-
-			// Description The description of the task
-			Description *string `json:"description,omitempty"`
-
-			// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-			Done *UpdateTask200DataDone `json:"done,omitempty"`
-
-			// DueDate The due date of the task. Format: YYYY-MM-DD.
-			DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-			// Id The ID of the task, generated when the task was created
-			Id *int `json:"id,omitempty"`
-
-			// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-			// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-			ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-			// ProjectId The ID of the project this task is associated with
-			ProjectId *float32 `json:"project_id,omitempty"`
-
-			// Title The title of the task
-			Title *string `json:"title,omitempty"`
-
-			// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-			UpdateTime *string `json:"update_time,omitempty"`
-		} `json:"data,omitempty"`
-		Success *bool `json:"success,omitempty"`
-	}
-}
-type UpdateTask200DataDone float32
-
-// Status returns HTTPResponse.Status
-func (r UpdateTaskResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r UpdateTaskResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type GetUserConnectionsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -32569,9 +30725,14 @@ type GetUsersResponse struct {
 	JSON200      *struct {
 		Data *[]struct {
 			Access *[]struct {
-				Admin           *bool                     `json:"admin,omitempty"`
-				App             *GetUsers200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                   `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *GetUsers200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -32660,9 +30821,14 @@ type AddUserResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			Access *[]struct {
-				Admin           *bool                    `json:"admin,omitempty"`
-				App             *AddUser200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                  `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *AddUser200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -32758,9 +30924,14 @@ type FindUsersByNameResponse struct {
 	JSON200      *struct {
 		Data *[]struct {
 			Access *[]struct {
-				Admin           *bool                            `json:"admin,omitempty"`
-				App             *FindUsersByName200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                          `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *FindUsersByName200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -32849,9 +31020,14 @@ type GetCurrentUserResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			Access *[]struct {
-				Admin           *bool                           `json:"admin,omitempty"`
-				App             *GetCurrentUser200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                         `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *GetCurrentUser200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -32974,9 +31150,14 @@ type GetUserResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			Access *[]struct {
-				Admin           *bool                    `json:"admin,omitempty"`
-				App             *GetUser200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                  `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *GetUser200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -33072,9 +31253,14 @@ type UpdateUserResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			Access *[]struct {
-				Admin           *bool                       `json:"admin,omitempty"`
-				App             *UpdateUser200DataAccessApp `json:"app,omitempty"`
-				PermissionSetId *string                     `json:"permission_set_id,omitempty"`
+				// Admin Whether the user has admin access or not
+				Admin *bool `json:"admin,omitempty"`
+
+				// App The granular app access level
+				App *UpdateUser200DataAccessApp `json:"app,omitempty"`
+
+				// PermissionSetId The ID of the permission set
+				PermissionSetId *string `json:"permission_set_id,omitempty"`
 			} `json:"access,omitempty"`
 
 			// Activated Boolean that indicates whether the user is activated
@@ -34121,16 +32307,16 @@ func (c *ClientWithResponses) GetFiltersWithResponse(ctx context.Context, params
 }
 
 // AddFilterWithBodyWithResponse request with arbitrary body returning *AddFilterResponse
-func (c *ClientWithResponses) AddFilterWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddFilterResponse, error) {
-	rsp, err := c.AddFilterWithBody(ctx, contentType, body, reqEditors...)
+func (c *ClientWithResponses) AddFilterWithBodyWithResponse(ctx context.Context, params *AddFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddFilterResponse, error) {
+	rsp, err := c.AddFilterWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseAddFilterResponse(rsp)
 }
 
-func (c *ClientWithResponses) AddFilterWithResponse(ctx context.Context, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*AddFilterResponse, error) {
-	rsp, err := c.AddFilter(ctx, body, reqEditors...)
+func (c *ClientWithResponses) AddFilterWithResponse(ctx context.Context, params *AddFilterParams, body AddFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*AddFilterResponse, error) {
+	rsp, err := c.AddFilter(ctx, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -34156,8 +32342,8 @@ func (c *ClientWithResponses) DeleteFilterWithResponse(ctx context.Context, id i
 }
 
 // GetFilterWithResponse request returning *GetFilterResponse
-func (c *ClientWithResponses) GetFilterWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetFilterResponse, error) {
-	rsp, err := c.GetFilter(ctx, id, reqEditors...)
+func (c *ClientWithResponses) GetFilterWithResponse(ctx context.Context, id int, params *GetFilterParams, reqEditors ...RequestEditorFn) (*GetFilterResponse, error) {
+	rsp, err := c.GetFilter(ctx, id, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -34165,16 +32351,16 @@ func (c *ClientWithResponses) GetFilterWithResponse(ctx context.Context, id int,
 }
 
 // UpdateFilterWithBodyWithResponse request with arbitrary body returning *UpdateFilterResponse
-func (c *ClientWithResponses) UpdateFilterWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error) {
-	rsp, err := c.UpdateFilterWithBody(ctx, id, contentType, body, reqEditors...)
+func (c *ClientWithResponses) UpdateFilterWithBodyWithResponse(ctx context.Context, id int, params *UpdateFilterParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error) {
+	rsp, err := c.UpdateFilterWithBody(ctx, id, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUpdateFilterResponse(rsp)
 }
 
-func (c *ClientWithResponses) UpdateFilterWithResponse(ctx context.Context, id int, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error) {
-	rsp, err := c.UpdateFilter(ctx, id, body, reqEditors...)
+func (c *ClientWithResponses) UpdateFilterWithResponse(ctx context.Context, id int, params *UpdateFilterParams, body UpdateFilterJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFilterResponse, error) {
+	rsp, err := c.UpdateFilter(ctx, id, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -35077,121 +33263,6 @@ func (c *ClientWithResponses) GetProductUsersWithResponse(ctx context.Context, i
 	return ParseGetProductUsersResponse(rsp)
 }
 
-// GetProjectTemplatesWithResponse request returning *GetProjectTemplatesResponse
-func (c *ClientWithResponses) GetProjectTemplatesWithResponse(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*GetProjectTemplatesResponse, error) {
-	rsp, err := c.GetProjectTemplates(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectTemplatesResponse(rsp)
-}
-
-// GetProjectTemplateWithResponse request returning *GetProjectTemplateResponse
-func (c *ClientWithResponses) GetProjectTemplateWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectTemplateResponse, error) {
-	rsp, err := c.GetProjectTemplate(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectTemplateResponse(rsp)
-}
-
-// GetProjectsWithResponse request returning *GetProjectsResponse
-func (c *ClientWithResponses) GetProjectsWithResponse(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*GetProjectsResponse, error) {
-	rsp, err := c.GetProjects(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectsResponse(rsp)
-}
-
-// AddProjectWithBodyWithResponse request with arbitrary body returning *AddProjectResponse
-func (c *ClientWithResponses) AddProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectResponse, error) {
-	rsp, err := c.AddProjectWithBody(ctx, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseAddProjectResponse(rsp)
-}
-
-func (c *ClientWithResponses) AddProjectWithResponse(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectResponse, error) {
-	rsp, err := c.AddProject(ctx, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseAddProjectResponse(rsp)
-}
-
-// GetProjectsBoardsWithResponse request returning *GetProjectsBoardsResponse
-func (c *ClientWithResponses) GetProjectsBoardsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetProjectsBoardsResponse, error) {
-	rsp, err := c.GetProjectsBoards(ctx, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectsBoardsResponse(rsp)
-}
-
-// GetProjectsBoardWithResponse request returning *GetProjectsBoardResponse
-func (c *ClientWithResponses) GetProjectsBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsBoardResponse, error) {
-	rsp, err := c.GetProjectsBoard(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectsBoardResponse(rsp)
-}
-
-// GetProjectsPhasesWithResponse request returning *GetProjectsPhasesResponse
-func (c *ClientWithResponses) GetProjectsPhasesWithResponse(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*GetProjectsPhasesResponse, error) {
-	rsp, err := c.GetProjectsPhases(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectsPhasesResponse(rsp)
-}
-
-// GetProjectsPhaseWithResponse request returning *GetProjectsPhaseResponse
-func (c *ClientWithResponses) GetProjectsPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsPhaseResponse, error) {
-	rsp, err := c.GetProjectsPhase(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectsPhaseResponse(rsp)
-}
-
-// DeleteProjectWithResponse request returning *DeleteProjectResponse
-func (c *ClientWithResponses) DeleteProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectResponse, error) {
-	rsp, err := c.DeleteProject(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteProjectResponse(rsp)
-}
-
-// GetProjectWithResponse request returning *GetProjectResponse
-func (c *ClientWithResponses) GetProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectResponse, error) {
-	rsp, err := c.GetProject(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetProjectResponse(rsp)
-}
-
-// UpdateProjectWithBodyWithResponse request with arbitrary body returning *UpdateProjectResponse
-func (c *ClientWithResponses) UpdateProjectWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error) {
-	rsp, err := c.UpdateProjectWithBody(ctx, id, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateProjectResponse(rsp)
-}
-
-func (c *ClientWithResponses) UpdateProjectWithResponse(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error) {
-	rsp, err := c.UpdateProject(ctx, id, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateProjectResponse(rsp)
-}
-
 // GetProjectActivitiesWithResponse request returning *GetProjectActivitiesResponse
 func (c *ClientWithResponses) GetProjectActivitiesWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectActivitiesResponse, error) {
 	rsp, err := c.GetProjectActivities(ctx, id, reqEditors...)
@@ -35199,15 +33270,6 @@ func (c *ClientWithResponses) GetProjectActivitiesWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseGetProjectActivitiesResponse(rsp)
-}
-
-// ArchiveProjectWithResponse request returning *ArchiveProjectResponse
-func (c *ClientWithResponses) ArchiveProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*ArchiveProjectResponse, error) {
-	rsp, err := c.ArchiveProject(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseArchiveProjectResponse(rsp)
 }
 
 // GetProjectGroupsWithResponse request returning *GetProjectGroupsResponse
@@ -35443,67 +33505,6 @@ func (c *ClientWithResponses) GetStageDealsWithResponse(ctx context.Context, id 
 		return nil, err
 	}
 	return ParseGetStageDealsResponse(rsp)
-}
-
-// GetTasksWithResponse request returning *GetTasksResponse
-func (c *ClientWithResponses) GetTasksWithResponse(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*GetTasksResponse, error) {
-	rsp, err := c.GetTasks(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetTasksResponse(rsp)
-}
-
-// AddTaskWithBodyWithResponse request with arbitrary body returning *AddTaskResponse
-func (c *ClientWithResponses) AddTaskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddTaskResponse, error) {
-	rsp, err := c.AddTaskWithBody(ctx, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseAddTaskResponse(rsp)
-}
-
-func (c *ClientWithResponses) AddTaskWithResponse(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*AddTaskResponse, error) {
-	rsp, err := c.AddTask(ctx, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseAddTaskResponse(rsp)
-}
-
-// DeleteTaskWithResponse request returning *DeleteTaskResponse
-func (c *ClientWithResponses) DeleteTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteTaskResponse, error) {
-	rsp, err := c.DeleteTask(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteTaskResponse(rsp)
-}
-
-// GetTaskWithResponse request returning *GetTaskResponse
-func (c *ClientWithResponses) GetTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetTaskResponse, error) {
-	rsp, err := c.GetTask(ctx, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetTaskResponse(rsp)
-}
-
-// UpdateTaskWithBodyWithResponse request with arbitrary body returning *UpdateTaskResponse
-func (c *ClientWithResponses) UpdateTaskWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error) {
-	rsp, err := c.UpdateTaskWithBody(ctx, id, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateTaskResponse(rsp)
-}
-
-func (c *ClientWithResponses) UpdateTaskWithResponse(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error) {
-	rsp, err := c.UpdateTask(ctx, id, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateTaskResponse(rsp)
 }
 
 // GetUserConnectionsWithResponse request returning *GetUserConnectionsResponse
@@ -38250,6 +36251,9 @@ func ParseGetDealMailMessagesResponse(rsp *http.Response) (*GetDealMailMessagesR
 						Name *string `json:"name,omitempty"`
 					} `json:"bcc,omitempty"`
 
+					// Body The mail message body content. Only present when `include_body=1` is passed.
+					Body *string `json:"body,omitempty"`
+
 					// BodyUrl The mail message body URL
 					BodyUrl *string `json:"body_url,omitempty"`
 
@@ -38727,9 +36731,14 @@ func ParseGetDealParticipantsResponse(rsp *http.Response) (*GetDealParticipantsR
 				AddedByUserId *struct {
 					Data *struct {
 						Access *[]struct {
-							Admin           *bool                                                 `json:"admin,omitempty"`
-							App             *GetDealParticipants200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
-							PermissionSetId *string                                               `json:"permission_set_id,omitempty"`
+							// Admin Whether the user has admin access or not
+							Admin *bool `json:"admin,omitempty"`
+
+							// App The granular app access level
+							App *GetDealParticipants200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
+
+							// PermissionSetId The ID of the permission set
+							PermissionSetId *string `json:"permission_set_id,omitempty"`
 						} `json:"access,omitempty"`
 
 						// Activated Boolean that indicates whether the user is activated
@@ -39193,9 +37202,14 @@ func ParseAddDealParticipantResponse(rsp *http.Response) (*AddDealParticipantRes
 				AddedByUserId *struct {
 					Data *struct {
 						Access *[]struct {
-							Admin           *bool                                                `json:"admin,omitempty"`
-							App             *AddDealParticipant200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
-							PermissionSetId *string                                              `json:"permission_set_id,omitempty"`
+							// Admin Whether the user has admin access or not
+							Admin *bool `json:"admin,omitempty"`
+
+							// App The granular app access level
+							App *AddDealParticipant200DataAddedByUserIdDataAccessApp `json:"app,omitempty"`
+
+							// PermissionSetId The ID of the permission set
+							PermissionSetId *string `json:"permission_set_id,omitempty"`
 						} `json:"access,omitempty"`
 
 						// Activated Boolean that indicates whether the user is activated
@@ -39829,6 +37843,12 @@ func ParseGetFilesResponse(rsp *http.Response) (*GetFilesResponse, error) {
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
 
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
+
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
 
@@ -39944,6 +37964,12 @@ func ParseAddFileResponse(rsp *http.Response) (*AddFileResponse, error) {
 
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
+
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
 
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
@@ -40061,6 +38087,12 @@ func ParseAddFileAndLinkItResponse(rsp *http.Response) (*AddFileAndLinkItRespons
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
 
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
+
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
 
@@ -40176,6 +38208,12 @@ func ParseLinkFileToItemResponse(rsp *http.Response) (*LinkFileToItemResponse, e
 
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
+
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
 
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
@@ -40327,6 +38365,12 @@ func ParseGetFileResponse(rsp *http.Response) (*GetFileResponse, error) {
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
 
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
+
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
 
@@ -40443,6 +38487,12 @@ func ParseUpdateFileResponse(rsp *http.Response) (*UpdateFileResponse, error) {
 				// ProductName The name of the product associated with the file
 				ProductName *string `json:"product_name,omitempty"`
 
+				// ProjectId The ID of the project to associate the file with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// ProjectName The name of the project associated with the file
+				ProjectName *string `json:"project_name,omitempty"`
+
 				// RemoteId The ID of the remote item
 				RemoteId *string `json:"remote_id,omitempty"`
 
@@ -40549,26 +38599,36 @@ func ParseGetFiltersResponse(rsp *http.Response) (*GetFiltersResponse, error) {
 				// AddTime The date and time when the filter was added
 				AddTime *string `json:"add_time,omitempty"`
 
-				// CustomViewId Used by Pipedrive webapp
-				CustomViewId *int `json:"custom_view_id,omitempty"`
+				// CustomViewId The custom view ID linked to the filter
+				CustomViewId *int `json:"custom_view_id"`
+
+				// FilterCode The system code of the filter
+				FilterCode *string `json:"filter_code"`
 
 				// Id The ID of the filter
 				Id *int `json:"id,omitempty"`
 
+				// IsEditable Whether the filter can be edited by the requesting user
+				IsEditable *bool `json:"is_editable,omitempty"`
+
+				// LastUsedTime The date and time when the filter was last used
+				LastUsedTime *string `json:"last_used_time"`
+
 				// Name The name of the filter
 				Name *string `json:"name,omitempty"`
 
-				// Type The type of the item
-				Type *string `json:"type,omitempty"`
+				// TemporaryFlag Whether the filter is temporary
+				TemporaryFlag *bool                  `json:"temporary_flag"`
+				Type          *GetFilters200DataType `json:"type,omitempty"`
 
 				// UpdateTime The date and time when the filter was updated
-				UpdateTime *string `json:"update_time,omitempty"`
+				UpdateTime *string `json:"update_time"`
 
 				// UserId The owner of the filter
 				UserId *int `json:"user_id,omitempty"`
 
-				// VisibleTo The visibility group ID of who can see then filter
-				VisibleTo *int `json:"visible_to,omitempty"`
+				// VisibleTo The visibility group ID of who can see the filter
+				VisibleTo *GetFilters200DataVisibleTo `json:"visible_to,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -40601,36 +38661,78 @@ func ParseAddFilterResponse(rsp *http.Response) (*AddFilterResponse, error) {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Data *struct {
-				// ActiveFlag The activity flag of the created filter
+				// ActiveFlag The activity flag of the filter
 				ActiveFlag *bool `json:"active_flag,omitempty"`
 
-				// AddTime The add time of the created filter
+				// AddTime The date and time when the filter was added
 				AddTime *string `json:"add_time,omitempty"`
 
-				// Conditions The created filter conditions object
-				Conditions *map[string]interface{} `json:"conditions,omitempty"`
+				// Conditions The conditions object of a filter
+				Conditions *struct {
+					// Conditions The condition groups
+					Conditions *[]struct {
+						// Conditions The individual conditions in this group
+						Conditions *[]struct {
+							// ExtraValue An extra value for conditions that require two values
+							ExtraValue *string `json:"extra_value"`
 
-				// CustomViewId The custom view ID of the created filter
-				CustomViewId *int `json:"custom_view_id,omitempty"`
+							// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+							FieldCode *string `json:"field_code"`
 
-				// Id The ID of the created filter
+							// FieldId The ID of the field
+							FieldId *string `json:"field_id,omitempty"`
+
+							// JsonValueFlag Whether the value is JSON-encoded
+							JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+							// Object The type of entity the condition applies to (e.g. "deal", "person")
+							Object *string `json:"object,omitempty"`
+
+							// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+							Operator *string `json:"operator,omitempty"`
+
+							// Value The value of the condition
+							Value *string `json:"value"`
+						} `json:"conditions,omitempty"`
+
+						// Glue The logical operator joining conditions within this group
+						Glue *AddFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The top-level glue is always "and"
+					Glue *AddFilter200DataConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// CustomViewId The custom view ID linked to the filter
+				CustomViewId *int `json:"custom_view_id"`
+
+				// FilterCode The system code of the filter
+				FilterCode *string `json:"filter_code"`
+
+				// Id The ID of the filter
 				Id *int `json:"id,omitempty"`
 
-				// Name The name of the created filter
+				// IsEditable Whether the filter can be edited by the requesting user
+				IsEditable *bool `json:"is_editable,omitempty"`
+
+				// LastUsedTime The date and time when the filter was last used
+				LastUsedTime *string `json:"last_used_time"`
+
+				// Name The name of the filter
 				Name *string `json:"name,omitempty"`
 
-				// TemporaryFlag If the created filter is temporary or not
-				TemporaryFlag *bool                 `json:"temporary_flag,omitempty"`
+				// TemporaryFlag Whether the filter is temporary
+				TemporaryFlag *bool                 `json:"temporary_flag"`
 				Type          *AddFilter200DataType `json:"type,omitempty"`
 
-				// UpdateTime The update time of the created filter
-				UpdateTime *string `json:"update_time,omitempty"`
+				// UpdateTime The date and time when the filter was last updated
+				UpdateTime *string `json:"update_time"`
 
-				// UserId The user ID of the created filter
+				// UserId The user ID of the filter owner
 				UserId *int `json:"user_id,omitempty"`
 
-				// VisibleTo The visibility group ID of the created filter
-				VisibleTo *int `json:"visible_to,omitempty"`
+				// VisibleTo The visibility group ID of the filter
+				VisibleTo *AddFilter200DataVisibleTo `json:"visible_to,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -40722,7 +38824,7 @@ func ParseGetFilterResponse(rsp *http.Response) (*GetFilterResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			// Data The filter object
+			// Data The filter object including conditions
 			Data *struct {
 				// ActiveFlag The active flag of the filter
 				ActiveFlag *bool `json:"active_flag,omitempty"`
@@ -40730,26 +38832,72 @@ func ParseGetFilterResponse(rsp *http.Response) (*GetFilterResponse, error) {
 				// AddTime The date and time when the filter was added
 				AddTime *string `json:"add_time,omitempty"`
 
-				// CustomViewId Used by Pipedrive webapp
-				CustomViewId *int `json:"custom_view_id,omitempty"`
+				// Conditions The conditions object of a filter
+				Conditions *struct {
+					// Conditions The condition groups
+					Conditions *[]struct {
+						// Conditions The individual conditions in this group
+						Conditions *[]struct {
+							// ExtraValue An extra value for conditions that require two values
+							ExtraValue *string `json:"extra_value"`
+
+							// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+							FieldCode *string `json:"field_code"`
+
+							// FieldId The ID of the field
+							FieldId *string `json:"field_id,omitempty"`
+
+							// JsonValueFlag Whether the value is JSON-encoded
+							JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+							// Object The type of entity the condition applies to (e.g. "deal", "person")
+							Object *string `json:"object,omitempty"`
+
+							// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+							Operator *string `json:"operator,omitempty"`
+
+							// Value The value of the condition
+							Value *string `json:"value"`
+						} `json:"conditions,omitempty"`
+
+						// Glue The logical operator joining conditions within this group
+						Glue *GetFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The top-level glue is always "and"
+					Glue *GetFilter200DataConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// CustomViewId The custom view ID linked to the filter
+				CustomViewId *int `json:"custom_view_id"`
+
+				// FilterCode The system code of the filter
+				FilterCode *string `json:"filter_code"`
 
 				// Id The ID of the filter
 				Id *int `json:"id,omitempty"`
 
+				// IsEditable Whether the filter can be edited by the requesting user
+				IsEditable *bool `json:"is_editable,omitempty"`
+
+				// LastUsedTime The date and time when the filter was last used
+				LastUsedTime *string `json:"last_used_time"`
+
 				// Name The name of the filter
 				Name *string `json:"name,omitempty"`
 
-				// Type The type of the item
-				Type *string `json:"type,omitempty"`
+				// TemporaryFlag Whether the filter is temporary
+				TemporaryFlag *bool                 `json:"temporary_flag"`
+				Type          *GetFilter200DataType `json:"type,omitempty"`
 
 				// UpdateTime The date and time when the filter was updated
-				UpdateTime *string `json:"update_time,omitempty"`
+				UpdateTime *string `json:"update_time"`
 
 				// UserId The owner of the filter
 				UserId *int `json:"user_id,omitempty"`
 
-				// VisibleTo The visibility group ID of who can see then filter
-				VisibleTo *int `json:"visible_to,omitempty"`
+				// VisibleTo The visibility group ID of who can see the filter
+				VisibleTo *GetFilter200DataVisibleTo `json:"visible_to,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -40782,36 +38930,78 @@ func ParseUpdateFilterResponse(rsp *http.Response) (*UpdateFilterResponse, error
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Data *struct {
-				// ActiveFlag The activity flag of the created filter
+				// ActiveFlag The activity flag of the filter
 				ActiveFlag *bool `json:"active_flag,omitempty"`
 
-				// AddTime The add time of the created filter
+				// AddTime The date and time when the filter was added
 				AddTime *string `json:"add_time,omitempty"`
 
-				// Conditions The created filter conditions object
-				Conditions *map[string]interface{} `json:"conditions,omitempty"`
+				// Conditions The conditions object of a filter
+				Conditions *struct {
+					// Conditions The condition groups
+					Conditions *[]struct {
+						// Conditions The individual conditions in this group
+						Conditions *[]struct {
+							// ExtraValue An extra value for conditions that require two values
+							ExtraValue *string `json:"extra_value"`
 
-				// CustomViewId The custom view ID of the created filter
-				CustomViewId *int `json:"custom_view_id,omitempty"`
+							// FieldCode The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
+							FieldCode *string `json:"field_code"`
 
-				// Id The ID of the created filter
+							// FieldId The ID of the field
+							FieldId *string `json:"field_id,omitempty"`
+
+							// JsonValueFlag Whether the value is JSON-encoded
+							JsonValueFlag *bool `json:"json_value_flag,omitempty"`
+
+							// Object The type of entity the condition applies to (e.g. "deal", "person")
+							Object *string `json:"object,omitempty"`
+
+							// Operator The operator used in the condition (e.g. "=", "IS NOT NULL")
+							Operator *string `json:"operator,omitempty"`
+
+							// Value The value of the condition
+							Value *string `json:"value"`
+						} `json:"conditions,omitempty"`
+
+						// Glue The logical operator joining conditions within this group
+						Glue *UpdateFilter200DataConditionsConditionsGlue `json:"glue,omitempty"`
+					} `json:"conditions,omitempty"`
+
+					// Glue The top-level glue is always "and"
+					Glue *UpdateFilter200DataConditionsGlue `json:"glue,omitempty"`
+				} `json:"conditions,omitempty"`
+
+				// CustomViewId The custom view ID linked to the filter
+				CustomViewId *int `json:"custom_view_id"`
+
+				// FilterCode The system code of the filter
+				FilterCode *string `json:"filter_code"`
+
+				// Id The ID of the filter
 				Id *int `json:"id,omitempty"`
 
-				// Name The name of the created filter
+				// IsEditable Whether the filter can be edited by the requesting user
+				IsEditable *bool `json:"is_editable,omitempty"`
+
+				// LastUsedTime The date and time when the filter was last used
+				LastUsedTime *string `json:"last_used_time"`
+
+				// Name The name of the filter
 				Name *string `json:"name,omitempty"`
 
-				// TemporaryFlag If the created filter is temporary or not
-				TemporaryFlag *bool                    `json:"temporary_flag,omitempty"`
+				// TemporaryFlag Whether the filter is temporary
+				TemporaryFlag *bool                    `json:"temporary_flag"`
 				Type          *UpdateFilter200DataType `json:"type,omitempty"`
 
-				// UpdateTime The update time of the created filter
-				UpdateTime *string `json:"update_time,omitempty"`
+				// UpdateTime The date and time when the filter was last updated
+				UpdateTime *string `json:"update_time"`
 
-				// UserId The user ID of the created filter
+				// UserId The user ID of the filter owner
 				UserId *int `json:"user_id,omitempty"`
 
-				// VisibleTo The visibility group ID of the created filter
-				VisibleTo *int `json:"visible_to,omitempty"`
+				// VisibleTo The visibility group ID of the filter
+				VisibleTo *UpdateFilter200DataVisibleTo `json:"visible_to,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -42747,6 +40937,9 @@ func ParseGetMailMessageResponse(rsp *http.Response) (*GetMailMessageResponse, e
 					Name *string `json:"name,omitempty"`
 				} `json:"bcc,omitempty"`
 
+				// Body The mail message body content. Only present when `include_body=1` is passed.
+				Body *string `json:"body,omitempty"`
+
 				// BodyUrl The mail message body URL
 				BodyUrl *string `json:"body_url,omitempty"`
 
@@ -44034,6 +42227,9 @@ func ParseGetNotesResponse(rsp *http.Response) (*GetNotesResponse, error) {
 				// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 				PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+				// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+				PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 				// Project The project the note is attached to
 				Project *struct {
 					// Title The title of the project the note is attached to
@@ -44042,6 +42238,15 @@ func ParseGetNotesResponse(rsp *http.Response) (*GetNotesResponse, error) {
 
 				// ProjectId The ID of the project the note is attached to
 				ProjectId *int `json:"project_id,omitempty"`
+
+				// Task The task the note is attached to
+				Task *struct {
+					// Title The title of the task the note is attached to
+					Title *string `json:"title,omitempty"`
+				} `json:"task,omitempty"`
+
+				// TaskId The ID of the task the note is attached to
+				TaskId *int `json:"task_id,omitempty"`
 
 				// UpdateTime The last updated date and time of the note
 				UpdateTime *string `json:"update_time,omitempty"`
@@ -44152,6 +42357,9 @@ func ParseAddNoteResponse(rsp *http.Response) (*AddNoteResponse, error) {
 				// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 				PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+				// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+				PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 				// Project The project the note is attached to
 				Project *struct {
 					// Title The title of the project the note is attached to
@@ -44160,6 +42368,15 @@ func ParseAddNoteResponse(rsp *http.Response) (*AddNoteResponse, error) {
 
 				// ProjectId The ID of the project the note is attached to
 				ProjectId *int `json:"project_id,omitempty"`
+
+				// Task The task the note is attached to
+				Task *struct {
+					// Title The title of the task the note is attached to
+					Title *string `json:"title,omitempty"`
+				} `json:"task,omitempty"`
+
+				// TaskId The ID of the task the note is attached to
+				TaskId *int `json:"task_id,omitempty"`
 
 				// UpdateTime The last updated date and time of the note
 				UpdateTime *string `json:"update_time,omitempty"`
@@ -44302,6 +42519,9 @@ func ParseGetNoteResponse(rsp *http.Response) (*GetNoteResponse, error) {
 				// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 				PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+				// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+				PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 				// Project The project the note is attached to
 				Project *struct {
 					// Title The title of the project the note is attached to
@@ -44310,6 +42530,15 @@ func ParseGetNoteResponse(rsp *http.Response) (*GetNoteResponse, error) {
 
 				// ProjectId The ID of the project the note is attached to
 				ProjectId *int `json:"project_id,omitempty"`
+
+				// Task The task the note is attached to
+				Task *struct {
+					// Title The title of the task the note is attached to
+					Title *string `json:"title,omitempty"`
+				} `json:"task,omitempty"`
+
+				// TaskId The ID of the task the note is attached to
+				TaskId *int `json:"task_id,omitempty"`
 
 				// UpdateTime The last updated date and time of the note
 				UpdateTime *string `json:"update_time,omitempty"`
@@ -44420,6 +42649,9 @@ func ParseUpdateNoteResponse(rsp *http.Response) (*UpdateNoteResponse, error) {
 				// PinnedToProjectFlag If true, the results are filtered by note to project pinning state
 				PinnedToProjectFlag *bool `json:"pinned_to_project_flag,omitempty"`
 
+				// PinnedToTaskFlag If true, the results are filtered by note to task pinning state
+				PinnedToTaskFlag *bool `json:"pinned_to_task_flag,omitempty"`
+
 				// Project The project the note is attached to
 				Project *struct {
 					// Title The title of the project the note is attached to
@@ -44428,6 +42660,15 @@ func ParseUpdateNoteResponse(rsp *http.Response) (*UpdateNoteResponse, error) {
 
 				// ProjectId The ID of the project the note is attached to
 				ProjectId *int `json:"project_id,omitempty"`
+
+				// Task The task the note is attached to
+				Task *struct {
+					// Title The title of the task the note is attached to
+					Title *string `json:"title,omitempty"`
+				} `json:"task,omitempty"`
+
+				// TaskId The ID of the task the note is attached to
+				TaskId *int `json:"task_id,omitempty"`
 
 				// UpdateTime The last updated date and time of the note
 				UpdateTime *string `json:"update_time,omitempty"`
@@ -45732,6 +43973,9 @@ func ParseGetOrganizationMailMessagesResponse(rsp *http.Response) (*GetOrganizat
 						Name *string `json:"name,omitempty"`
 					} `json:"bcc,omitempty"`
 
+					// Body The mail message body content. Only present when `include_body=1` is passed.
+					Body *string `json:"body,omitempty"`
+
 					// BodyUrl The mail message body URL
 					BodyUrl *string `json:"body_url,omitempty"`
 
@@ -46567,6 +44811,9 @@ func ParseGetPersonMailMessagesResponse(rsp *http.Response) (*GetPersonMailMessa
 						// Name Name of the mail participant
 						Name *string `json:"name,omitempty"`
 					} `json:"bcc,omitempty"`
+
+					// Body The mail message body content. Only present when `include_body=1` is passed.
+					Body *string `json:"body,omitempty"`
 
 					// BodyUrl The mail message body URL
 					BodyUrl *string `json:"body_url,omitempty"`
@@ -48441,664 +46688,6 @@ func ParseGetProductUsersResponse(rsp *http.Response) (*GetProductUsersResponse,
 	return response, nil
 }
 
-// ParseGetProjectTemplatesResponse parses an HTTP response from a GetProjectTemplatesWithResponse call
-func ParseGetProjectTemplatesResponse(rsp *http.Response) (*GetProjectTemplatesResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectTemplatesResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			// AdditionalData The additional data of the list
-			AdditionalData *struct {
-				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-				NextCursor *string `json:"next_cursor,omitempty"`
-			} `json:"additional_data,omitempty"`
-			Data *[]struct {
-				// AddTime The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// Description The description of a template
-				Description *string `json:"description,omitempty"`
-
-				// Id The ID of a template
-				Id *float32 `json:"id,omitempty"`
-
-				// OwnerId The ID of a template owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// ProjectsBoardId The ID of the project board this template is associated with
-				ProjectsBoardId *float32 `json:"projects_board_id,omitempty"`
-
-				// Title The title of a template
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectTemplateResponse parses an HTTP response from a GetProjectTemplateWithResponse call
-func ParseGetProjectTemplateResponse(rsp *http.Response) (*GetProjectTemplateResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectTemplateResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// Description The description of a template
-				Description *string `json:"description,omitempty"`
-
-				// Id The ID of a template
-				Id *float32 `json:"id,omitempty"`
-
-				// OwnerId The ID of a template owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// ProjectsBoardId The ID of the project board this template is associated with
-				ProjectsBoardId *float32 `json:"projects_board_id,omitempty"`
-
-				// Title The title of a template
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectsResponse parses an HTTP response from a GetProjectsWithResponse call
-func ParseGetProjectsResponse(rsp *http.Response) (*GetProjectsResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectsResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			// AdditionalData The additional data of the list
-			AdditionalData *struct {
-				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-				NextCursor *string `json:"next_cursor,omitempty"`
-			} `json:"additional_data,omitempty"`
-			Data *[]struct {
-				// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-				ArchiveTime *string `json:"archive_time,omitempty"`
-
-				// BoardId The ID of the board this project is associated with
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// DealIds An array of IDs of the deals this project is associated with
-				DealIds *[]int `json:"deal_ids,omitempty"`
-
-				// Description The description of the project
-				Description *string `json:"description,omitempty"`
-
-				// EndDate The end date of the project. Format: YYYY-MM-DD.
-				EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-				// Id The ID of the project, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// Labels An array of IDs of the labels this project has
-				Labels *[]int `json:"labels,omitempty"`
-
-				// OrgId The ID of the organization this project is associated with
-				OrgId *float32 `json:"org_id,omitempty"`
-
-				// OwnerId The ID of a project owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// PersonId The ID of the person this project is associated with
-				PersonId *float32 `json:"person_id,omitempty"`
-
-				// PhaseId The ID of the phase this project is associated with
-				PhaseId *float32 `json:"phase_id,omitempty"`
-
-				// StartDate The start date of the project. Format: YYYY-MM-DD.
-				StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-				// Status The status of the project
-				Status *string `json:"status,omitempty"`
-
-				// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-				// Title The title of the project
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseAddProjectResponse parses an HTTP response from a AddProjectWithResponse call
-func ParseAddProjectResponse(rsp *http.Response) (*AddProjectResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &AddProjectResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-				ArchiveTime *string `json:"archive_time,omitempty"`
-
-				// BoardId The ID of the board this project is associated with
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// DealIds An array of IDs of the deals this project is associated with
-				DealIds *[]int `json:"deal_ids,omitempty"`
-
-				// Description The description of the project
-				Description *string `json:"description,omitempty"`
-
-				// EndDate The end date of the project. Format: YYYY-MM-DD.
-				EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-				// Id The ID of the project, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// Labels An array of IDs of the labels this project has
-				Labels *[]int `json:"labels,omitempty"`
-
-				// OrgId The ID of the organization this project is associated with
-				OrgId *float32 `json:"org_id,omitempty"`
-
-				// OwnerId The ID of a project owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// PersonId The ID of the person this project is associated with
-				PersonId *float32 `json:"person_id,omitempty"`
-
-				// PhaseId The ID of the phase this project is associated with
-				PhaseId *float32 `json:"phase_id,omitempty"`
-
-				// StartDate The start date of the project. Format: YYYY-MM-DD.
-				StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-				// Status The status of the project
-				Status *string `json:"status,omitempty"`
-
-				// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-				// Title The title of the project
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectsBoardsResponse parses an HTTP response from a GetProjectsBoardsWithResponse call
-func ParseGetProjectsBoardsResponse(rsp *http.Response) (*GetProjectsBoardsResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectsBoardsResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *[]struct {
-				// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// Id The ID of the project board
-				Id *int `json:"id,omitempty"`
-
-				// Name Name of a project board
-				Name *string `json:"name,omitempty"`
-
-				// OrderNr The order of a board
-				OrderNr *float32 `json:"order_nr,omitempty"`
-
-				// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectsBoardResponse parses an HTTP response from a GetProjectsBoardWithResponse call
-func ParseGetProjectsBoardResponse(rsp *http.Response) (*GetProjectsBoardResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectsBoardResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// Id The ID of the project board
-				Id *int `json:"id,omitempty"`
-
-				// Name Name of a project board
-				Name *string `json:"name,omitempty"`
-
-				// OrderNr The order of a board
-				OrderNr *float32 `json:"order_nr,omitempty"`
-
-				// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectsPhasesResponse parses an HTTP response from a GetProjectsPhasesWithResponse call
-func ParseGetProjectsPhasesResponse(rsp *http.Response) (*GetProjectsPhasesResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectsPhasesResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *[]struct {
-				// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// BoardId The ID of the project board this phase is linked to
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// Id The ID of the project phase
-				Id *int `json:"id,omitempty"`
-
-				// Name Name of a project phase
-				Name *string `json:"name,omitempty"`
-
-				// OrderNr The order of a phase
-				OrderNr *float32 `json:"order_nr,omitempty"`
-
-				// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectsPhaseResponse parses an HTTP response from a GetProjectsPhaseWithResponse call
-func ParseGetProjectsPhaseResponse(rsp *http.Response) (*GetProjectsPhaseResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectsPhaseResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// BoardId The ID of the project board this phase is linked to
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// Id The ID of the project phase
-				Id *int `json:"id,omitempty"`
-
-				// Name Name of a project phase
-				Name *string `json:"name,omitempty"`
-
-				// OrderNr The order of a phase
-				OrderNr *float32 `json:"order_nr,omitempty"`
-
-				// UpdateTime The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteProjectResponse parses an HTTP response from a DeleteProjectWithResponse call
-func ParseDeleteProjectResponse(rsp *http.Response) (*DeleteProjectResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DeleteProjectResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				Data *struct {
-					// Id The ID of the project that was deleted
-					Id *int `json:"id,omitempty"`
-				} `json:"data,omitempty"`
-
-				// Success If the request was successful or not
-				Success *bool `json:"success,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetProjectResponse parses an HTTP response from a GetProjectWithResponse call
-func ParseGetProjectResponse(rsp *http.Response) (*GetProjectResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetProjectResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-				ArchiveTime *string `json:"archive_time,omitempty"`
-
-				// BoardId The ID of the board this project is associated with
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// DealIds An array of IDs of the deals this project is associated with
-				DealIds *[]int `json:"deal_ids,omitempty"`
-
-				// Description The description of the project
-				Description *string `json:"description,omitempty"`
-
-				// EndDate The end date of the project. Format: YYYY-MM-DD.
-				EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-				// Id The ID of the project, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// Labels An array of IDs of the labels this project has
-				Labels *[]int `json:"labels,omitempty"`
-
-				// OrgId The ID of the organization this project is associated with
-				OrgId *float32 `json:"org_id,omitempty"`
-
-				// OwnerId The ID of a project owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// PersonId The ID of the person this project is associated with
-				PersonId *float32 `json:"person_id,omitempty"`
-
-				// PhaseId The ID of the phase this project is associated with
-				PhaseId *float32 `json:"phase_id,omitempty"`
-
-				// StartDate The start date of the project. Format: YYYY-MM-DD.
-				StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-				// Status The status of the project
-				Status *string `json:"status,omitempty"`
-
-				// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-				// Title The title of the project
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseUpdateProjectResponse parses an HTTP response from a UpdateProjectWithResponse call
-func ParseUpdateProjectResponse(rsp *http.Response) (*UpdateProjectResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &UpdateProjectResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-				ArchiveTime *string `json:"archive_time,omitempty"`
-
-				// BoardId The ID of the board this project is associated with
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// DealIds An array of IDs of the deals this project is associated with
-				DealIds *[]int `json:"deal_ids,omitempty"`
-
-				// Description The description of the project
-				Description *string `json:"description,omitempty"`
-
-				// EndDate The end date of the project. Format: YYYY-MM-DD.
-				EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-				// Id The ID of the project, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// Labels An array of IDs of the labels this project has
-				Labels *[]int `json:"labels,omitempty"`
-
-				// OrgId The ID of the organization this project is associated with
-				OrgId *float32 `json:"org_id,omitempty"`
-
-				// OwnerId The ID of a project owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// PersonId The ID of the person this project is associated with
-				PersonId *float32 `json:"person_id,omitempty"`
-
-				// PhaseId The ID of the phase this project is associated with
-				PhaseId *float32 `json:"phase_id,omitempty"`
-
-				// StartDate The start date of the project. Format: YYYY-MM-DD.
-				StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-				// Status The status of the project
-				Status *string `json:"status,omitempty"`
-
-				// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-				// Title The title of the project
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseGetProjectActivitiesResponse parses an HTTP response from a GetProjectActivitiesWithResponse call
 func ParseGetProjectActivitiesResponse(rsp *http.Response) (*GetProjectActivitiesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -49228,87 +46817,6 @@ func ParseGetProjectActivitiesResponse(rsp *http.Response) (*GetProjectActivitie
 
 				// UserId The ID of the user whom the activity is assigned to
 				UserId *int `json:"user_id,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseArchiveProjectResponse parses an HTTP response from a ArchiveProjectWithResponse call
-func ParseArchiveProjectResponse(rsp *http.Response) (*ArchiveProjectResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &ArchiveProjectResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// ArchiveTime The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then 'null'.
-				ArchiveTime *string `json:"archive_time,omitempty"`
-
-				// BoardId The ID of the board this project is associated with
-				BoardId *float32 `json:"board_id,omitempty"`
-
-				// DealIds An array of IDs of the deals this project is associated with
-				DealIds *[]int `json:"deal_ids,omitempty"`
-
-				// Description The description of the project
-				Description *string `json:"description,omitempty"`
-
-				// EndDate The end date of the project. Format: YYYY-MM-DD.
-				EndDate *openapi_types.Date `json:"end_date,omitempty"`
-
-				// Id The ID of the project, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// Labels An array of IDs of the labels this project has
-				Labels *[]int `json:"labels,omitempty"`
-
-				// OrgId The ID of the organization this project is associated with
-				OrgId *float32 `json:"org_id,omitempty"`
-
-				// OwnerId The ID of a project owner
-				OwnerId *float32 `json:"owner_id,omitempty"`
-
-				// PersonId The ID of the person this project is associated with
-				PersonId *float32 `json:"person_id,omitempty"`
-
-				// PhaseId The ID of the phase this project is associated with
-				PhaseId *float32 `json:"phase_id,omitempty"`
-
-				// StartDate The start date of the project. Format: YYYY-MM-DD.
-				StartDate *openapi_types.Date `json:"start_date,omitempty"`
-
-				// Status The status of the project
-				Status *string `json:"status,omitempty"`
-
-				// StatusChangeTime The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				StatusChangeTime *string `json:"status_change_time,omitempty"`
-
-				// Title The title of the project
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
 			} `json:"data,omitempty"`
 			Success *bool `json:"success,omitempty"`
 		}
@@ -49512,8 +47020,11 @@ func ParseGetProjectTasksResponse(rsp *http.Response) (*GetProjectTasksResponse,
 				// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
 				AddTime *string `json:"add_time,omitempty"`
 
-				// AssigneeId The ID of the user who will be the assignee of the task
+				// AssigneeId The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.
 				AssigneeId *float32 `json:"assignee_id,omitempty"`
+
+				// AssigneeIds The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.
+				AssigneeIds *[]float32 `json:"assignee_ids,omitempty"`
 
 				// CreatorId The creator of a task
 				CreatorId *float32 `json:"creator_id,omitempty"`
@@ -50446,312 +47957,6 @@ func ParseGetStageDealsResponse(rsp *http.Response) (*GetStageDealsResponse, err
 	return response, nil
 }
 
-// ParseGetTasksResponse parses an HTTP response from a GetTasksWithResponse call
-func ParseGetTasksResponse(rsp *http.Response) (*GetTasksResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetTasksResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			// AdditionalData The additional data of the list
-			AdditionalData *struct {
-				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-				NextCursor *string `json:"next_cursor,omitempty"`
-			} `json:"additional_data,omitempty"`
-			Data *[]struct {
-				// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// AssigneeId The ID of the user who will be the assignee of the task
-				AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-				// CreatorId The creator of a task
-				CreatorId *float32 `json:"creator_id,omitempty"`
-
-				// Description The description of the task
-				Description *string `json:"description,omitempty"`
-
-				// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-				Done *GetTasks200DataDone `json:"done,omitempty"`
-
-				// DueDate The due date of the task. Format: YYYY-MM-DD.
-				DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-				// Id The ID of the task, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-				// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-				ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-				// ProjectId The ID of the project this task is associated with
-				ProjectId *float32 `json:"project_id,omitempty"`
-
-				// Title The title of the task
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseAddTaskResponse parses an HTTP response from a AddTaskWithResponse call
-func ParseAddTaskResponse(rsp *http.Response) (*AddTaskResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &AddTaskResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// AssigneeId The ID of the user who will be the assignee of the task
-				AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-				// CreatorId The creator of a task
-				CreatorId *float32 `json:"creator_id,omitempty"`
-
-				// Description The description of the task
-				Description *string `json:"description,omitempty"`
-
-				// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-				Done *AddTask201DataDone `json:"done,omitempty"`
-
-				// DueDate The due date of the task. Format: YYYY-MM-DD.
-				DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-				// Id The ID of the task, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-				// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-				ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-				// ProjectId The ID of the project this task is associated with
-				ProjectId *float32 `json:"project_id,omitempty"`
-
-				// Title The title of the task
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON201 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseDeleteTaskResponse parses an HTTP response from a DeleteTaskWithResponse call
-func ParseDeleteTaskResponse(rsp *http.Response) (*DeleteTaskResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DeleteTaskResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				Data *struct {
-					// Id The ID of the task that was deleted
-					Id *int `json:"id,omitempty"`
-				} `json:"data,omitempty"`
-
-				// Success If the request was successful or not
-				Success *bool `json:"success,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetTaskResponse parses an HTTP response from a GetTaskWithResponse call
-func ParseGetTaskResponse(rsp *http.Response) (*GetTaskResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetTaskResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// AssigneeId The ID of the user who will be the assignee of the task
-				AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-				// CreatorId The creator of a task
-				CreatorId *float32 `json:"creator_id,omitempty"`
-
-				// Description The description of the task
-				Description *string `json:"description,omitempty"`
-
-				// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-				Done *GetTask200DataDone `json:"done,omitempty"`
-
-				// DueDate The due date of the task. Format: YYYY-MM-DD.
-				DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-				// Id The ID of the task, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-				// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-				ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-				// ProjectId The ID of the project this task is associated with
-				ProjectId *float32 `json:"project_id,omitempty"`
-
-				// Title The title of the task
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseUpdateTaskResponse parses an HTTP response from a UpdateTaskWithResponse call
-func ParseUpdateTaskResponse(rsp *http.Response) (*UpdateTaskResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &UpdateTaskResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			AdditionalData *map[string]interface{} `json:"additional_data"`
-			Data           *struct {
-				// AddTime The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				AddTime *string `json:"add_time,omitempty"`
-
-				// AssigneeId The ID of the user who will be the assignee of the task
-				AssigneeId *float32 `json:"assignee_id,omitempty"`
-
-				// CreatorId The creator of a task
-				CreatorId *float32 `json:"creator_id,omitempty"`
-
-				// Description The description of the task
-				Description *string `json:"description,omitempty"`
-
-				// Done Whether the task is done or not. 0 = Not done, 1 = Done.
-				Done *UpdateTask200DataDone `json:"done,omitempty"`
-
-				// DueDate The due date of the task. Format: YYYY-MM-DD.
-				DueDate *openapi_types.Date `json:"due_date,omitempty"`
-
-				// Id The ID of the task, generated when the task was created
-				Id *int `json:"id,omitempty"`
-
-				// MarkedAsDoneTime The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				MarkedAsDoneTime *string `json:"marked_as_done_time,omitempty"`
-
-				// ParentTaskId The ID of a parent task. Can not be ID of a task which is already a subtask.
-				ParentTaskId *float32 `json:"parent_task_id,omitempty"`
-
-				// ProjectId The ID of the project this task is associated with
-				ProjectId *float32 `json:"project_id,omitempty"`
-
-				// Title The title of the task
-				Title *string `json:"title,omitempty"`
-
-				// UpdateTime The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.
-				UpdateTime *string `json:"update_time,omitempty"`
-			} `json:"data,omitempty"`
-			Success *bool `json:"success,omitempty"`
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseGetUserConnectionsResponse parses an HTTP response from a GetUserConnectionsWithResponse call
 func ParseGetUserConnectionsResponse(rsp *http.Response) (*GetUserConnectionsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -50892,9 +48097,14 @@ func ParseGetUsersResponse(rsp *http.Response) (*GetUsersResponse, error) {
 		var dest struct {
 			Data *[]struct {
 				Access *[]struct {
-					Admin           *bool                     `json:"admin,omitempty"`
-					App             *GetUsers200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                   `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *GetUsers200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated
@@ -50986,9 +48196,14 @@ func ParseAddUserResponse(rsp *http.Response) (*AddUserResponse, error) {
 		var dest struct {
 			Data *struct {
 				Access *[]struct {
-					Admin           *bool                    `json:"admin,omitempty"`
-					App             *AddUser200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                  `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *AddUser200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated
@@ -51093,9 +48308,14 @@ func ParseFindUsersByNameResponse(rsp *http.Response) (*FindUsersByNameResponse,
 		var dest struct {
 			Data *[]struct {
 				Access *[]struct {
-					Admin           *bool                            `json:"admin,omitempty"`
-					App             *FindUsersByName200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                          `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *FindUsersByName200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated
@@ -51187,9 +48407,14 @@ func ParseGetCurrentUserResponse(rsp *http.Response) (*GetCurrentUserResponse, e
 		var dest struct {
 			Data *struct {
 				Access *[]struct {
-					Admin           *bool                           `json:"admin,omitempty"`
-					App             *GetCurrentUser200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                         `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *GetCurrentUser200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated
@@ -51321,9 +48546,14 @@ func ParseGetUserResponse(rsp *http.Response) (*GetUserResponse, error) {
 		var dest struct {
 			Data *struct {
 				Access *[]struct {
-					Admin           *bool                    `json:"admin,omitempty"`
-					App             *GetUser200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                  `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *GetUser200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated
@@ -51428,9 +48658,14 @@ func ParseUpdateUserResponse(rsp *http.Response) (*UpdateUserResponse, error) {
 		var dest struct {
 			Data *struct {
 				Access *[]struct {
-					Admin           *bool                       `json:"admin,omitempty"`
-					App             *UpdateUser200DataAccessApp `json:"app,omitempty"`
-					PermissionSetId *string                     `json:"permission_set_id,omitempty"`
+					// Admin Whether the user has admin access or not
+					Admin *bool `json:"admin,omitempty"`
+
+					// App The granular app access level
+					App *UpdateUser200DataAccessApp `json:"app,omitempty"`
+
+					// PermissionSetId The ID of the permission set
+					PermissionSetId *string `json:"permission_set_id,omitempty"`
 				} `json:"access,omitempty"`
 
 				// Activated Boolean that indicates whether the user is activated

--- a/internal/gen/v2/openapi.gen.go
+++ b/internal/gen/v2/openapi.gen.go
@@ -686,22 +686,22 @@ const (
 
 // Defines values for AddProductFieldJSONBodyFieldType.
 const (
-	Address     AddProductFieldJSONBodyFieldType = "address"
-	Date        AddProductFieldJSONBodyFieldType = "date"
-	Daterange   AddProductFieldJSONBodyFieldType = "daterange"
-	Double      AddProductFieldJSONBodyFieldType = "double"
-	Enum        AddProductFieldJSONBodyFieldType = "enum"
-	Monetary    AddProductFieldJSONBodyFieldType = "monetary"
-	Org         AddProductFieldJSONBodyFieldType = "org"
-	People      AddProductFieldJSONBodyFieldType = "people"
-	Phone       AddProductFieldJSONBodyFieldType = "phone"
-	Set         AddProductFieldJSONBodyFieldType = "set"
-	Text        AddProductFieldJSONBodyFieldType = "text"
-	Time        AddProductFieldJSONBodyFieldType = "time"
-	Timerange   AddProductFieldJSONBodyFieldType = "timerange"
-	User        AddProductFieldJSONBodyFieldType = "user"
-	Varchar     AddProductFieldJSONBodyFieldType = "varchar"
-	VarcharAuto AddProductFieldJSONBodyFieldType = "varchar_auto"
+	AddProductFieldJSONBodyFieldTypeAddress     AddProductFieldJSONBodyFieldType = "address"
+	AddProductFieldJSONBodyFieldTypeDate        AddProductFieldJSONBodyFieldType = "date"
+	AddProductFieldJSONBodyFieldTypeDaterange   AddProductFieldJSONBodyFieldType = "daterange"
+	AddProductFieldJSONBodyFieldTypeDouble      AddProductFieldJSONBodyFieldType = "double"
+	AddProductFieldJSONBodyFieldTypeEnum        AddProductFieldJSONBodyFieldType = "enum"
+	AddProductFieldJSONBodyFieldTypeMonetary    AddProductFieldJSONBodyFieldType = "monetary"
+	AddProductFieldJSONBodyFieldTypeOrg         AddProductFieldJSONBodyFieldType = "org"
+	AddProductFieldJSONBodyFieldTypePeople      AddProductFieldJSONBodyFieldType = "people"
+	AddProductFieldJSONBodyFieldTypePhone       AddProductFieldJSONBodyFieldType = "phone"
+	AddProductFieldJSONBodyFieldTypeSet         AddProductFieldJSONBodyFieldType = "set"
+	AddProductFieldJSONBodyFieldTypeText        AddProductFieldJSONBodyFieldType = "text"
+	AddProductFieldJSONBodyFieldTypeTime        AddProductFieldJSONBodyFieldType = "time"
+	AddProductFieldJSONBodyFieldTypeTimerange   AddProductFieldJSONBodyFieldType = "timerange"
+	AddProductFieldJSONBodyFieldTypeUser        AddProductFieldJSONBodyFieldType = "user"
+	AddProductFieldJSONBodyFieldTypeVarchar     AddProductFieldJSONBodyFieldType = "varchar"
+	AddProductFieldJSONBodyFieldTypeVarcharAuto AddProductFieldJSONBodyFieldType = "varchar_auto"
 )
 
 // Defines values for GetProductFieldParamsIncludeFields.
@@ -743,9 +743,9 @@ const (
 
 // Defines values for SearchProductsParamsFields.
 const (
-	Code         SearchProductsParamsFields = "code"
-	CustomFields SearchProductsParamsFields = "custom_fields"
-	Name         SearchProductsParamsFields = "name"
+	SearchProductsParamsFieldsCode         SearchProductsParamsFields = "code"
+	SearchProductsParamsFieldsCustomFields SearchProductsParamsFields = "custom_fields"
+	SearchProductsParamsFieldsName         SearchProductsParamsFields = "name"
 )
 
 // Defines values for SearchProductsParamsIncludeFields.
@@ -771,6 +771,34 @@ const (
 	UpdateProductJSONBodyVisibleToN7 UpdateProductJSONBodyVisibleTo = 7
 )
 
+// Defines values for AddProjectFieldJSONBodyFieldType.
+const (
+	AddProjectFieldJSONBodyFieldTypeAddress     AddProjectFieldJSONBodyFieldType = "address"
+	AddProjectFieldJSONBodyFieldTypeDate        AddProjectFieldJSONBodyFieldType = "date"
+	AddProjectFieldJSONBodyFieldTypeDaterange   AddProjectFieldJSONBodyFieldType = "daterange"
+	AddProjectFieldJSONBodyFieldTypeDouble      AddProjectFieldJSONBodyFieldType = "double"
+	AddProjectFieldJSONBodyFieldTypeEnum        AddProjectFieldJSONBodyFieldType = "enum"
+	AddProjectFieldJSONBodyFieldTypeMonetary    AddProjectFieldJSONBodyFieldType = "monetary"
+	AddProjectFieldJSONBodyFieldTypeOrg         AddProjectFieldJSONBodyFieldType = "org"
+	AddProjectFieldJSONBodyFieldTypePeople      AddProjectFieldJSONBodyFieldType = "people"
+	AddProjectFieldJSONBodyFieldTypePhone       AddProjectFieldJSONBodyFieldType = "phone"
+	AddProjectFieldJSONBodyFieldTypeSet         AddProjectFieldJSONBodyFieldType = "set"
+	AddProjectFieldJSONBodyFieldTypeText        AddProjectFieldJSONBodyFieldType = "text"
+	AddProjectFieldJSONBodyFieldTypeTime        AddProjectFieldJSONBodyFieldType = "time"
+	AddProjectFieldJSONBodyFieldTypeTimerange   AddProjectFieldJSONBodyFieldType = "timerange"
+	AddProjectFieldJSONBodyFieldTypeUser        AddProjectFieldJSONBodyFieldType = "user"
+	AddProjectFieldJSONBodyFieldTypeVarchar     AddProjectFieldJSONBodyFieldType = "varchar"
+	AddProjectFieldJSONBodyFieldTypeVarcharAuto AddProjectFieldJSONBodyFieldType = "varchar_auto"
+)
+
+// Defines values for SearchProjectsParamsFields.
+const (
+	SearchProjectsParamsFieldsCustomFields SearchProjectsParamsFields = "custom_fields"
+	SearchProjectsParamsFieldsDescription  SearchProjectsParamsFields = "description"
+	SearchProjectsParamsFieldsNotes        SearchProjectsParamsFields = "notes"
+	SearchProjectsParamsFieldsTitle        SearchProjectsParamsFields = "title"
+)
+
 // Defines values for GetStagesParamsSortBy.
 const (
 	AddTime    GetStagesParamsSortBy = "add_time"
@@ -783,6 +811,30 @@ const (
 const (
 	Asc  GetStagesParamsSortDirection = "asc"
 	Desc GetStagesParamsSortDirection = "desc"
+)
+
+// Defines values for AddTaskJSONBodyDone.
+const (
+	AddTaskJSONBodyDoneN0 AddTaskJSONBodyDone = 0
+	AddTaskJSONBodyDoneN1 AddTaskJSONBodyDone = 1
+)
+
+// Defines values for AddTaskJSONBodyMilestone.
+const (
+	AddTaskJSONBodyMilestoneN0 AddTaskJSONBodyMilestone = 0
+	AddTaskJSONBodyMilestoneN1 AddTaskJSONBodyMilestone = 1
+)
+
+// Defines values for UpdateTaskJSONBodyDone.
+const (
+	UpdateTaskJSONBodyDoneN0 UpdateTaskJSONBodyDone = 0
+	UpdateTaskJSONBodyDoneN1 UpdateTaskJSONBodyDone = 1
+)
+
+// Defines values for UpdateTaskJSONBodyMilestone.
+const (
+	UpdateTaskJSONBodyMilestoneN0 UpdateTaskJSONBodyMilestone = 0
+	UpdateTaskJSONBodyMilestoneN1 UpdateTaskJSONBodyMilestone = 1
 )
 
 // GetActivitiesParams defines parameters for GetActivities.
@@ -1103,6 +1155,24 @@ type GetActivityFieldParams struct {
 // GetActivityFieldParamsIncludeFields defines parameters for GetActivityField.
 type GetActivityFieldParamsIncludeFields string
 
+// AddProjectBoardJSONBody defines parameters for AddProjectBoard.
+type AddProjectBoardJSONBody struct {
+	// Name The name of the project board
+	Name string `json:"name"`
+
+	// OrderNr The order of the board. Must be between 1 and the total number of boards + 1.
+	OrderNr *int `json:"order_nr,omitempty"`
+}
+
+// UpdateProjectBoardJSONBody defines parameters for UpdateProjectBoard.
+type UpdateProjectBoardJSONBody struct {
+	// Name The name of the project board
+	Name *string `json:"name,omitempty"`
+
+	// OrderNr The order of the board. Must be between 1 and the total number of boards + 1.
+	OrderNr *int `json:"order_nr,omitempty"`
+}
+
 // GetDealFieldsParams defines parameters for GetDealFields.
 type GetDealFieldsParams struct {
 	// IncludeFields Optional comma separated string array of additional data namespaces to include in response
@@ -1169,7 +1239,7 @@ type AddDealFieldJSONBody_RequiredFields struct {
 	// StageIds Array of deal stage IDs where this field is required. Must reference valid, active deal stages. Empty array when enabled is false. The stages must be in pipelines where this field is visible (show_in_pipelines).
 	StageIds *[]int `json:"stage_ids,omitempty"`
 
-	// Statuses Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings ('won', 'lost'). Example - {"1":["won","lost"],"2":["won"]} means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.
+	// Statuses Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings ('won', 'lost'). Example - `{"1":["won","lost"],"2":["won"]}` means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.
 	Statuses             *map[string][]AddDealFieldJSONBodyRequiredFieldsStatuses `json:"statuses,omitempty"`
 	AdditionalProperties map[string]interface{}                                   `json:"-"`
 }
@@ -1244,7 +1314,7 @@ type UpdateDealFieldJSONBody_RequiredFields struct {
 	// StageIds Array of deal stage IDs where this field is required. Must reference valid, active deal stages. Empty array when enabled is false. The stages must be in pipelines where this field is visible (show_in_pipelines).
 	StageIds *[]int `json:"stage_ids,omitempty"`
 
-	// Statuses Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings ('won', 'lost'). Example - {"1":["won","lost"],"2":["won"]} means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.
+	// Statuses Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings ('won', 'lost'). Example - `{"1":["won","lost"],"2":["won"]}` means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.
 	Statuses             *map[string][]UpdateDealFieldJSONBodyRequiredFieldsStatuses `json:"statuses,omitempty"`
 	AdditionalProperties map[string]interface{}                                      `json:"-"`
 }
@@ -1336,6 +1406,12 @@ type GetDealsParams struct {
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
+
 	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
@@ -1366,7 +1442,7 @@ type AddDealJSONBody struct {
 	// Currency The currency associated with the deal
 	Currency *string `json:"currency,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// ExpectedCloseDate The expected close date of the deal
@@ -1578,6 +1654,12 @@ type GetDealParams struct {
 
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
+
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
 }
 
 // GetDealParamsIncludeFields defines parameters for GetDeal.
@@ -1594,7 +1676,7 @@ type UpdateDealJSONBody struct {
 	// Currency The currency associated with the deal
 	Currency *string `json:"currency,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// ExpectedCloseDate The expected close date of the deal
@@ -1781,7 +1863,7 @@ type AddDealProductJSONBody struct {
 	// BillingStartDate Only available in Growth and above plans
 	//
 	// The billing start date. Must be between 10 years in the past and 10 years in the future
-	BillingStartDate *string `json:"billing_start_date"`
+	BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 	// Comments The comments of the product
 	Comments *string `json:"comments,omitempty"`
@@ -1829,7 +1911,7 @@ type AddDealProductJSONBodyTaxMethod string
 
 // AddManyDealProductsJSONBody defines parameters for AddManyDealProducts.
 type AddManyDealProductsJSONBody struct {
-	// Data Array of products to attach to the deal. See the single product endpoint (https://developers.pipedrive.com/docs/api/v1/Deals#addDealProduct) for the expected format of array items.
+	// Data Array of products to attach to the deal. Each product object may have the following properties.
 	Data []struct {
 		// BillingFrequency Only available in Growth and above plans
 		//
@@ -1856,7 +1938,7 @@ type AddManyDealProductsJSONBody struct {
 		// BillingStartDate Only available in Growth and above plans
 		//
 		// The billing start date. Must be between 10 years in the past and 10 years in the future
-		BillingStartDate *string `json:"billing_start_date"`
+		BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 		// Comments The comments of the product
 		Comments *string `json:"comments,omitempty"`
@@ -1930,7 +2012,7 @@ type UpdateDealProductJSONBody struct {
 	// BillingStartDate Only available in Growth and above plans
 	//
 	// The billing start date. Must be between 10 years in the past and 10 years in the future
-	BillingStartDate *string `json:"billing_start_date"`
+	BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 	// Comments The comments of the product
 	Comments *string `json:"comments,omitempty"`
@@ -2098,9 +2180,6 @@ type GetOrganizationFieldsParamsIncludeFields string
 
 // AddOrganizationFieldJSONBody defines parameters for AddOrganizationField.
 type AddOrganizationFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName string `json:"field_name"`
 
@@ -2182,9 +2261,6 @@ type GetOrganizationFieldParamsIncludeFields string
 
 // UpdateOrganizationFieldJSONBody defines parameters for UpdateOrganizationField.
 type UpdateOrganizationFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName *string `json:"field_name,omitempty"`
 
@@ -2293,6 +2369,12 @@ type GetOrganizationsParams struct {
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
+
 	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
@@ -2347,7 +2429,7 @@ type AddOrganizationJSONBody struct {
 		Value *string `json:"value,omitempty"`
 	} `json:"address,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// LabelIds The IDs of labels assigned to the organization
@@ -2394,6 +2476,12 @@ type GetOrganizationParams struct {
 
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
+
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
 }
 
 // GetOrganizationParamsIncludeFields defines parameters for GetOrganization.
@@ -2437,7 +2525,7 @@ type UpdateOrganizationJSONBody struct {
 		Value *string `json:"value,omitempty"`
 	} `json:"address,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// LabelIds The IDs of labels assigned to the organization
@@ -2497,9 +2585,6 @@ type GetPersonFieldsParamsIncludeFields string
 
 // AddPersonFieldJSONBody defines parameters for AddPersonField.
 type AddPersonFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName string `json:"field_name"`
 
@@ -2572,9 +2657,6 @@ type GetPersonFieldParamsIncludeFields string
 
 // UpdatePersonFieldJSONBody defines parameters for UpdatePersonField.
 type UpdatePersonFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName *string `json:"field_name,omitempty"`
 
@@ -2680,6 +2762,12 @@ type GetPersonsParams struct {
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
+
 	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
 	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
 
@@ -2701,7 +2789,7 @@ type AddPersonJSONBody struct {
 	// AddTime The creation date and time of the person
 	AddTime *string `json:"add_time,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// Emails The emails of the person
@@ -2790,6 +2878,12 @@ type GetPersonParams struct {
 
 	// CustomFields Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
+
+	// IncludeOptionLabels When provided with a 'true' value, single option and multiple option custom fields values contain objects in the form of '{ id: number, label: string }' instead of plain id
+	IncludeOptionLabels *bool `form:"include_option_labels,omitempty" json:"include_option_labels,omitempty"`
+
+	// IncludeLabels When provided with 'true' value, response will include an array of label objects in the form of '{ id: number, label: string }'
+	IncludeLabels *bool `form:"include_labels,omitempty" json:"include_labels,omitempty"`
 }
 
 // GetPersonParamsIncludeFields defines parameters for GetPerson.
@@ -2800,7 +2894,7 @@ type UpdatePersonJSONBody struct {
 	// AddTime The creation date and time of the person
 	AddTime *string `json:"add_time,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// Emails The emails of the person
@@ -2876,6 +2970,36 @@ type GetPersonFollowersChangelogParams struct {
 	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
+// GetProjectsPhasesParams defines parameters for GetProjectsPhases.
+type GetProjectsPhasesParams struct {
+	// BoardId The ID of the board for which phases are requested
+	BoardId int `form:"board_id" json:"board_id"`
+}
+
+// AddProjectPhaseJSONBody defines parameters for AddProjectPhase.
+type AddProjectPhaseJSONBody struct {
+	// BoardId The ID of the project board to add the phase to
+	BoardId int `json:"board_id"`
+
+	// Name The name of the project phase
+	Name string `json:"name"`
+
+	// OrderNr The order of the phase within its board. Must be between 1 and the total number of phases on the board + 1.
+	OrderNr *int `json:"order_nr,omitempty"`
+}
+
+// UpdateProjectPhaseJSONBody defines parameters for UpdateProjectPhase.
+type UpdateProjectPhaseJSONBody struct {
+	// BoardId The ID of the project board to add the phase to
+	BoardId *int `json:"board_id,omitempty"`
+
+	// Name The name of the project phase
+	Name *string `json:"name,omitempty"`
+
+	// OrderNr The order of the phase within its board. Must be between 1 and the total number of phases on the board + 1.
+	OrderNr *int `json:"order_nr,omitempty"`
+}
+
 // GetPipelinesParams defines parameters for GetPipelines.
 type GetPipelinesParams struct {
 	// SortBy The field to sort by. Supported fields: `id`, `update_time`, `add_time`.
@@ -2932,9 +3056,6 @@ type GetProductFieldsParamsIncludeFields string
 
 // AddProductFieldJSONBody defines parameters for AddProductField.
 type AddProductFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName string `json:"field_name"`
 
@@ -2975,9 +3096,6 @@ type GetProductFieldParamsIncludeFields string
 
 // UpdateProductFieldJSONBody defines parameters for UpdateProductField.
 type UpdateProductFieldJSONBody struct {
-	// Description Field description
-	Description *string `json:"description"`
-
 	// FieldName Field name
 	FieldName *string `json:"field_name,omitempty"`
 
@@ -3039,6 +3157,9 @@ type GetProductsParams struct {
 	// SortDirection The sorting direction. Supported values: `asc`, `desc`.
 	SortDirection *GetProductsParamsSortDirection `form:"sort_direction,omitempty" json:"sort_direction,omitempty"`
 
+	// UpdatedSince If set, only products with an `update_time` later than or equal to this time are returned. In RFC3339 format, e.g. 2025-01-01T10:20:00Z.
+	UpdatedSince *string `form:"updated_since,omitempty" json:"updated_since,omitempty"`
+
 	// CustomFields Comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for a smaller response.<br/>A maximum of 15 keys is allowed.
 	CustomFields *string `form:"custom_fields,omitempty" json:"custom_fields,omitempty"`
 }
@@ -3075,7 +3196,7 @@ type AddProductJSONBody struct {
 	// Code The product code
 	Code *string `json:"code,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// Description The product description
@@ -3162,7 +3283,7 @@ type UpdateProductJSONBody struct {
 	// Code The product code
 	Code *string `json:"code,omitempty"`
 
-	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 	// Description The product description
@@ -3259,6 +3380,318 @@ type UpdateProductVariationJSONBody struct {
 	Prices *[]map[string]interface{} `json:"prices,omitempty"`
 }
 
+// GetProjectFieldsParams defines parameters for GetProjectFields.
+type GetProjectFieldsParams struct {
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// AddProjectFieldJSONBody defines parameters for AddProjectField.
+type AddProjectFieldJSONBody struct {
+	// FieldName Field name
+	FieldName string `json:"field_name"`
+
+	// FieldType The type of the field<table><tr><th>Value</th><th>Description</th></tr><tr><td>`varchar`</td><td>Text (up to 255 characters)</td><tr><td>`varchar_auto`</td><td>Autocomplete text (up to 255 characters)</td><tr><td>`text`</td><td>Long text (up to 65k characters)</td><tr><td>`double`</td><td>Numeric value</td><tr><td>`monetary`</td><td>Monetary field (has a numeric value and a currency value)</td><tr><td>`date`</td><td>Date (format YYYY-MM-DD)</td><tr><td>`set`</td><td>Options field with a possibility of having multiple chosen options</td><tr><td>`enum`</td><td>Options field with a single possible chosen option</td><tr><td>`user`</td><td>User field (contains a user ID of another Pipedrive user)</td><tr><td>`org`</td><td>Organization field (contains an organization ID which is stored on the same account)</td><tr><td>`people`</td><td>Person field (contains a person ID which is stored on the same account)</td><tr><td>`phone`</td><td>Phone field (up to 255 numbers and/or characters)</td><tr><td>`time`</td><td>Time field (format HH:MM:SS)</td><tr><td>`timerange`</td><td>Time-range field (has a start time and end time value, both HH:MM:SS)</td><tr><td>`daterange`</td><td>Date-range field (has a start date and end date value, both YYYY-MM-DD)</td><tr><td>`address`</td><td>Address field</dd></table>
+	FieldType AddProjectFieldJSONBodyFieldType `json:"field_type"`
+
+	// ImportantFields Configuration for highlighting the field at specific stages.
+	ImportantFields *AddProjectFieldJSONBody_ImportantFields `json:"important_fields,omitempty"`
+
+	// Options Field options (required for enum and set field types)
+	Options *[]struct {
+		// Label The option label
+		Label string `json:"label"`
+	} `json:"options,omitempty"`
+
+	// RequiredFields Required fields configuration for marking the field as mandatory when interacted with in the Pipedrive web UI.
+	RequiredFields *AddProjectFieldJSONBody_RequiredFields `json:"required_fields,omitempty"`
+
+	// UiVisibility UI visibility settings for the field. Controls where the field appears in the Pipedrive web UI.
+	UiVisibility *AddProjectFieldJSONBody_UiVisibility `json:"ui_visibility,omitempty"`
+}
+
+// AddProjectFieldJSONBodyFieldType defines parameters for AddProjectField.
+type AddProjectFieldJSONBodyFieldType string
+
+// AddProjectFieldJSONBody_ImportantFields defines parameters for AddProjectField.
+type AddProjectFieldJSONBody_ImportantFields struct {
+	// Enabled Whether the field is marked as important. When false, the field is not highlighted. When true with empty stage_ids, the field is important everywhere. When true with specific stage_ids, the field is important only at those deal stages. Default is false.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// StageIds Array of deal stage IDs where this project field should be highlighted as important. Must reference valid, active deal stages. Empty array when enabled is false.
+	StageIds             *[]int                 `json:"stage_ids,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// AddProjectFieldJSONBody_RequiredFields defines parameters for AddProjectField.
+type AddProjectFieldJSONBody_RequiredFields struct {
+	// Enabled Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating projects. Default is false.
+	Enabled              *bool                  `json:"enabled,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// AddProjectFieldJSONBody_UiVisibility defines parameters for AddProjectField.
+type AddProjectFieldJSONBody_UiVisibility struct {
+	// AddVisibleFlag Whether the field is shown in the add project modal. Default is false.
+	AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+	// DetailsVisibleFlag Whether the field is shown in the project details view. Default is true.
+	DetailsVisibleFlag   *bool                  `json:"details_visible_flag,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// UpdateProjectFieldJSONBody defines parameters for UpdateProjectField.
+type UpdateProjectFieldJSONBody struct {
+	// FieldName Field name
+	FieldName *string `json:"field_name,omitempty"`
+
+	// ImportantFields Configuration for highlighting the field at specific stages.
+	ImportantFields *UpdateProjectFieldJSONBody_ImportantFields `json:"important_fields,omitempty"`
+
+	// RequiredFields Required fields configuration for marking the field as mandatory when interacted with in the Pipedrive web UI.
+	RequiredFields *UpdateProjectFieldJSONBody_RequiredFields `json:"required_fields,omitempty"`
+
+	// UiVisibility UI visibility settings for the field. Controls where the field appears in the Pipedrive web UI.
+	UiVisibility *UpdateProjectFieldJSONBody_UiVisibility `json:"ui_visibility,omitempty"`
+}
+
+// UpdateProjectFieldJSONBody_ImportantFields defines parameters for UpdateProjectField.
+type UpdateProjectFieldJSONBody_ImportantFields struct {
+	// Enabled Whether the field is marked as important. When false, the field is not highlighted. When true with empty stage_ids, the field is important everywhere. When true with specific stage_ids, the field is important only at those deal stages. Default is false.
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// StageIds Array of deal stage IDs where this project field should be highlighted as important. Must reference valid, active deal stages. Empty array when enabled is false.
+	StageIds             *[]int                 `json:"stage_ids,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// UpdateProjectFieldJSONBody_RequiredFields defines parameters for UpdateProjectField.
+type UpdateProjectFieldJSONBody_RequiredFields struct {
+	// Enabled Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating projects. Default is false.
+	Enabled              *bool                  `json:"enabled,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// UpdateProjectFieldJSONBody_UiVisibility defines parameters for UpdateProjectField.
+type UpdateProjectFieldJSONBody_UiVisibility struct {
+	// AddVisibleFlag Whether the field is shown in the add project modal. Default is false.
+	AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+	// DetailsVisibleFlag Whether the field is shown in the project details view. Default is true.
+	DetailsVisibleFlag   *bool                  `json:"details_visible_flag,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// DeleteProjectFieldOptionsJSONBody defines parameters for DeleteProjectFieldOptions.
+type DeleteProjectFieldOptionsJSONBody = []struct {
+	// Id The unique identifier of the option to delete
+	Id int `json:"id"`
+}
+
+// UpdateProjectFieldOptionsJSONBody defines parameters for UpdateProjectFieldOptions.
+type UpdateProjectFieldOptionsJSONBody = []struct {
+	// Id The unique identifier of the option to update
+	Id int `json:"id"`
+
+	// Label The new display label for the option
+	Label string `json:"label"`
+}
+
+// AddProjectFieldOptionsJSONBody defines parameters for AddProjectFieldOptions.
+type AddProjectFieldOptionsJSONBody = []struct {
+	// Label The display label for the new option
+	Label string `json:"label"`
+}
+
+// GetProjectTemplatesParams defines parameters for GetProjectTemplates.
+type GetProjectTemplatesParams struct {
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetProjectsParams defines parameters for GetProjects.
+type GetProjectsParams struct {
+	// FilterId If supplied, only projects matching the specified filter are returned
+	FilterId *int `form:"filter_id,omitempty" json:"filter_id,omitempty"`
+
+	// Status If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.
+	Status *string `form:"status,omitempty" json:"status,omitempty"`
+
+	// PhaseId If supplied, only projects in the specified phase are returned
+	PhaseId *int `form:"phase_id,omitempty" json:"phase_id,omitempty"`
+
+	// DealId If supplied, only projects associated with the specified deal are returned
+	DealId *int `form:"deal_id,omitempty" json:"deal_id,omitempty"`
+
+	// PersonId If supplied, only projects associated with the specified person are returned
+	PersonId *int `form:"person_id,omitempty" json:"person_id,omitempty"`
+
+	// OrgId If supplied, only projects associated with the specified organization are returned
+	OrgId *int `form:"org_id,omitempty" json:"org_id,omitempty"`
+
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// AddProjectJSONBody defines parameters for AddProject.
+type AddProjectJSONBody struct {
+	// BoardId The ID of the board this project is associated with
+	BoardId *int `json:"board_id,omitempty"`
+
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+	// DealIds An array of IDs of the deals this project is associated with
+	DealIds *[]int `json:"deal_ids,omitempty"`
+
+	// Description The description of the project
+	Description *string `json:"description,omitempty"`
+
+	// EndDate The end date of the project. Format: YYYY-MM-DD
+	EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+	// HealthStatus The health status of the project
+	HealthStatus *int `json:"health_status,omitempty"`
+
+	// LabelIds An array of IDs of the labels this project has
+	LabelIds *[]int `json:"label_ids,omitempty"`
+
+	// OrgIds An array of IDs of the organizations this project is associated with
+	OrgIds *[]int `json:"org_ids,omitempty"`
+
+	// OwnerId The ID of the user who owns the project
+	OwnerId *int `json:"owner_id,omitempty"`
+
+	// PersonIds An array of IDs of the persons this project is associated with
+	PersonIds *[]int `json:"person_ids,omitempty"`
+
+	// PhaseId The ID of the phase this project is associated with
+	PhaseId *int `json:"phase_id,omitempty"`
+
+	// StartDate The start date of the project. Format: YYYY-MM-DD
+	StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+	// Status The status of the project
+	Status *string `json:"status,omitempty"`
+
+	// TemplateId The ID of the template the project will be based on. Only used when creating a new project.
+	TemplateId *int `json:"template_id,omitempty"`
+
+	// Title The title of the project
+	Title string `json:"title"`
+}
+
+// GetArchivedProjectsParams defines parameters for GetArchivedProjects.
+type GetArchivedProjectsParams struct {
+	// FilterId If supplied, only projects matching the specified filter are returned
+	FilterId *int `form:"filter_id,omitempty" json:"filter_id,omitempty"`
+
+	// Status If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.
+	Status *string `form:"status,omitempty" json:"status,omitempty"`
+
+	// PhaseId If supplied, only projects in the specified phase are returned
+	PhaseId *int `form:"phase_id,omitempty" json:"phase_id,omitempty"`
+
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// SearchProjectsParams defines parameters for SearchProjects.
+type SearchProjectsParams struct {
+	// Term The search term to look for. Minimum 2 characters (or 1 if using `exact_match`). Please note that the search term has to be URL encoded.
+	Term string `form:"term" json:"term"`
+
+	// Fields A comma-separated string array. The fields to perform the search from. Defaults to all of them. Only the following custom field types are searchable: `address`, `varchar`, `text`, `varchar_auto`, `double`, `monetary` and `phone`. Read more about searching by custom fields <a href="https://support.pipedrive.com/en/article/search-finding-what-you-need#searching-by-custom-fields" target="_blank" rel="noopener noreferrer">here</a>.
+	Fields *SearchProjectsParamsFields `form:"fields,omitempty" json:"fields,omitempty"`
+
+	// ExactMatch When enabled, only full exact matches against the given term are returned. It is <b>not</b> case sensitive.
+	ExactMatch *bool `form:"exact_match,omitempty" json:"exact_match,omitempty"`
+
+	// PersonId Will filter projects by the provided person ID
+	PersonId *int `form:"person_id,omitempty" json:"person_id,omitempty"`
+
+	// OrganizationId Will filter projects by the provided organization ID
+	OrganizationId *int `form:"organization_id,omitempty" json:"organization_id,omitempty"`
+
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// SearchProjectsParamsFields defines parameters for SearchProjects.
+type SearchProjectsParamsFields string
+
+// UpdateProjectJSONBody defines parameters for UpdateProject.
+type UpdateProjectJSONBody struct {
+	// BoardId The ID of the board this project is associated with
+	BoardId *int `json:"board_id,omitempty"`
+
+	// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+	CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+	// DealIds An array of IDs of the deals this project is associated with
+	DealIds *[]int `json:"deal_ids,omitempty"`
+
+	// Description The description of the project
+	Description *string `json:"description,omitempty"`
+
+	// EndDate The end date of the project. Format: YYYY-MM-DD
+	EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+	// HealthStatus The health status of the project
+	HealthStatus *int `json:"health_status,omitempty"`
+
+	// LabelIds An array of IDs of the labels this project has
+	LabelIds *[]int `json:"label_ids,omitempty"`
+
+	// OrgIds An array of IDs of the organizations this project is associated with
+	OrgIds *[]int `json:"org_ids,omitempty"`
+
+	// OwnerId The ID of the user who owns the project
+	OwnerId *int `json:"owner_id,omitempty"`
+
+	// PersonIds An array of IDs of the persons this project is associated with
+	PersonIds *[]int `json:"person_ids,omitempty"`
+
+	// PhaseId The ID of the phase this project is associated with
+	PhaseId *int `json:"phase_id,omitempty"`
+
+	// StartDate The start date of the project. Format: YYYY-MM-DD
+	StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+	// Status The status of the project
+	Status *string `json:"status,omitempty"`
+
+	// TemplateId The ID of the template the project will be based on. Only used when creating a new project.
+	TemplateId *int `json:"template_id,omitempty"`
+
+	// Title The title of the project
+	Title *string `json:"title,omitempty"`
+}
+
+// GetProjectChangelogParams defines parameters for GetProjectChangelog.
+type GetProjectChangelogParams struct {
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
 // GetStagesParams defines parameters for GetStages.
 type GetStagesParams struct {
 	// PipelineId The ID of the pipeline to fetch stages for. If omitted, stages for all pipelines will be fetched.
@@ -3319,6 +3752,114 @@ type UpdateStageJSONBody struct {
 	PipelineId *int `json:"pipeline_id,omitempty"`
 }
 
+// GetTasksParams defines parameters for GetTasks.
+type GetTasksParams struct {
+	// Cursor For pagination, the marker (an opaque string value) representing the first item on the next page
+	Cursor *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+
+	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// IsDone Whether the task is done or not. If omitted, both done and not done tasks are returned.
+	IsDone *bool `form:"is_done,omitempty" json:"is_done,omitempty"`
+
+	// IsMilestone Whether the task is a milestone or not. If omitted, both milestone and non-milestone tasks are returned.
+	IsMilestone *bool `form:"is_milestone,omitempty" json:"is_milestone,omitempty"`
+
+	// AssigneeId If supplied, only tasks assigned to this user are returned
+	AssigneeId *int `form:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+
+	// ProjectId If supplied, only tasks belonging to this project are returned
+	ProjectId *int `form:"project_id,omitempty" json:"project_id,omitempty"`
+
+	// ParentTaskId If `null` is supplied, only root-level tasks (without a parent) are returned. If an integer is supplied, only subtasks of that specific task are returned. By default all tasks are returned.
+	ParentTaskId *string `form:"parent_task_id,omitempty" json:"parent_task_id,omitempty"`
+}
+
+// AddTaskJSONBody defines parameters for AddTask.
+type AddTaskJSONBody struct {
+	// AssigneeId The ID of the user assigned to the task. When set, the `assignee_ids` field will be overwritten with this value.
+	AssigneeId *int `json:"assignee_id"`
+
+	// AssigneeIds The IDs of users assigned to the task. When set, the `assignee_id` field will be set to the first value in this array, or `null` if empty.
+	AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+	// Description The description of the task
+	Description *string `json:"description"`
+
+	// Done Whether the task is done or not. `0` = Not done, `1` = Done.
+	Done *AddTaskJSONBodyDone `json:"done,omitempty"`
+
+	// DueDate The due date of the task. Format: YYYY-MM-DD.
+	DueDate *openapi_types.Date `json:"due_date"`
+
+	// Milestone Whether the task is a milestone or not. `0` = Not a milestone, `1` = Milestone.
+	Milestone *AddTaskJSONBodyMilestone `json:"milestone,omitempty"`
+
+	// ParentTaskId The ID of the parent task. Cannot be the ID of a task that is already a subtask.
+	ParentTaskId *int `json:"parent_task_id"`
+
+	// Priority The priority of the task
+	Priority *int `json:"priority"`
+
+	// ProjectId The ID of the project this task is associated with
+	ProjectId int `json:"project_id"`
+
+	// StartDate The start date of the task. Format: YYYY-MM-DD.
+	StartDate *openapi_types.Date `json:"start_date"`
+
+	// Title The title of the task
+	Title string `json:"title"`
+}
+
+// AddTaskJSONBodyDone defines parameters for AddTask.
+type AddTaskJSONBodyDone int
+
+// AddTaskJSONBodyMilestone defines parameters for AddTask.
+type AddTaskJSONBodyMilestone int
+
+// UpdateTaskJSONBody defines parameters for UpdateTask.
+type UpdateTaskJSONBody struct {
+	// AssigneeId The ID of the user assigned to the task. When set, the `assignee_ids` field will be overwritten with this value.
+	AssigneeId *int `json:"assignee_id"`
+
+	// AssigneeIds The IDs of users assigned to the task. When set, the `assignee_id` field will be set to the first value in this array, or `null` if empty.
+	AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+	// Description The description of the task
+	Description *string `json:"description"`
+
+	// Done Whether the task is done or not. `0` = Not done, `1` = Done.
+	Done *UpdateTaskJSONBodyDone `json:"done,omitempty"`
+
+	// DueDate The due date of the task. Format: YYYY-MM-DD.
+	DueDate *openapi_types.Date `json:"due_date"`
+
+	// Milestone Whether the task is a milestone or not. `0` = Not a milestone, `1` = Milestone.
+	Milestone *UpdateTaskJSONBodyMilestone `json:"milestone,omitempty"`
+
+	// ParentTaskId The ID of the parent task. Cannot be the ID of a task that is already a subtask.
+	ParentTaskId *int `json:"parent_task_id"`
+
+	// Priority The priority of the task
+	Priority *int `json:"priority"`
+
+	// ProjectId The ID of the project this task is associated with
+	ProjectId *int `json:"project_id,omitempty"`
+
+	// StartDate The start date of the task. Format: YYYY-MM-DD.
+	StartDate *openapi_types.Date `json:"start_date"`
+
+	// Title The title of the task
+	Title *string `json:"title,omitempty"`
+}
+
+// UpdateTaskJSONBodyDone defines parameters for UpdateTask.
+type UpdateTaskJSONBodyDone int
+
+// UpdateTaskJSONBodyMilestone defines parameters for UpdateTask.
+type UpdateTaskJSONBodyMilestone int
+
 // GetUserFollowersParams defines parameters for GetUserFollowers.
 type GetUserFollowersParams struct {
 	// Limit For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.
@@ -3333,6 +3874,12 @@ type AddActivityJSONRequestBody AddActivityJSONBody
 
 // UpdateActivityJSONRequestBody defines body for UpdateActivity for application/json ContentType.
 type UpdateActivityJSONRequestBody UpdateActivityJSONBody
+
+// AddProjectBoardJSONRequestBody defines body for AddProjectBoard for application/json ContentType.
+type AddProjectBoardJSONRequestBody AddProjectBoardJSONBody
+
+// UpdateProjectBoardJSONRequestBody defines body for UpdateProjectBoard for application/json ContentType.
+type UpdateProjectBoardJSONRequestBody UpdateProjectBoardJSONBody
 
 // AddDealFieldJSONRequestBody defines body for AddDealField for application/json ContentType.
 type AddDealFieldJSONRequestBody AddDealFieldJSONBody
@@ -3430,6 +3977,12 @@ type UpdatePersonJSONRequestBody UpdatePersonJSONBody
 // AddPersonFollowerJSONRequestBody defines body for AddPersonFollower for application/json ContentType.
 type AddPersonFollowerJSONRequestBody AddPersonFollowerJSONBody
 
+// AddProjectPhaseJSONRequestBody defines body for AddProjectPhase for application/json ContentType.
+type AddProjectPhaseJSONRequestBody AddProjectPhaseJSONBody
+
+// UpdateProjectPhaseJSONRequestBody defines body for UpdateProjectPhase for application/json ContentType.
+type UpdateProjectPhaseJSONRequestBody UpdateProjectPhaseJSONBody
+
 // AddPipelineJSONRequestBody defines body for AddPipeline for application/json ContentType.
 type AddPipelineJSONRequestBody AddPipelineJSONBody
 
@@ -3472,11 +4025,38 @@ type AddProductVariationJSONRequestBody AddProductVariationJSONBody
 // UpdateProductVariationJSONRequestBody defines body for UpdateProductVariation for application/json ContentType.
 type UpdateProductVariationJSONRequestBody UpdateProductVariationJSONBody
 
+// AddProjectFieldJSONRequestBody defines body for AddProjectField for application/json ContentType.
+type AddProjectFieldJSONRequestBody AddProjectFieldJSONBody
+
+// UpdateProjectFieldJSONRequestBody defines body for UpdateProjectField for application/json ContentType.
+type UpdateProjectFieldJSONRequestBody UpdateProjectFieldJSONBody
+
+// DeleteProjectFieldOptionsJSONRequestBody defines body for DeleteProjectFieldOptions for application/json ContentType.
+type DeleteProjectFieldOptionsJSONRequestBody = DeleteProjectFieldOptionsJSONBody
+
+// UpdateProjectFieldOptionsJSONRequestBody defines body for UpdateProjectFieldOptions for application/json ContentType.
+type UpdateProjectFieldOptionsJSONRequestBody = UpdateProjectFieldOptionsJSONBody
+
+// AddProjectFieldOptionsJSONRequestBody defines body for AddProjectFieldOptions for application/json ContentType.
+type AddProjectFieldOptionsJSONRequestBody = AddProjectFieldOptionsJSONBody
+
+// AddProjectJSONRequestBody defines body for AddProject for application/json ContentType.
+type AddProjectJSONRequestBody AddProjectJSONBody
+
+// UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
+type UpdateProjectJSONRequestBody UpdateProjectJSONBody
+
 // AddStageJSONRequestBody defines body for AddStage for application/json ContentType.
 type AddStageJSONRequestBody AddStageJSONBody
 
 // UpdateStageJSONRequestBody defines body for UpdateStage for application/json ContentType.
 type UpdateStageJSONRequestBody UpdateStageJSONBody
+
+// AddTaskJSONRequestBody defines body for AddTask for application/json ContentType.
+type AddTaskJSONRequestBody AddTaskJSONBody
+
+// UpdateTaskJSONRequestBody defines body for UpdateTask for application/json ContentType.
+type UpdateTaskJSONRequestBody UpdateTaskJSONBody
 
 // Getter for additional properties for AddDealFieldJSONBody_ImportantFields. Returns the specified
 // element and whether it was found
@@ -5258,6 +5838,474 @@ func (a UpdateProductFieldJSONBody_UiVisibility) MarshalJSON() ([]byte, error) {
 	return json.Marshal(object)
 }
 
+// Getter for additional properties for AddProjectFieldJSONBody_ImportantFields. Returns the specified
+// element and whether it was found
+func (a AddProjectFieldJSONBody_ImportantFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for AddProjectFieldJSONBody_ImportantFields
+func (a *AddProjectFieldJSONBody_ImportantFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_ImportantFields to handle AdditionalProperties
+func (a *AddProjectFieldJSONBody_ImportantFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["enabled"]; found {
+		err = json.Unmarshal(raw, &a.Enabled)
+		if err != nil {
+			return fmt.Errorf("error reading 'enabled': %w", err)
+		}
+		delete(object, "enabled")
+	}
+
+	if raw, found := object["stage_ids"]; found {
+		err = json.Unmarshal(raw, &a.StageIds)
+		if err != nil {
+			return fmt.Errorf("error reading 'stage_ids': %w", err)
+		}
+		delete(object, "stage_ids")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_ImportantFields to handle AdditionalProperties
+func (a AddProjectFieldJSONBody_ImportantFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Enabled != nil {
+		object["enabled"], err = json.Marshal(a.Enabled)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'enabled': %w", err)
+		}
+	}
+
+	if a.StageIds != nil {
+		object["stage_ids"], err = json.Marshal(a.StageIds)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'stage_ids': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for AddProjectFieldJSONBody_RequiredFields. Returns the specified
+// element and whether it was found
+func (a AddProjectFieldJSONBody_RequiredFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for AddProjectFieldJSONBody_RequiredFields
+func (a *AddProjectFieldJSONBody_RequiredFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_RequiredFields to handle AdditionalProperties
+func (a *AddProjectFieldJSONBody_RequiredFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["enabled"]; found {
+		err = json.Unmarshal(raw, &a.Enabled)
+		if err != nil {
+			return fmt.Errorf("error reading 'enabled': %w", err)
+		}
+		delete(object, "enabled")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_RequiredFields to handle AdditionalProperties
+func (a AddProjectFieldJSONBody_RequiredFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Enabled != nil {
+		object["enabled"], err = json.Marshal(a.Enabled)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'enabled': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for AddProjectFieldJSONBody_UiVisibility. Returns the specified
+// element and whether it was found
+func (a AddProjectFieldJSONBody_UiVisibility) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for AddProjectFieldJSONBody_UiVisibility
+func (a *AddProjectFieldJSONBody_UiVisibility) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_UiVisibility to handle AdditionalProperties
+func (a *AddProjectFieldJSONBody_UiVisibility) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["add_visible_flag"]; found {
+		err = json.Unmarshal(raw, &a.AddVisibleFlag)
+		if err != nil {
+			return fmt.Errorf("error reading 'add_visible_flag': %w", err)
+		}
+		delete(object, "add_visible_flag")
+	}
+
+	if raw, found := object["details_visible_flag"]; found {
+		err = json.Unmarshal(raw, &a.DetailsVisibleFlag)
+		if err != nil {
+			return fmt.Errorf("error reading 'details_visible_flag': %w", err)
+		}
+		delete(object, "details_visible_flag")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for AddProjectFieldJSONBody_UiVisibility to handle AdditionalProperties
+func (a AddProjectFieldJSONBody_UiVisibility) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.AddVisibleFlag != nil {
+		object["add_visible_flag"], err = json.Marshal(a.AddVisibleFlag)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'add_visible_flag': %w", err)
+		}
+	}
+
+	if a.DetailsVisibleFlag != nil {
+		object["details_visible_flag"], err = json.Marshal(a.DetailsVisibleFlag)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'details_visible_flag': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for UpdateProjectFieldJSONBody_ImportantFields. Returns the specified
+// element and whether it was found
+func (a UpdateProjectFieldJSONBody_ImportantFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for UpdateProjectFieldJSONBody_ImportantFields
+func (a *UpdateProjectFieldJSONBody_ImportantFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_ImportantFields to handle AdditionalProperties
+func (a *UpdateProjectFieldJSONBody_ImportantFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["enabled"]; found {
+		err = json.Unmarshal(raw, &a.Enabled)
+		if err != nil {
+			return fmt.Errorf("error reading 'enabled': %w", err)
+		}
+		delete(object, "enabled")
+	}
+
+	if raw, found := object["stage_ids"]; found {
+		err = json.Unmarshal(raw, &a.StageIds)
+		if err != nil {
+			return fmt.Errorf("error reading 'stage_ids': %w", err)
+		}
+		delete(object, "stage_ids")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_ImportantFields to handle AdditionalProperties
+func (a UpdateProjectFieldJSONBody_ImportantFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Enabled != nil {
+		object["enabled"], err = json.Marshal(a.Enabled)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'enabled': %w", err)
+		}
+	}
+
+	if a.StageIds != nil {
+		object["stage_ids"], err = json.Marshal(a.StageIds)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'stage_ids': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for UpdateProjectFieldJSONBody_RequiredFields. Returns the specified
+// element and whether it was found
+func (a UpdateProjectFieldJSONBody_RequiredFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for UpdateProjectFieldJSONBody_RequiredFields
+func (a *UpdateProjectFieldJSONBody_RequiredFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_RequiredFields to handle AdditionalProperties
+func (a *UpdateProjectFieldJSONBody_RequiredFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["enabled"]; found {
+		err = json.Unmarshal(raw, &a.Enabled)
+		if err != nil {
+			return fmt.Errorf("error reading 'enabled': %w", err)
+		}
+		delete(object, "enabled")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_RequiredFields to handle AdditionalProperties
+func (a UpdateProjectFieldJSONBody_RequiredFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Enabled != nil {
+		object["enabled"], err = json.Marshal(a.Enabled)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'enabled': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for UpdateProjectFieldJSONBody_UiVisibility. Returns the specified
+// element and whether it was found
+func (a UpdateProjectFieldJSONBody_UiVisibility) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for UpdateProjectFieldJSONBody_UiVisibility
+func (a *UpdateProjectFieldJSONBody_UiVisibility) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_UiVisibility to handle AdditionalProperties
+func (a *UpdateProjectFieldJSONBody_UiVisibility) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["add_visible_flag"]; found {
+		err = json.Unmarshal(raw, &a.AddVisibleFlag)
+		if err != nil {
+			return fmt.Errorf("error reading 'add_visible_flag': %w", err)
+		}
+		delete(object, "add_visible_flag")
+	}
+
+	if raw, found := object["details_visible_flag"]; found {
+		err = json.Unmarshal(raw, &a.DetailsVisibleFlag)
+		if err != nil {
+			return fmt.Errorf("error reading 'details_visible_flag': %w", err)
+		}
+		delete(object, "details_visible_flag")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for UpdateProjectFieldJSONBody_UiVisibility to handle AdditionalProperties
+func (a UpdateProjectFieldJSONBody_UiVisibility) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.AddVisibleFlag != nil {
+		object["add_visible_flag"], err = json.Marshal(a.AddVisibleFlag)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'add_visible_flag': %w", err)
+		}
+	}
+
+	if a.DetailsVisibleFlag != nil {
+		object["details_visible_flag"], err = json.Marshal(a.DetailsVisibleFlag)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'details_visible_flag': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
 
@@ -5355,6 +6403,25 @@ type ClientInterface interface {
 
 	// GetActivityField request
 	GetActivityField(ctx context.Context, fieldCode string, params *GetActivityFieldParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectsBoards request
+	GetProjectsBoards(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddProjectBoardWithBody request with any body
+	AddProjectBoardWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddProjectBoard(ctx context.Context, body AddProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectBoard request
+	DeleteProjectBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectsBoard request
+	GetProjectsBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectBoardWithBody request with any body
+	UpdateProjectBoardWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectBoard(ctx context.Context, id int, body UpdateProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDealFields request
 	GetDealFields(ctx context.Context, params *GetDealFieldsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5654,6 +6721,25 @@ type ClientInterface interface {
 	// GetPersonPicture request
 	GetPersonPicture(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetProjectsPhases request
+	GetProjectsPhases(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddProjectPhaseWithBody request with any body
+	AddProjectPhaseWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddProjectPhase(ctx context.Context, body AddProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectPhase request
+	DeleteProjectPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectsPhase request
+	GetProjectsPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectPhaseWithBody request with any body
+	UpdateProjectPhaseWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectPhase(ctx context.Context, id int, body UpdateProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetPipelines request
 	GetPipelines(ctx context.Context, params *GetPipelinesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5774,6 +6860,80 @@ type ClientInterface interface {
 
 	UpdateProductVariation(ctx context.Context, id int, productVariationId int, body UpdateProductVariationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetProjectFields request
+	GetProjectFields(ctx context.Context, params *GetProjectFieldsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddProjectFieldWithBody request with any body
+	AddProjectFieldWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddProjectField(ctx context.Context, body AddProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectField request
+	DeleteProjectField(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectField request
+	GetProjectField(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectFieldWithBody request with any body
+	UpdateProjectFieldWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectField(ctx context.Context, fieldCode string, body UpdateProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectFieldOptionsWithBody request with any body
+	DeleteProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	DeleteProjectFieldOptions(ctx context.Context, fieldCode string, body DeleteProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectFieldOptionsWithBody request with any body
+	UpdateProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectFieldOptions(ctx context.Context, fieldCode string, body UpdateProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddProjectFieldOptionsWithBody request with any body
+	AddProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddProjectFieldOptions(ctx context.Context, fieldCode string, body AddProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectTemplates request
+	GetProjectTemplates(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectTemplate request
+	GetProjectTemplate(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjects request
+	GetProjects(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddProjectWithBody request with any body
+	AddProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddProject(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetArchivedProjects request
+	GetArchivedProjects(ctx context.Context, params *GetArchivedProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// SearchProjects request
+	SearchProjects(ctx context.Context, params *SearchProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProject request
+	DeleteProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProject request
+	GetProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectWithBody request with any body
+	UpdateProjectWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProject(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ArchiveProject request
+	ArchiveProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectChangelog request
+	GetProjectChangelog(ctx context.Context, id int, params *GetProjectChangelogParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectUsers request
+	GetProjectUsers(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetStages request
 	GetStages(ctx context.Context, params *GetStagesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5792,6 +6952,25 @@ type ClientInterface interface {
 	UpdateStageWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateStage(ctx context.Context, id int, body UpdateStageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetTasks request
+	GetTasks(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AddTaskWithBody request with any body
+	AddTaskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AddTask(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteTask request
+	DeleteTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetTask request
+	GetTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateTaskWithBody request with any body
+	UpdateTaskWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateTask(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetUserFollowers request
 	GetUserFollowers(ctx context.Context, id int, params *GetUserFollowersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5895,6 +7074,90 @@ func (c *Client) GetActivityFields(ctx context.Context, params *GetActivityField
 
 func (c *Client) GetActivityField(ctx context.Context, fieldCode string, params *GetActivityFieldParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetActivityFieldRequest(c.Server, fieldCode, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectsBoards(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectsBoardsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectBoardWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectBoardRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectBoard(ctx context.Context, body AddProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectBoardRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectBoardRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectsBoard(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectsBoardRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectBoardWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectBoardRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectBoard(ctx context.Context, id int, body UpdateProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectBoardRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -7225,6 +8488,90 @@ func (c *Client) GetPersonPicture(ctx context.Context, id int, reqEditors ...Req
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetProjectsPhases(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectsPhasesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectPhaseWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectPhaseRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectPhase(ctx context.Context, body AddProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectPhaseRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectPhaseRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectsPhase(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectsPhaseRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectPhaseWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectPhaseRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectPhase(ctx context.Context, id int, body UpdateProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectPhaseRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetPipelines(ctx context.Context, params *GetPipelinesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetPipelinesRequest(c.Server, params)
 	if err != nil {
@@ -7753,6 +9100,330 @@ func (c *Client) UpdateProductVariation(ctx context.Context, id int, productVari
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetProjectFields(ctx context.Context, params *GetProjectFieldsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectFieldsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectFieldWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectFieldRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectField(ctx context.Context, body AddProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectFieldRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectField(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectFieldRequest(c.Server, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectField(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectFieldRequest(c.Server, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectFieldWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectFieldRequestWithBody(c.Server, fieldCode, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectField(ctx context.Context, fieldCode string, body UpdateProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectFieldRequest(c.Server, fieldCode, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectFieldOptionsRequestWithBody(c.Server, fieldCode, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectFieldOptions(ctx context.Context, fieldCode string, body DeleteProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectFieldOptionsRequest(c.Server, fieldCode, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectFieldOptionsRequestWithBody(c.Server, fieldCode, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectFieldOptions(ctx context.Context, fieldCode string, body UpdateProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectFieldOptionsRequest(c.Server, fieldCode, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectFieldOptionsWithBody(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectFieldOptionsRequestWithBody(c.Server, fieldCode, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectFieldOptions(ctx context.Context, fieldCode string, body AddProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectFieldOptionsRequest(c.Server, fieldCode, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectTemplates(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectTemplatesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectTemplate(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectTemplateRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjects(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProjectWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddProject(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddProjectRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetArchivedProjects(ctx context.Context, params *GetArchivedProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetArchivedProjectsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) SearchProjects(ctx context.Context, params *SearchProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSearchProjectsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProject(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ArchiveProject(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewArchiveProjectRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectChangelog(ctx context.Context, id int, params *GetProjectChangelogParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectChangelogRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectUsers(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectUsersRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetStages(ctx context.Context, params *GetStagesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetStagesRequest(c.Server, params)
 	if err != nil {
@@ -7827,6 +9498,90 @@ func (c *Client) UpdateStageWithBody(ctx context.Context, id int, contentType st
 
 func (c *Client) UpdateStage(ctx context.Context, id int, body UpdateStageJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateStageRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetTasks(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetTasksRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddTaskWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddTaskRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AddTask(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAddTaskRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteTaskRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetTask(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetTaskRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateTaskWithBody(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateTaskRequestWithBody(c.Server, id, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateTask(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateTaskRequest(c.Server, id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -8432,6 +10187,188 @@ func NewGetActivityFieldRequest(server string, fieldCode string, params *GetActi
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewGetProjectsBoardsRequest generates requests for GetProjectsBoards
+func NewGetProjectsBoardsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boards")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAddProjectBoardRequest calls the generic AddProjectBoard builder with application/json body
+func NewAddProjectBoardRequest(server string, body AddProjectBoardJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddProjectBoardRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAddProjectBoardRequestWithBody generates requests for AddProjectBoard with any type of body
+func NewAddProjectBoardRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boards")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectBoardRequest generates requests for DeleteProjectBoard
+func NewDeleteProjectBoardRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boards/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectsBoardRequest generates requests for GetProjectsBoard
+func NewGetProjectsBoardRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boards/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectBoardRequest calls the generic UpdateProjectBoard builder with application/json body
+func NewUpdateProjectBoardRequest(server string, id int, body UpdateProjectBoardJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectBoardRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateProjectBoardRequestWithBody generates requests for UpdateProjectBoard with any type of body
+func NewUpdateProjectBoardRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/boards/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -9081,6 +11018,38 @@ func NewGetDealsRequest(server string, params *GetDealsParams) (*http.Request, e
 
 		}
 
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
@@ -9584,7 +11553,7 @@ func NewGetDealsProductsRequest(server string, params *GetDealsProductsParams) (
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "deal_ids", runtime.ParamLocationQuery, params.DealIds); err != nil {
+		if queryFrag, err := runtime.StyleParamWithLocation("form", false, "deal_ids", runtime.ParamLocationQuery, params.DealIds); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err
@@ -9926,6 +11895,38 @@ func NewGetDealRequest(server string, id int, params *GetDealParams) (*http.Requ
 		if params.CustomFields != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "custom_fields", runtime.ParamLocationQuery, *params.CustomFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -12055,6 +14056,38 @@ func NewGetOrganizationsRequest(server string, params *GetOrganizationsParams) (
 
 		}
 
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
@@ -12329,6 +14362,38 @@ func NewGetOrganizationRequest(server string, id int, params *GetOrganizationPar
 		if params.CustomFields != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "custom_fields", runtime.ParamLocationQuery, *params.CustomFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -13229,6 +15294,38 @@ func NewGetPersonsRequest(server string, params *GetPersonsParams) (*http.Reques
 
 		}
 
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Limit != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
@@ -13535,6 +15632,38 @@ func NewGetPersonRequest(server string, id int, params *GetPersonParams) (*http.
 		if params.CustomFields != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "custom_fields", runtime.ParamLocationQuery, *params.CustomFields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeOptionLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_option_labels", runtime.ParamLocationQuery, *params.IncludeOptionLabels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeLabels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_labels", runtime.ParamLocationQuery, *params.IncludeLabels); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -13868,6 +15997,206 @@ func NewGetPersonPictureRequest(server string, id int) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewGetProjectsPhasesRequest generates requests for GetProjectsPhases
+func NewGetProjectsPhasesRequest(server string, params *GetProjectsPhasesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/phases")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "board_id", runtime.ParamLocationQuery, params.BoardId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAddProjectPhaseRequest calls the generic AddProjectPhase builder with application/json body
+func NewAddProjectPhaseRequest(server string, body AddProjectPhaseJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddProjectPhaseRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAddProjectPhaseRequestWithBody generates requests for AddProjectPhase with any type of body
+func NewAddProjectPhaseRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/phases")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectPhaseRequest generates requests for DeleteProjectPhase
+func NewDeleteProjectPhaseRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/phases/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectsPhaseRequest generates requests for GetProjectsPhase
+func NewGetProjectsPhaseRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/phases/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectPhaseRequest calls the generic UpdateProjectPhase builder with application/json body
+func NewUpdateProjectPhaseRequest(server string, id int, body UpdateProjectPhaseJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectPhaseRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateProjectPhaseRequestWithBody generates requests for UpdateProjectPhase with any type of body
+func NewUpdateProjectPhaseRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/phases/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -14644,6 +16973,22 @@ func NewGetProductsRequest(server string, params *GetProductsParams) (*http.Requ
 		if params.SortDirection != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort_direction", runtime.ParamLocationQuery, *params.SortDirection); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.UpdatedSince != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "updated_since", runtime.ParamLocationQuery, *params.UpdatedSince); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -15584,6 +17929,1176 @@ func NewUpdateProductVariationRequestWithBody(server string, id int, productVari
 	return req, nil
 }
 
+// NewGetProjectFieldsRequest generates requests for GetProjectFields
+func NewGetProjectFieldsRequest(server string, params *GetProjectFieldsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAddProjectFieldRequest calls the generic AddProjectField builder with application/json body
+func NewAddProjectFieldRequest(server string, body AddProjectFieldJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddProjectFieldRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAddProjectFieldRequestWithBody generates requests for AddProjectField with any type of body
+func NewAddProjectFieldRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectFieldRequest generates requests for DeleteProjectField
+func NewDeleteProjectFieldRequest(server string, fieldCode string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectFieldRequest generates requests for GetProjectField
+func NewGetProjectFieldRequest(server string, fieldCode string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectFieldRequest calls the generic UpdateProjectField builder with application/json body
+func NewUpdateProjectFieldRequest(server string, fieldCode string, body UpdateProjectFieldJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectFieldRequestWithBody(server, fieldCode, "application/json", bodyReader)
+}
+
+// NewUpdateProjectFieldRequestWithBody generates requests for UpdateProjectField with any type of body
+func NewUpdateProjectFieldRequestWithBody(server string, fieldCode string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectFieldOptionsRequest calls the generic DeleteProjectFieldOptions builder with application/json body
+func NewDeleteProjectFieldOptionsRequest(server string, fieldCode string, body DeleteProjectFieldOptionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewDeleteProjectFieldOptionsRequestWithBody(server, fieldCode, "application/json", bodyReader)
+}
+
+// NewDeleteProjectFieldOptionsRequestWithBody generates requests for DeleteProjectFieldOptions with any type of body
+func NewDeleteProjectFieldOptionsRequestWithBody(server string, fieldCode string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s/options", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUpdateProjectFieldOptionsRequest calls the generic UpdateProjectFieldOptions builder with application/json body
+func NewUpdateProjectFieldOptionsRequest(server string, fieldCode string, body UpdateProjectFieldOptionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectFieldOptionsRequestWithBody(server, fieldCode, "application/json", bodyReader)
+}
+
+// NewUpdateProjectFieldOptionsRequestWithBody generates requests for UpdateProjectFieldOptions with any type of body
+func NewUpdateProjectFieldOptionsRequestWithBody(server string, fieldCode string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s/options", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewAddProjectFieldOptionsRequest calls the generic AddProjectFieldOptions builder with application/json body
+func NewAddProjectFieldOptionsRequest(server string, fieldCode string, body AddProjectFieldOptionsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddProjectFieldOptionsRequestWithBody(server, fieldCode, "application/json", bodyReader)
+}
+
+// NewAddProjectFieldOptionsRequestWithBody generates requests for AddProjectFieldOptions with any type of body
+func NewAddProjectFieldOptionsRequestWithBody(server string, fieldCode string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "field_code", runtime.ParamLocationPath, fieldCode)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectFields/%s/options", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetProjectTemplatesRequest generates requests for GetProjectTemplates
+func NewGetProjectTemplatesRequest(server string, params *GetProjectTemplatesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectTemplates")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectTemplateRequest generates requests for GetProjectTemplate
+func NewGetProjectTemplateRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projectTemplates/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectsRequest generates requests for GetProjects
+func NewGetProjectsRequest(server string, params *GetProjectsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.FilterId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "filter_id", runtime.ParamLocationQuery, *params.FilterId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PhaseId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "phase_id", runtime.ParamLocationQuery, *params.PhaseId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.DealId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "deal_id", runtime.ParamLocationQuery, *params.DealId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PersonId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, *params.PersonId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OrgId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "org_id", runtime.ParamLocationQuery, *params.OrgId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAddProjectRequest calls the generic AddProject builder with application/json body
+func NewAddProjectRequest(server string, body AddProjectJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddProjectRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAddProjectRequestWithBody generates requests for AddProject with any type of body
+func NewAddProjectRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetArchivedProjectsRequest generates requests for GetArchivedProjects
+func NewGetArchivedProjectsRequest(server string, params *GetArchivedProjectsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/archived")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.FilterId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "filter_id", runtime.ParamLocationQuery, *params.FilterId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PhaseId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "phase_id", runtime.ParamLocationQuery, *params.PhaseId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewSearchProjectsRequest generates requests for SearchProjects
+func NewSearchProjectsRequest(server string, params *SearchProjectsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/search")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "term", runtime.ParamLocationQuery, params.Term); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.Fields != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "fields", runtime.ParamLocationQuery, *params.Fields); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExactMatch != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "exact_match", runtime.ParamLocationQuery, *params.ExactMatch); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PersonId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, *params.PersonId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OrganizationId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "organization_id", runtime.ParamLocationQuery, *params.OrganizationId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteProjectRequest generates requests for DeleteProject
+func NewDeleteProjectRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectRequest generates requests for GetProject
+func NewGetProjectRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectRequest calls the generic UpdateProject builder with application/json body
+func NewUpdateProjectRequest(server string, id int, body UpdateProjectJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateProjectRequestWithBody generates requests for UpdateProject with any type of body
+func NewUpdateProjectRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewArchiveProjectRequest generates requests for ArchiveProject
+func NewArchiveProjectRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/archive", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectChangelogRequest generates requests for GetProjectChangelog
+func NewGetProjectChangelogRequest(server string, id int, params *GetProjectChangelogParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/changelog", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectUsersRequest generates requests for GetProjectUsers
+func NewGetProjectUsersRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/projects/%s/permittedUsers", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetStagesRequest generates requests for GetStages
 func NewGetStagesRequest(server string, params *GetStagesParams) (*http.Request, error) {
 	var err error
@@ -15852,6 +19367,306 @@ func NewUpdateStageRequestWithBody(server string, id int, contentType string, bo
 	return req, nil
 }
 
+// NewGetTasksRequest generates requests for GetTasks
+func NewGetTasksRequest(server string, params *GetTasksParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tasks")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IsDone != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "is_done", runtime.ParamLocationQuery, *params.IsDone); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IsMilestone != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "is_milestone", runtime.ParamLocationQuery, *params.IsMilestone); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.AssigneeId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_id", runtime.ParamLocationQuery, *params.AssigneeId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ProjectId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "project_id", runtime.ParamLocationQuery, *params.ProjectId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ParentTaskId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "parent_task_id", runtime.ParamLocationQuery, *params.ParentTaskId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewAddTaskRequest calls the generic AddTask builder with application/json body
+func NewAddTaskRequest(server string, body AddTaskJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAddTaskRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewAddTaskRequestWithBody generates requests for AddTask with any type of body
+func NewAddTaskRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tasks")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteTaskRequest generates requests for DeleteTask
+func NewDeleteTaskRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetTaskRequest generates requests for GetTask
+func NewGetTaskRequest(server string, id int) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateTaskRequest calls the generic UpdateTask builder with application/json body
+func NewUpdateTaskRequest(server string, id int, body UpdateTaskJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateTaskRequestWithBody(server, id, "application/json", bodyReader)
+}
+
+// NewUpdateTaskRequestWithBody generates requests for UpdateTask with any type of body
+func NewUpdateTaskRequestWithBody(server string, id int, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tasks/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetUserFollowersRequest generates requests for GetUserFollowers
 func NewGetUserFollowersRequest(server string, id int, params *GetUserFollowersParams) (*http.Request, error) {
 	var err error
@@ -15991,6 +19806,25 @@ type ClientWithResponsesInterface interface {
 
 	// GetActivityFieldWithResponse request
 	GetActivityFieldWithResponse(ctx context.Context, fieldCode string, params *GetActivityFieldParams, reqEditors ...RequestEditorFn) (*GetActivityFieldResponse, error)
+
+	// GetProjectsBoardsWithResponse request
+	GetProjectsBoardsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetProjectsBoardsResponse, error)
+
+	// AddProjectBoardWithBodyWithResponse request with any body
+	AddProjectBoardWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectBoardResponse, error)
+
+	AddProjectBoardWithResponse(ctx context.Context, body AddProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectBoardResponse, error)
+
+	// DeleteProjectBoardWithResponse request
+	DeleteProjectBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectBoardResponse, error)
+
+	// GetProjectsBoardWithResponse request
+	GetProjectsBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsBoardResponse, error)
+
+	// UpdateProjectBoardWithBodyWithResponse request with any body
+	UpdateProjectBoardWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectBoardResponse, error)
+
+	UpdateProjectBoardWithResponse(ctx context.Context, id int, body UpdateProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectBoardResponse, error)
 
 	// GetDealFieldsWithResponse request
 	GetDealFieldsWithResponse(ctx context.Context, params *GetDealFieldsParams, reqEditors ...RequestEditorFn) (*GetDealFieldsResponse, error)
@@ -16290,6 +20124,25 @@ type ClientWithResponsesInterface interface {
 	// GetPersonPictureWithResponse request
 	GetPersonPictureWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetPersonPictureResponse, error)
 
+	// GetProjectsPhasesWithResponse request
+	GetProjectsPhasesWithResponse(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*GetProjectsPhasesResponse, error)
+
+	// AddProjectPhaseWithBodyWithResponse request with any body
+	AddProjectPhaseWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectPhaseResponse, error)
+
+	AddProjectPhaseWithResponse(ctx context.Context, body AddProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectPhaseResponse, error)
+
+	// DeleteProjectPhaseWithResponse request
+	DeleteProjectPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectPhaseResponse, error)
+
+	// GetProjectsPhaseWithResponse request
+	GetProjectsPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsPhaseResponse, error)
+
+	// UpdateProjectPhaseWithBodyWithResponse request with any body
+	UpdateProjectPhaseWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectPhaseResponse, error)
+
+	UpdateProjectPhaseWithResponse(ctx context.Context, id int, body UpdateProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectPhaseResponse, error)
+
 	// GetPipelinesWithResponse request
 	GetPipelinesWithResponse(ctx context.Context, params *GetPipelinesParams, reqEditors ...RequestEditorFn) (*GetPipelinesResponse, error)
 
@@ -16410,6 +20263,80 @@ type ClientWithResponsesInterface interface {
 
 	UpdateProductVariationWithResponse(ctx context.Context, id int, productVariationId int, body UpdateProductVariationJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProductVariationResponse, error)
 
+	// GetProjectFieldsWithResponse request
+	GetProjectFieldsWithResponse(ctx context.Context, params *GetProjectFieldsParams, reqEditors ...RequestEditorFn) (*GetProjectFieldsResponse, error)
+
+	// AddProjectFieldWithBodyWithResponse request with any body
+	AddProjectFieldWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectFieldResponse, error)
+
+	AddProjectFieldWithResponse(ctx context.Context, body AddProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectFieldResponse, error)
+
+	// DeleteProjectFieldWithResponse request
+	DeleteProjectFieldWithResponse(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*DeleteProjectFieldResponse, error)
+
+	// GetProjectFieldWithResponse request
+	GetProjectFieldWithResponse(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*GetProjectFieldResponse, error)
+
+	// UpdateProjectFieldWithBodyWithResponse request with any body
+	UpdateProjectFieldWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectFieldResponse, error)
+
+	UpdateProjectFieldWithResponse(ctx context.Context, fieldCode string, body UpdateProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectFieldResponse, error)
+
+	// DeleteProjectFieldOptionsWithBodyWithResponse request with any body
+	DeleteProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteProjectFieldOptionsResponse, error)
+
+	DeleteProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body DeleteProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteProjectFieldOptionsResponse, error)
+
+	// UpdateProjectFieldOptionsWithBodyWithResponse request with any body
+	UpdateProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectFieldOptionsResponse, error)
+
+	UpdateProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body UpdateProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectFieldOptionsResponse, error)
+
+	// AddProjectFieldOptionsWithBodyWithResponse request with any body
+	AddProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectFieldOptionsResponse, error)
+
+	AddProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body AddProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectFieldOptionsResponse, error)
+
+	// GetProjectTemplatesWithResponse request
+	GetProjectTemplatesWithResponse(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*GetProjectTemplatesResponse, error)
+
+	// GetProjectTemplateWithResponse request
+	GetProjectTemplateWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectTemplateResponse, error)
+
+	// GetProjectsWithResponse request
+	GetProjectsWithResponse(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*GetProjectsResponse, error)
+
+	// AddProjectWithBodyWithResponse request with any body
+	AddProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectResponse, error)
+
+	AddProjectWithResponse(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectResponse, error)
+
+	// GetArchivedProjectsWithResponse request
+	GetArchivedProjectsWithResponse(ctx context.Context, params *GetArchivedProjectsParams, reqEditors ...RequestEditorFn) (*GetArchivedProjectsResponse, error)
+
+	// SearchProjectsWithResponse request
+	SearchProjectsWithResponse(ctx context.Context, params *SearchProjectsParams, reqEditors ...RequestEditorFn) (*SearchProjectsResponse, error)
+
+	// DeleteProjectWithResponse request
+	DeleteProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectResponse, error)
+
+	// GetProjectWithResponse request
+	GetProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectResponse, error)
+
+	// UpdateProjectWithBodyWithResponse request with any body
+	UpdateProjectWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
+
+	UpdateProjectWithResponse(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error)
+
+	// ArchiveProjectWithResponse request
+	ArchiveProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*ArchiveProjectResponse, error)
+
+	// GetProjectChangelogWithResponse request
+	GetProjectChangelogWithResponse(ctx context.Context, id int, params *GetProjectChangelogParams, reqEditors ...RequestEditorFn) (*GetProjectChangelogResponse, error)
+
+	// GetProjectUsersWithResponse request
+	GetProjectUsersWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectUsersResponse, error)
+
 	// GetStagesWithResponse request
 	GetStagesWithResponse(ctx context.Context, params *GetStagesParams, reqEditors ...RequestEditorFn) (*GetStagesResponse, error)
 
@@ -16428,6 +20355,25 @@ type ClientWithResponsesInterface interface {
 	UpdateStageWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateStageResponse, error)
 
 	UpdateStageWithResponse(ctx context.Context, id int, body UpdateStageJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateStageResponse, error)
+
+	// GetTasksWithResponse request
+	GetTasksWithResponse(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*GetTasksResponse, error)
+
+	// AddTaskWithBodyWithResponse request with any body
+	AddTaskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddTaskResponse, error)
+
+	AddTaskWithResponse(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*AddTaskResponse, error)
+
+	// DeleteTaskWithResponse request
+	DeleteTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteTaskResponse, error)
+
+	// GetTaskWithResponse request
+	GetTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetTaskResponse, error)
+
+	// UpdateTaskWithBodyWithResponse request with any body
+	UpdateTaskWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error)
+
+	UpdateTaskWithResponse(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error)
 
 	// GetUserFollowersWithResponse request
 	GetUserFollowersWithResponse(ctx context.Context, id int, params *GetUserFollowersParams, reqEditors ...RequestEditorFn) (*GetUserFollowersResponse, error)
@@ -17162,8 +21108,8 @@ type GetActivityFieldsResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetActivityFields_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17199,6 +21145,11 @@ type GetActivityFieldsResponse struct {
 	}
 }
 type GetActivityFields200DataFieldType string
+type GetActivityFields200DataOptionsId0 = int
+type GetActivityFields200DataOptionsId1 = string
+type GetActivityFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetActivityFieldsResponse) Status() string {
@@ -17244,8 +21195,8 @@ type GetActivityFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetActivityField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17281,6 +21232,11 @@ type GetActivityFieldResponse struct {
 	}
 }
 type GetActivityField200DataFieldType string
+type GetActivityField200DataOptionsId0 = int
+type GetActivityField200DataOptionsId1 = string
+type GetActivityField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetActivityFieldResponse) Status() string {
@@ -17298,6 +21254,207 @@ func (r GetActivityFieldResponse) StatusCode() int {
 	return 0
 }
 
+type GetProjectsBoardsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+
+		// Data The array of project boards
+		Data *[]struct {
+			// AddTime The creation date and time of the board in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Id The ID of the project board
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project board
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the board in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectsBoardsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectsBoardsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddProjectBoardResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the board in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Id The ID of the project board
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project board
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the board in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r AddProjectBoardResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddProjectBoardResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectBoardResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// Id The ID of the deleted project board
+			Id *int `json:"id,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectBoardResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectBoardResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectsBoardResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the board in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Id The ID of the project board
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project board
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the board in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectsBoardResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectsBoardResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectBoardResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the board in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Id The ID of the project board
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project board
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the board in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectBoardResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectBoardResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetDealFieldsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17308,7 +21465,7 @@ type GetDealFieldsResponse struct {
 		} `json:"additional_data,omitempty"`
 		Data *[]struct {
 			// Description The description of the field
-			Description string `json:"description"`
+			Description *string `json:"description,omitempty"`
 
 			// FieldCode The unique identifier for the field (40-character hash for custom fields)
 			FieldCode string `json:"field_code"`
@@ -17342,8 +21499,8 @@ type GetDealFieldsResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetDealFields_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17403,6 +21560,11 @@ type GetDealFieldsResponse struct {
 	}
 }
 type GetDealFields200DataFieldType string
+type GetDealFields200DataOptionsId0 = int
+type GetDealFields200DataOptionsId1 = string
+type GetDealFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 type GetDealFields200DataRequiredFieldsStatuses string
 
 // Status returns HTTPResponse.Status
@@ -17427,7 +21589,7 @@ type AddDealFieldResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			// Description The description of the field
-			Description string `json:"description"`
+			Description *string `json:"description,omitempty"`
 
 			// FieldCode The unique identifier for the field (40-character hash for custom fields)
 			FieldCode string `json:"field_code"`
@@ -17461,8 +21623,8 @@ type AddDealFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *AddDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17522,6 +21684,11 @@ type AddDealFieldResponse struct {
 	}
 }
 type AddDealField200DataFieldType string
+type AddDealField200DataOptionsId0 = int
+type AddDealField200DataOptionsId1 = string
+type AddDealField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 type AddDealField200DataRequiredFieldsStatuses string
 
 // Status returns HTTPResponse.Status
@@ -17546,7 +21713,7 @@ type DeleteDealFieldResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			// Description The description of the field
-			Description string `json:"description"`
+			Description *string `json:"description,omitempty"`
 
 			// FieldCode The unique identifier for the field (40-character hash for custom fields)
 			FieldCode string `json:"field_code"`
@@ -17597,7 +21764,7 @@ type GetDealFieldResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			// Description The description of the field
-			Description string `json:"description"`
+			Description *string `json:"description,omitempty"`
 
 			// FieldCode The unique identifier for the field (40-character hash for custom fields)
 			FieldCode string `json:"field_code"`
@@ -17631,8 +21798,8 @@ type GetDealFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17692,6 +21859,11 @@ type GetDealFieldResponse struct {
 	}
 }
 type GetDealField200DataFieldType string
+type GetDealField200DataOptionsId0 = int
+type GetDealField200DataOptionsId1 = string
+type GetDealField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 type GetDealField200DataRequiredFieldsStatuses string
 
 // Status returns HTTPResponse.Status
@@ -17716,7 +21888,7 @@ type UpdateDealFieldResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			// Description The description of the field
-			Description string `json:"description"`
+			Description *string `json:"description,omitempty"`
 
 			// FieldCode The unique identifier for the field (40-character hash for custom fields)
 			FieldCode string `json:"field_code"`
@@ -17750,8 +21922,8 @@ type UpdateDealFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *UpdateDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -17811,6 +21983,11 @@ type UpdateDealFieldResponse struct {
 	}
 }
 type UpdateDealField200DataFieldType string
+type UpdateDealField200DataOptionsId0 = int
+type UpdateDealField200DataOptionsId1 = string
+type UpdateDealField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 type UpdateDealField200DataRequiredFieldsStatuses string
 
 // Status returns HTTPResponse.Status
@@ -17966,7 +22143,7 @@ type GetDealsResponse struct {
 			// Currency The currency associated with the deal
 			Currency *string `json:"currency,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// ExpectedCloseDate The expected close date of the deal
@@ -18101,7 +22278,7 @@ type AddDealResponse struct {
 			// Currency The currency associated with the deal
 			Currency *string `json:"currency,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// ExpectedCloseDate The expected close date of the deal
@@ -18243,7 +22420,7 @@ type GetArchivedDealsResponse struct {
 			// Currency The currency associated with the deal
 			Currency *string `json:"currency,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// ExpectedCloseDate The expected close date of the deal
@@ -18427,7 +22604,7 @@ type GetDealsProductsResponse struct {
 			// BillingStartDate Only available in Growth and above plans
 			//
 			// The billing start date. Must be between 10 years in the past and 10 years in the future
-			BillingStartDate *string `json:"billing_start_date"`
+			BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 			// Comments The comments of the product
 			Comments *string `json:"comments,omitempty"`
@@ -18466,7 +22643,7 @@ type GetDealsProductsResponse struct {
 			ProductVariationId *int `json:"product_variation_id"`
 
 			// Quantity The quantity of the product
-			Quantity *int `json:"quantity,omitempty"`
+			Quantity *float32 `json:"quantity,omitempty"`
 
 			// Sum The sum of all the products attached to the deal
 			Sum *float32 `json:"sum,omitempty"`
@@ -18664,7 +22841,7 @@ type GetDealResponse struct {
 			// Currency The currency associated with the deal
 			Currency *string `json:"currency,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// ExpectedCloseDate The expected close date of the deal
@@ -18799,7 +22976,7 @@ type UpdateDealResponse struct {
 			// Currency The currency associated with the deal
 			Currency *string `json:"currency,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// ExpectedCloseDate The expected close date of the deal
@@ -19527,7 +23704,7 @@ type GetDealProductsResponse struct {
 			// BillingStartDate Only available in Growth and above plans
 			//
 			// The billing start date. Must be between 10 years in the past and 10 years in the future
-			BillingStartDate *string `json:"billing_start_date"`
+			BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 			// Comments The comments of the product
 			Comments *string `json:"comments,omitempty"`
@@ -19566,7 +23743,7 @@ type GetDealProductsResponse struct {
 			ProductVariationId *int `json:"product_variation_id"`
 
 			// Quantity The quantity of the product
-			Quantity *int `json:"quantity,omitempty"`
+			Quantity *float32 `json:"quantity,omitempty"`
 
 			// Sum The sum of all the products attached to the deal
 			Sum *float32 `json:"sum,omitempty"`
@@ -19638,7 +23815,7 @@ type AddDealProductResponse struct {
 			// BillingStartDate Only available in Growth and above plans
 			//
 			// The billing start date. Must be between 10 years in the past and 10 years in the future
-			BillingStartDate *string `json:"billing_start_date"`
+			BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 			// Comments The comments of the product
 			Comments *string `json:"comments,omitempty"`
@@ -19677,7 +23854,7 @@ type AddDealProductResponse struct {
 			ProductVariationId *int `json:"product_variation_id"`
 
 			// Quantity The quantity of the product
-			Quantity *int `json:"quantity,omitempty"`
+			Quantity *float32 `json:"quantity,omitempty"`
 
 			// Sum The sum of all the products attached to the deal
 			Sum *float32 `json:"sum,omitempty"`
@@ -19750,7 +23927,7 @@ type AddManyDealProductsResponse struct {
 			// BillingStartDate Only available in Growth and above plans
 			//
 			// The billing start date. Must be between 10 years in the past and 10 years in the future
-			BillingStartDate *string `json:"billing_start_date"`
+			BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 			// Comments The comments of the product
 			Comments *string `json:"comments,omitempty"`
@@ -19789,7 +23966,7 @@ type AddManyDealProductsResponse struct {
 			ProductVariationId *int `json:"product_variation_id"`
 
 			// Quantity The quantity of the product
-			Quantity *int `json:"quantity,omitempty"`
+			Quantity *float32 `json:"quantity,omitempty"`
 
 			// Sum The sum of all the products attached to the deal
 			Sum *float32 `json:"sum,omitempty"`
@@ -19891,7 +24068,7 @@ type UpdateDealProductResponse struct {
 			// BillingStartDate Only available in Growth and above plans
 			//
 			// The billing start date. Must be between 10 years in the past and 10 years in the future
-			BillingStartDate *string `json:"billing_start_date"`
+			BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 			// Comments The comments of the product
 			Comments *string `json:"comments,omitempty"`
@@ -19930,7 +24107,7 @@ type UpdateDealProductResponse struct {
 			ProductVariationId *int `json:"product_variation_id"`
 
 			// Quantity The quantity of the product
-			Quantity *int `json:"quantity,omitempty"`
+			Quantity *float32 `json:"quantity,omitempty"`
 
 			// Sum The sum of all the products attached to the deal
 			Sum *float32 `json:"sum,omitempty"`
@@ -20281,8 +24458,8 @@ type GetOrganizationFieldsResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetOrganizationFields_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -20351,6 +24528,11 @@ type GetOrganizationFieldsResponse struct {
 	}
 }
 type GetOrganizationFields200DataFieldType string
+type GetOrganizationFields200DataOptionsId0 = int
+type GetOrganizationFields200DataOptionsId1 = string
+type GetOrganizationFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetOrganizationFieldsResponse) Status() string {
@@ -20405,8 +24587,8 @@ type AddOrganizationFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *AddOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -20475,6 +24657,11 @@ type AddOrganizationFieldResponse struct {
 	}
 }
 type AddOrganizationField200DataFieldType string
+type AddOrganizationField200DataOptionsId0 = int
+type AddOrganizationField200DataOptionsId1 = string
+type AddOrganizationField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r AddOrganizationFieldResponse) Status() string {
@@ -20577,8 +24764,8 @@ type GetOrganizationFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -20647,6 +24834,11 @@ type GetOrganizationFieldResponse struct {
 	}
 }
 type GetOrganizationField200DataFieldType string
+type GetOrganizationField200DataOptionsId0 = int
+type GetOrganizationField200DataOptionsId1 = string
+type GetOrganizationField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetOrganizationFieldResponse) Status() string {
@@ -20701,8 +24893,8 @@ type UpdateOrganizationFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *UpdateOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -20771,6 +24963,11 @@ type UpdateOrganizationFieldResponse struct {
 	}
 }
 type UpdateOrganizationField200DataFieldType string
+type UpdateOrganizationField200DataOptionsId0 = int
+type UpdateOrganizationField200DataOptionsId1 = string
+type UpdateOrganizationField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r UpdateOrganizationFieldResponse) Status() string {
@@ -20932,17 +25129,29 @@ type GetOrganizationsResponse struct {
 				Value *string `json:"value,omitempty"`
 			} `json:"address,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// AnnualRevenue The annual revenue of the organization
+			AnnualRevenue *int `json:"annual_revenue"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// EmployeeCount The number of employees in the organization
+			EmployeeCount *int `json:"employee_count"`
 
 			// Id The ID of the organization
 			Id *int `json:"id,omitempty"`
+
+			// Industry The industry the organization belongs to
+			Industry *int `json:"industry"`
 
 			// IsDeleted Whether the organization is deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
 
 			// LabelIds The IDs of labels assigned to the organization
 			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// Linkedin The LinkedIn profile URL of the organization
+			Linkedin *string `json:"linkedin"`
 
 			// Name The name of the organization
 			Name *string `json:"name,omitempty"`
@@ -20955,6 +25164,9 @@ type GetOrganizationsResponse struct {
 
 			// VisibleTo The visibility of the organization
 			VisibleTo *int `json:"visible_to,omitempty"`
+
+			// Website The website of the organization
+			Website *string `json:"website"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -21019,17 +25231,29 @@ type AddOrganizationResponse struct {
 				Value *string `json:"value,omitempty"`
 			} `json:"address,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// AnnualRevenue The annual revenue of the organization
+			AnnualRevenue *int `json:"annual_revenue"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// EmployeeCount The number of employees in the organization
+			EmployeeCount *int `json:"employee_count"`
 
 			// Id The ID of the organization
 			Id *int `json:"id,omitempty"`
+
+			// Industry The industry the organization belongs to
+			Industry *int `json:"industry"`
 
 			// IsDeleted Whether the organization is deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
 
 			// LabelIds The IDs of labels assigned to the organization
 			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// Linkedin The LinkedIn profile URL of the organization
+			Linkedin *string `json:"linkedin"`
 
 			// Name The name of the organization
 			Name *string `json:"name,omitempty"`
@@ -21042,6 +25266,9 @@ type AddOrganizationResponse struct {
 
 			// VisibleTo The visibility of the organization
 			VisibleTo *int `json:"visible_to,omitempty"`
+
+			// Website The website of the organization
+			Website *string `json:"website"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -21201,17 +25428,29 @@ type GetOrganizationResponse struct {
 				Value *string `json:"value,omitempty"`
 			} `json:"address,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// AnnualRevenue The annual revenue of the organization
+			AnnualRevenue *int `json:"annual_revenue"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// EmployeeCount The number of employees in the organization
+			EmployeeCount *int `json:"employee_count"`
 
 			// Id The ID of the organization
 			Id *int `json:"id,omitempty"`
+
+			// Industry The industry the organization belongs to
+			Industry *int `json:"industry"`
 
 			// IsDeleted Whether the organization is deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
 
 			// LabelIds The IDs of labels assigned to the organization
 			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// Linkedin The LinkedIn profile URL of the organization
+			Linkedin *string `json:"linkedin"`
 
 			// Name The name of the organization
 			Name *string `json:"name,omitempty"`
@@ -21224,6 +25463,9 @@ type GetOrganizationResponse struct {
 
 			// VisibleTo The visibility of the organization
 			VisibleTo *int `json:"visible_to,omitempty"`
+
+			// Website The website of the organization
+			Website *string `json:"website"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -21288,17 +25530,29 @@ type UpdateOrganizationResponse struct {
 				Value *string `json:"value,omitempty"`
 			} `json:"address,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// AnnualRevenue The annual revenue of the organization
+			AnnualRevenue *int `json:"annual_revenue"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// EmployeeCount The number of employees in the organization
+			EmployeeCount *int `json:"employee_count"`
 
 			// Id The ID of the organization
 			Id *int `json:"id,omitempty"`
+
+			// Industry The industry the organization belongs to
+			Industry *int `json:"industry"`
 
 			// IsDeleted Whether the organization is deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
 
 			// LabelIds The IDs of labels assigned to the organization
 			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// Linkedin The LinkedIn profile URL of the organization
+			Linkedin *string `json:"linkedin"`
 
 			// Name The name of the organization
 			Name *string `json:"name,omitempty"`
@@ -21311,6 +25565,9 @@ type UpdateOrganizationResponse struct {
 
 			// VisibleTo The visibility of the organization
 			VisibleTo *int `json:"visible_to,omitempty"`
+
+			// Website The website of the organization
+			Website *string `json:"website"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -21524,8 +25781,8 @@ type GetPersonFieldsResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetPersonFields_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -21576,6 +25833,11 @@ type GetPersonFieldsResponse struct {
 	}
 }
 type GetPersonFields200DataFieldType string
+type GetPersonFields200DataOptionsId0 = int
+type GetPersonFields200DataOptionsId1 = string
+type GetPersonFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetPersonFieldsResponse) Status() string {
@@ -21630,8 +25892,8 @@ type AddPersonFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *AddPersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -21682,6 +25944,11 @@ type AddPersonFieldResponse struct {
 	}
 }
 type AddPersonField200DataFieldType string
+type AddPersonField200DataOptionsId0 = int
+type AddPersonField200DataOptionsId1 = string
+type AddPersonField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r AddPersonFieldResponse) Status() string {
@@ -21784,8 +26051,8 @@ type GetPersonFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetPersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -21836,6 +26103,11 @@ type GetPersonFieldResponse struct {
 	}
 }
 type GetPersonField200DataFieldType string
+type GetPersonField200DataOptionsId0 = int
+type GetPersonField200DataOptionsId1 = string
+type GetPersonField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetPersonFieldResponse) Status() string {
@@ -21890,8 +26162,8 @@ type UpdatePersonFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *UpdatePersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -21942,6 +26214,11 @@ type UpdatePersonFieldResponse struct {
 	}
 }
 type UpdatePersonField200DataFieldType string
+type UpdatePersonField200DataOptionsId0 = int
+type UpdatePersonField200DataOptionsId1 = string
+type UpdatePersonField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r UpdatePersonFieldResponse) Status() string {
@@ -22073,7 +26350,7 @@ type GetPersonsResponse struct {
 			// Birthday The birthday of the person, included if contact sync is enabled for the company
 			Birthday *string `json:"birthday,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// Emails The emails of the person
@@ -22217,7 +26494,7 @@ type AddPersonResponse struct {
 			// Birthday The birthday of the person, included if contact sync is enabled for the company
 			Birthday *string `json:"birthday,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// Emails The emails of the person
@@ -22466,7 +26743,7 @@ type GetPersonResponse struct {
 			// Birthday The birthday of the person, included if contact sync is enabled for the company
 			Birthday *string `json:"birthday,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// Emails The emails of the person
@@ -22610,7 +26887,7 @@ type UpdatePersonResponse struct {
 			// Birthday The birthday of the person, included if contact sync is enabled for the company
 			Birthday *string `json:"birthday,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 			// Emails The emails of the person
@@ -22946,6 +27223,219 @@ func (r GetPersonPictureResponse) StatusCode() int {
 	return 0
 }
 
+type GetProjectsPhasesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+
+		// Data The array of project phases
+		Data *[]struct {
+			// AddTime The creation date and time of the phase in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// BoardId The ID of the project board this phase belongs to
+			BoardId *int `json:"board_id,omitempty"`
+
+			// Id The ID of the project phase
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project phase
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the phase within its board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the phase in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectsPhasesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectsPhasesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddProjectPhaseResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the phase in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// BoardId The ID of the project board this phase belongs to
+			BoardId *int `json:"board_id,omitempty"`
+
+			// Id The ID of the project phase
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project phase
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the phase within its board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the phase in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r AddProjectPhaseResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddProjectPhaseResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectPhaseResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// Id The ID of the deleted project phase
+			Id *int `json:"id,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectPhaseResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectPhaseResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectsPhaseResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the phase in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// BoardId The ID of the project board this phase belongs to
+			BoardId *int `json:"board_id,omitempty"`
+
+			// Id The ID of the project phase
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project phase
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the phase within its board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the phase in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectsPhaseResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectsPhaseResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectPhaseResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the phase in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// BoardId The ID of the project board this phase belongs to
+			BoardId *int `json:"board_id,omitempty"`
+
+			// Id The ID of the project phase
+			Id *int `json:"id,omitempty"`
+
+			// Name The name of the project phase
+			Name *string `json:"name,omitempty"`
+
+			// OrderNr The order of the phase within its board
+			OrderNr *int `json:"order_nr,omitempty"`
+
+			// UpdateTime The update date and time of the phase in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectPhaseResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectPhaseResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetPipelinesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -23210,8 +27700,8 @@ type GetProductFieldsResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetProductFields_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -23247,6 +27737,11 @@ type GetProductFieldsResponse struct {
 	}
 }
 type GetProductFields200DataFieldType string
+type GetProductFields200DataOptionsId0 = int
+type GetProductFields200DataOptionsId1 = string
+type GetProductFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetProductFieldsResponse) Status() string {
@@ -23292,8 +27787,8 @@ type AddProductFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *AddProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -23329,6 +27824,11 @@ type AddProductFieldResponse struct {
 	}
 }
 type AddProductField200DataFieldType string
+type AddProductField200DataOptionsId0 = int
+type AddProductField200DataOptionsId1 = string
+type AddProductField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r AddProductFieldResponse) Status() string {
@@ -23422,8 +27922,8 @@ type GetProductFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -23459,6 +27959,11 @@ type GetProductFieldResponse struct {
 	}
 }
 type GetProductField200DataFieldType string
+type GetProductField200DataOptionsId0 = int
+type GetProductField200DataOptionsId1 = string
+type GetProductField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r GetProductFieldResponse) Status() string {
@@ -23504,8 +28009,8 @@ type UpdateProductFieldResponse struct {
 				// Color Optional color code for the option
 				Color *string `json:"color"`
 
-				// Id The option ID
-				Id *int `json:"id,omitempty"`
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *UpdateProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 				// Label The option display label
 				Label *string `json:"label,omitempty"`
@@ -23541,6 +28046,11 @@ type UpdateProductFieldResponse struct {
 	}
 }
 type UpdateProductField200DataFieldType string
+type UpdateProductField200DataOptionsId0 = int
+type UpdateProductField200DataOptionsId1 = string
+type UpdateProductField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
 
 // Status returns HTTPResponse.Status
 func (r UpdateProductFieldResponse) Status() string {
@@ -23666,69 +28176,94 @@ type GetProductsResponse struct {
 
 		// Data Array containing data for all products
 		Data *[]struct {
-			Data *struct {
-				// BillingFrequency Only available in Growth and above plans
-				//
-				// How often a customer is billed for access to a service or product
-				BillingFrequency *GetProducts200DataDataBillingFrequency `json:"billing_frequency,omitempty"`
+			// AddTime The date and time when the product was added
+			AddTime *string `json:"add_time,omitempty"`
 
-				// BillingFrequencyCycles Only available in Growth and above plans
-				//
-				// The number of times the billing frequency repeats for a product in a deal
-				//
-				// When `billing_frequency` is set to `one-time`, this field must be `null`
-				//
-				// When `billing_frequency` is set to `weekly`, this field cannot be `null`
-				//
-				// For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
-				//
-				// Must be a positive integer less or equal to 208
-				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
+			// BillingFrequency Only available in Growth and above plans
+			//
+			// How often a customer is billed for access to a service or product
+			BillingFrequency *GetProducts200DataBillingFrequency `json:"billing_frequency,omitempty"`
 
-				// Code The product code
-				Code *string `json:"code,omitempty"`
+			// BillingFrequencyCycles Only available in Growth and above plans
+			//
+			// The number of times the billing frequency repeats for a product in a deal
+			//
+			// When `billing_frequency` is set to `one-time`, this field must be `null`
+			//
+			// When `billing_frequency` is set to `weekly`, this field cannot be `null`
+			//
+			// For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
+			//
+			// Must be a positive integer less or equal to 208
+			BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
-				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+			// Category The category of the product
+			Category *string `json:"category"`
 
-				// Id The ID of the product
-				Id *float32 `json:"id,omitempty"`
+			// Code The product code
+			Code *string `json:"code,omitempty"`
 
-				// IsDeleted Whether this product will be marked as deleted or not
-				IsDeleted *bool `json:"is_deleted,omitempty"`
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
-				// IsLinkable Whether this product can be added to a deal or not
-				IsLinkable *bool `json:"is_linkable,omitempty"`
+			// Description The description of the product
+			Description *string `json:"description,omitempty"`
 
-				// Name The name of the product
-				Name *string `json:"name,omitempty"`
+			// Id The ID of the product
+			Id *int `json:"id,omitempty"`
 
-				// OwnerId Information about the Pipedrive user who owns the product
-				OwnerId *int `json:"owner_id,omitempty"`
+			// IsDeleted Whether this product will be marked as deleted or not
+			IsDeleted *bool `json:"is_deleted,omitempty"`
 
-				// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-				Prices *[]map[string]interface{} `json:"prices,omitempty"`
+			// IsLinkable Whether this product can be added to a deal or not
+			IsLinkable *bool `json:"is_linkable,omitempty"`
 
-				// Tax The tax percentage
-				Tax *float32 `json:"tax,omitempty"`
+			// Name The name of the product
+			Name *string `json:"name,omitempty"`
 
-				// Unit The unit in which this product is sold
-				Unit *string `json:"unit,omitempty"`
+			// OwnerId The ID of the Pipedrive user who owns the product
+			OwnerId *int `json:"owner_id,omitempty"`
 
-				// VisibleTo Visibility of the product
-				VisibleTo *GetProducts200DataDataVisibleTo `json:"visible_to,omitempty"`
-			} `json:"data,omitempty"`
+			// Prices The prices of the product in different currencies
+			Prices *[]struct {
+				// Cost The cost of the product
+				Cost *float32 `json:"cost,omitempty"`
 
-			// Success If the response is successful or not
-			Success *bool `json:"success,omitempty"`
+				// Currency The currency of the price
+				Currency *string `json:"currency,omitempty"`
+
+				// DirectCost The direct cost of the product
+				DirectCost *float32 `json:"direct_cost"`
+
+				// Notes The notes about the price
+				Notes *string `json:"notes,omitempty"`
+
+				// Price The price of the product
+				Price *float32 `json:"price,omitempty"`
+
+				// ProductId The ID of the product
+				ProductId *int `json:"product_id,omitempty"`
+			} `json:"prices,omitempty"`
+
+			// Tax The tax percentage
+			Tax *float32 `json:"tax,omitempty"`
+
+			// Unit The unit in which this product is sold
+			Unit *string `json:"unit,omitempty"`
+
+			// UpdateTime The date and time when the product was last updated
+			UpdateTime *string `json:"update_time,omitempty"`
+
+			// VisibleTo Visibility of the product
+			VisibleTo *GetProducts200DataVisibleTo `json:"visible_to,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
 		Success *bool `json:"success,omitempty"`
 	}
 }
-type GetProducts200DataDataBillingFrequency string
-type GetProducts200DataDataVisibleTo float32
+type GetProducts200DataBillingFrequency string
+type GetProducts200DataVisibleTo float32
 
 // Status returns HTTPResponse.Status
 func (r GetProductsResponse) Status() string {
@@ -23751,6 +28286,9 @@ type AddProductResponse struct {
 	HTTPResponse *http.Response
 	JSON201      *struct {
 		Data *struct {
+			// AddTime The date and time when the product was added
+			AddTime *string `json:"add_time,omitempty"`
+
 			// BillingFrequency Only available in Growth and above plans
 			//
 			// How often a customer is billed for access to a service or product
@@ -23769,14 +28307,20 @@ type AddProductResponse struct {
 			// Must be a positive integer less or equal to 208
 			BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+			// Category The category of the product
+			Category *string `json:"category"`
+
 			// Code The product code
 			Code *string `json:"code,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+			// Description The description of the product
+			Description *string `json:"description,omitempty"`
+
 			// Id The ID of the product
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// IsDeleted Whether this product will be marked as deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -23787,17 +28331,38 @@ type AddProductResponse struct {
 			// Name The name of the product
 			Name *string `json:"name,omitempty"`
 
-			// OwnerId Information about the Pipedrive user who owns the product
+			// OwnerId The ID of the Pipedrive user who owns the product
 			OwnerId *int `json:"owner_id,omitempty"`
 
-			// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-			Prices *[]map[string]interface{} `json:"prices,omitempty"`
+			// Prices The prices of the product in different currencies
+			Prices *[]struct {
+				// Cost The cost of the product
+				Cost *float32 `json:"cost,omitempty"`
+
+				// Currency The currency of the price
+				Currency *string `json:"currency,omitempty"`
+
+				// DirectCost The direct cost of the product
+				DirectCost *float32 `json:"direct_cost"`
+
+				// Notes The notes about the price
+				Notes *string `json:"notes,omitempty"`
+
+				// Price The price of the product
+				Price *float32 `json:"price,omitempty"`
+
+				// ProductId The ID of the product
+				ProductId *int `json:"product_id,omitempty"`
+			} `json:"prices,omitempty"`
 
 			// Tax The tax percentage
 			Tax *float32 `json:"tax,omitempty"`
 
 			// Unit The unit in which this product is sold
 			Unit *string `json:"unit,omitempty"`
+
+			// UpdateTime The date and time when the product was last updated
+			UpdateTime *string `json:"update_time,omitempty"`
 
 			// VisibleTo Visibility of the product
 			VisibleTo *AddProduct201DataVisibleTo `json:"visible_to,omitempty"`
@@ -23923,6 +28488,9 @@ type GetProductResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Data *struct {
+			// AddTime The date and time when the product was added
+			AddTime *string `json:"add_time,omitempty"`
+
 			// BillingFrequency Only available in Growth and above plans
 			//
 			// How often a customer is billed for access to a service or product
@@ -23941,14 +28509,20 @@ type GetProductResponse struct {
 			// Must be a positive integer less or equal to 208
 			BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+			// Category The category of the product
+			Category *string `json:"category"`
+
 			// Code The product code
 			Code *string `json:"code,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+			// Description The description of the product
+			Description *string `json:"description,omitempty"`
+
 			// Id The ID of the product
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// IsDeleted Whether this product will be marked as deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -23959,17 +28533,38 @@ type GetProductResponse struct {
 			// Name The name of the product
 			Name *string `json:"name,omitempty"`
 
-			// OwnerId Information about the Pipedrive user who owns the product
+			// OwnerId The ID of the Pipedrive user who owns the product
 			OwnerId *int `json:"owner_id,omitempty"`
 
-			// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-			Prices *[]map[string]interface{} `json:"prices,omitempty"`
+			// Prices The prices of the product in different currencies
+			Prices *[]struct {
+				// Cost The cost of the product
+				Cost *float32 `json:"cost,omitempty"`
+
+				// Currency The currency of the price
+				Currency *string `json:"currency,omitempty"`
+
+				// DirectCost The direct cost of the product
+				DirectCost *float32 `json:"direct_cost"`
+
+				// Notes The notes about the price
+				Notes *string `json:"notes,omitempty"`
+
+				// Price The price of the product
+				Price *float32 `json:"price,omitempty"`
+
+				// ProductId The ID of the product
+				ProductId *int `json:"product_id,omitempty"`
+			} `json:"prices,omitempty"`
 
 			// Tax The tax percentage
 			Tax *float32 `json:"tax,omitempty"`
 
 			// Unit The unit in which this product is sold
 			Unit *string `json:"unit,omitempty"`
+
+			// UpdateTime The date and time when the product was last updated
+			UpdateTime *string `json:"update_time,omitempty"`
 
 			// VisibleTo Visibility of the product
 			VisibleTo *GetProduct200DataVisibleTo `json:"visible_to,omitempty"`
@@ -24003,6 +28598,9 @@ type UpdateProductResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *struct {
 		Data *struct {
+			// AddTime The date and time when the product was added
+			AddTime *string `json:"add_time,omitempty"`
+
 			// BillingFrequency Only available in Growth and above plans
 			//
 			// How often a customer is billed for access to a service or product
@@ -24021,14 +28619,20 @@ type UpdateProductResponse struct {
 			// Must be a positive integer less or equal to 208
 			BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+			// Category The category of the product
+			Category *string `json:"category"`
+
 			// Code The product code
 			Code *string `json:"code,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+			// Description The description of the product
+			Description *string `json:"description,omitempty"`
+
 			// Id The ID of the product
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// IsDeleted Whether this product will be marked as deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -24039,17 +28643,38 @@ type UpdateProductResponse struct {
 			// Name The name of the product
 			Name *string `json:"name,omitempty"`
 
-			// OwnerId Information about the Pipedrive user who owns the product
+			// OwnerId The ID of the Pipedrive user who owns the product
 			OwnerId *int `json:"owner_id,omitempty"`
 
-			// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-			Prices *[]map[string]interface{} `json:"prices,omitempty"`
+			// Prices The prices of the product in different currencies
+			Prices *[]struct {
+				// Cost The cost of the product
+				Cost *float32 `json:"cost,omitempty"`
+
+				// Currency The currency of the price
+				Currency *string `json:"currency,omitempty"`
+
+				// DirectCost The direct cost of the product
+				DirectCost *float32 `json:"direct_cost"`
+
+				// Notes The notes about the price
+				Notes *string `json:"notes,omitempty"`
+
+				// Price The price of the product
+				Price *float32 `json:"price,omitempty"`
+
+				// ProductId The ID of the product
+				ProductId *int `json:"product_id,omitempty"`
+			} `json:"prices,omitempty"`
 
 			// Tax The tax percentage
 			Tax *float32 `json:"tax,omitempty"`
 
 			// Unit The unit in which this product is sold
 			Unit *string `json:"unit,omitempty"`
+
+			// UpdateTime The date and time when the product was last updated
+			UpdateTime *string `json:"update_time,omitempty"`
 
 			// VisibleTo Visibility of the product
 			VisibleTo *UpdateProduct200DataVisibleTo `json:"visible_to,omitempty"`
@@ -24083,6 +28708,9 @@ type DuplicateProductResponse struct {
 	HTTPResponse *http.Response
 	JSON201      *struct {
 		Data *struct {
+			// AddTime The date and time when the product was added
+			AddTime *string `json:"add_time,omitempty"`
+
 			// BillingFrequency Only available in Growth and above plans
 			//
 			// How often a customer is billed for access to a service or product
@@ -24101,14 +28729,20 @@ type DuplicateProductResponse struct {
 			// Must be a positive integer less or equal to 208
 			BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+			// Category The category of the product
+			Category *string `json:"category"`
+
 			// Code The product code
 			Code *string `json:"code,omitempty"`
 
-			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+			// Description The description of the product
+			Description *string `json:"description,omitempty"`
+
 			// Id The ID of the product
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// IsDeleted Whether this product will be marked as deleted or not
 			IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -24119,17 +28753,38 @@ type DuplicateProductResponse struct {
 			// Name The name of the product
 			Name *string `json:"name,omitempty"`
 
-			// OwnerId Information about the Pipedrive user who owns the product
+			// OwnerId The ID of the Pipedrive user who owns the product
 			OwnerId *int `json:"owner_id,omitempty"`
 
-			// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-			Prices *[]map[string]interface{} `json:"prices,omitempty"`
+			// Prices The prices of the product in different currencies
+			Prices *[]struct {
+				// Cost The cost of the product
+				Cost *float32 `json:"cost,omitempty"`
+
+				// Currency The currency of the price
+				Currency *string `json:"currency,omitempty"`
+
+				// DirectCost The direct cost of the product
+				DirectCost *float32 `json:"direct_cost"`
+
+				// Notes The notes about the price
+				Notes *string `json:"notes,omitempty"`
+
+				// Price The price of the product
+				Price *float32 `json:"price,omitempty"`
+
+				// ProductId The ID of the product
+				ProductId *int `json:"product_id,omitempty"`
+			} `json:"prices,omitempty"`
 
 			// Tax The tax percentage
 			Tax *float32 `json:"tax,omitempty"`
 
 			// Unit The unit in which this product is sold
 			Unit *string `json:"unit,omitempty"`
+
+			// UpdateTime The date and time when the product was last updated
+			UpdateTime *string `json:"update_time,omitempty"`
 
 			// VisibleTo Visibility of the product
 			VisibleTo *DuplicateProduct201DataVisibleTo `json:"visible_to,omitempty"`
@@ -24401,7 +29056,7 @@ type UploadProductImageResponse struct {
 			Id *int `json:"id,omitempty"`
 
 			// ProductId The ID of the product associated
-			ProductId *float32 `json:"product_id,omitempty"`
+			ProductId *int `json:"product_id,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -24440,7 +29095,7 @@ type UpdateProductImageResponse struct {
 			Id *int `json:"id,omitempty"`
 
 			// ProductId The ID of the product associated
-			ProductId *float32 `json:"product_id,omitempty"`
+			ProductId *int `json:"product_id,omitempty"`
 		} `json:"data,omitempty"`
 
 		// Success If the response is successful or not
@@ -24477,7 +29132,7 @@ type GetProductVariationsResponse struct {
 		// Data Array containing data for all products
 		Data *[]struct {
 			// Id The ID of the product variation
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// Name The name of the product variation
 			Name *string `json:"name,omitempty"`
@@ -24516,7 +29171,7 @@ type AddProductVariationResponse struct {
 	JSON201      *struct {
 		Data *struct {
 			// Id The ID of the product variation
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// Name The name of the product variation
 			Name *string `json:"name,omitempty"`
@@ -24585,7 +29240,7 @@ type UpdateProductVariationResponse struct {
 	JSON200      *struct {
 		Data *struct {
 			// Id The ID of the product variation
-			Id *float32 `json:"id,omitempty"`
+			Id *int `json:"id,omitempty"`
 
 			// Name The name of the product variation
 			Name *string `json:"name,omitempty"`
@@ -24612,6 +29267,1393 @@ func (r UpdateProductVariationResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateProductVariationResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectFieldsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *struct {
+			// NextCursor Base64url-encoded cursor for fetching the next page of results, null if no more pages
+			NextCursor *string `json:"next_cursor"`
+		} `json:"additional_data,omitempty"`
+		Data *[]struct {
+			// FieldCode The unique identifier for the field (40-character hash for custom fields)
+			FieldCode string `json:"field_code"`
+
+			// FieldName The display name/label of the field
+			FieldName string `json:"field_name"`
+
+			// FieldType The type of the field
+			FieldType GetProjectFields200DataFieldType `json:"field_type"`
+
+			// ImportantFields Important fields configuration
+			ImportantFields *struct {
+				// Enabled Whether the field is marked as important
+				Enabled *bool `json:"enabled,omitempty"`
+
+				// StageIds Array of deal stage IDs where the field is important
+				StageIds *[]int `json:"stage_ids,omitempty"`
+			} `json:"important_fields,omitempty"`
+
+			// IsCustomField Whether this is a user-created custom field
+			IsCustomField bool `json:"is_custom_field"`
+
+			// IsOptionalResponseField Whether this field is not returned by default in entity responses
+			IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+			// Options Array of available options for enum/set fields, null for other field types
+			Options *[]struct {
+				// AddTime When the option was created
+				AddTime *time.Time `json:"add_time"`
+
+				// Color Optional color code for the option
+				Color *string `json:"color"`
+
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetProjectFields_200_Data_Options_Id `json:"id,omitempty"`
+
+				// Label The option display label
+				Label *string `json:"label,omitempty"`
+
+				// UpdateTime When the option was last updated
+				UpdateTime *time.Time `json:"update_time"`
+			} `json:"options"`
+
+			// RequiredFields Required fields configuration
+			RequiredFields *struct {
+				// Enabled Whether the field is required
+				Enabled *bool `json:"enabled,omitempty"`
+			} `json:"required_fields,omitempty"`
+
+			// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+			Subfields *[]struct {
+				// FieldCode The subfield identifier
+				FieldCode *string `json:"field_code,omitempty"`
+
+				// FieldName The subfield display name
+				FieldName *string `json:"field_name,omitempty"`
+
+				// FieldType The subfield type
+				FieldType *string `json:"field_type,omitempty"`
+			} `json:"subfields"`
+
+			// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+			UiVisibility *struct {
+				// AddVisibleFlag Whether the field is shown in the add modal
+				AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+				// DetailsVisibleFlag Whether the field is shown in the details view
+				DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+			} `json:"ui_visibility,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success Whether the request was successful
+		Success *bool `json:"success,omitempty"`
+	}
+}
+type GetProjectFields200DataFieldType string
+type GetProjectFields200DataOptionsId0 = int
+type GetProjectFields200DataOptionsId1 = string
+type GetProjectFields_200_Data_Options_Id struct {
+	union json.RawMessage
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectFieldsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectFieldsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddProjectFieldResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// FieldCode The unique identifier for the field (40-character hash for custom fields)
+			FieldCode string `json:"field_code"`
+
+			// FieldName The display name/label of the field
+			FieldName string `json:"field_name"`
+
+			// FieldType The type of the field
+			FieldType AddProjectField200DataFieldType `json:"field_type"`
+
+			// ImportantFields Important fields configuration
+			ImportantFields *struct {
+				// Enabled Whether the field is marked as important
+				Enabled *bool `json:"enabled,omitempty"`
+
+				// StageIds Array of deal stage IDs where the field is important
+				StageIds *[]int `json:"stage_ids,omitempty"`
+			} `json:"important_fields,omitempty"`
+
+			// IsCustomField Whether this is a user-created custom field
+			IsCustomField bool `json:"is_custom_field"`
+
+			// IsOptionalResponseField Whether this field is not returned by default in entity responses
+			IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+			// Options Array of available options for enum/set fields, null for other field types
+			Options *[]struct {
+				// AddTime When the option was created
+				AddTime *time.Time `json:"add_time"`
+
+				// Color Optional color code for the option
+				Color *string `json:"color"`
+
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *AddProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+				// Label The option display label
+				Label *string `json:"label,omitempty"`
+
+				// UpdateTime When the option was last updated
+				UpdateTime *time.Time `json:"update_time"`
+			} `json:"options"`
+
+			// RequiredFields Required fields configuration
+			RequiredFields *struct {
+				// Enabled Whether the field is required
+				Enabled *bool `json:"enabled,omitempty"`
+			} `json:"required_fields,omitempty"`
+
+			// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+			Subfields *[]struct {
+				// FieldCode The subfield identifier
+				FieldCode *string `json:"field_code,omitempty"`
+
+				// FieldName The subfield display name
+				FieldName *string `json:"field_name,omitempty"`
+
+				// FieldType The subfield type
+				FieldType *string `json:"field_type,omitempty"`
+			} `json:"subfields"`
+
+			// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+			UiVisibility *struct {
+				// AddVisibleFlag Whether the field is shown in the add modal
+				AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+				// DetailsVisibleFlag Whether the field is shown in the details view
+				DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+			} `json:"ui_visibility,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success Whether the request was successful
+		Success *bool `json:"success,omitempty"`
+	}
+}
+type AddProjectField200DataFieldType string
+type AddProjectField200DataOptionsId0 = int
+type AddProjectField200DataOptionsId1 = string
+type AddProjectField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
+
+// Status returns HTTPResponse.Status
+func (r AddProjectFieldResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddProjectFieldResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectFieldResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// FieldCode The unique identifier for the field (40-character hash for custom fields)
+			FieldCode string `json:"field_code"`
+
+			// FieldName The display name/label of the field
+			FieldName string `json:"field_name"`
+
+			// FieldType The type of the field
+			FieldType string `json:"field_type"`
+
+			// IsCustomField Whether this is a user-created custom field
+			IsCustomField bool `json:"is_custom_field"`
+
+			// IsOptionalResponseField Whether this field is not returned by default in entity responses
+			IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+			// Options Array of available options for enum/set fields, null for other field types
+			Options *[]map[string]interface{} `json:"options"`
+
+			// Subfields Array of subfields for complex field types, null for simple field types
+			Subfields *[]map[string]interface{} `json:"subfields"`
+		} `json:"data,omitempty"`
+
+		// Success Whether the request was successful
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectFieldResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectFieldResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectFieldResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// FieldCode The unique identifier for the field (40-character hash for custom fields)
+			FieldCode string `json:"field_code"`
+
+			// FieldName The display name/label of the field
+			FieldName string `json:"field_name"`
+
+			// FieldType The type of the field
+			FieldType GetProjectField200DataFieldType `json:"field_type"`
+
+			// ImportantFields Important fields configuration
+			ImportantFields *struct {
+				// Enabled Whether the field is marked as important
+				Enabled *bool `json:"enabled,omitempty"`
+
+				// StageIds Array of deal stage IDs where the field is important
+				StageIds *[]int `json:"stage_ids,omitempty"`
+			} `json:"important_fields,omitempty"`
+
+			// IsCustomField Whether this is a user-created custom field
+			IsCustomField bool `json:"is_custom_field"`
+
+			// IsOptionalResponseField Whether this field is not returned by default in entity responses
+			IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+			// Options Array of available options for enum/set fields, null for other field types
+			Options *[]struct {
+				// AddTime When the option was created
+				AddTime *time.Time `json:"add_time"`
+
+				// Color Optional color code for the option
+				Color *string `json:"color"`
+
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *GetProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+				// Label The option display label
+				Label *string `json:"label,omitempty"`
+
+				// UpdateTime When the option was last updated
+				UpdateTime *time.Time `json:"update_time"`
+			} `json:"options"`
+
+			// RequiredFields Required fields configuration
+			RequiredFields *struct {
+				// Enabled Whether the field is required
+				Enabled *bool `json:"enabled,omitempty"`
+			} `json:"required_fields,omitempty"`
+
+			// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+			Subfields *[]struct {
+				// FieldCode The subfield identifier
+				FieldCode *string `json:"field_code,omitempty"`
+
+				// FieldName The subfield display name
+				FieldName *string `json:"field_name,omitempty"`
+
+				// FieldType The subfield type
+				FieldType *string `json:"field_type,omitempty"`
+			} `json:"subfields"`
+
+			// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+			UiVisibility *struct {
+				// AddVisibleFlag Whether the field is shown in the add modal
+				AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+				// DetailsVisibleFlag Whether the field is shown in the details view
+				DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+			} `json:"ui_visibility,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success Whether the request was successful
+		Success *bool `json:"success,omitempty"`
+	}
+}
+type GetProjectField200DataFieldType string
+type GetProjectField200DataOptionsId0 = int
+type GetProjectField200DataOptionsId1 = string
+type GetProjectField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectFieldResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectFieldResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectFieldResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// FieldCode The unique identifier for the field (40-character hash for custom fields)
+			FieldCode string `json:"field_code"`
+
+			// FieldName The display name/label of the field
+			FieldName string `json:"field_name"`
+
+			// FieldType The type of the field
+			FieldType UpdateProjectField200DataFieldType `json:"field_type"`
+
+			// ImportantFields Important fields configuration
+			ImportantFields *struct {
+				// Enabled Whether the field is marked as important
+				Enabled *bool `json:"enabled,omitempty"`
+
+				// StageIds Array of deal stage IDs where the field is important
+				StageIds *[]int `json:"stage_ids,omitempty"`
+			} `json:"important_fields,omitempty"`
+
+			// IsCustomField Whether this is a user-created custom field
+			IsCustomField bool `json:"is_custom_field"`
+
+			// IsOptionalResponseField Whether this field is not returned by default in entity responses
+			IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+			// Options Array of available options for enum/set fields, null for other field types
+			Options *[]struct {
+				// AddTime When the option was created
+				AddTime *time.Time `json:"add_time"`
+
+				// Color Optional color code for the option
+				Color *string `json:"color"`
+
+				// Id The option ID (integer for custom fields, string for built-in fields)
+				Id *UpdateProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+				// Label The option display label
+				Label *string `json:"label,omitempty"`
+
+				// UpdateTime When the option was last updated
+				UpdateTime *time.Time `json:"update_time"`
+			} `json:"options"`
+
+			// RequiredFields Required fields configuration
+			RequiredFields *struct {
+				// Enabled Whether the field is required
+				Enabled *bool `json:"enabled,omitempty"`
+			} `json:"required_fields,omitempty"`
+
+			// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+			Subfields *[]struct {
+				// FieldCode The subfield identifier
+				FieldCode *string `json:"field_code,omitempty"`
+
+				// FieldName The subfield display name
+				FieldName *string `json:"field_name,omitempty"`
+
+				// FieldType The subfield type
+				FieldType *string `json:"field_type,omitempty"`
+			} `json:"subfields"`
+
+			// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+			UiVisibility *struct {
+				// AddVisibleFlag Whether the field is shown in the add modal
+				AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+				// DetailsVisibleFlag Whether the field is shown in the details view
+				DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+			} `json:"ui_visibility,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success Whether the request was successful
+		Success *bool `json:"success,omitempty"`
+	}
+}
+type UpdateProjectField200DataFieldType string
+type UpdateProjectField200DataOptionsId0 = int
+type UpdateProjectField200DataOptionsId1 = string
+type UpdateProjectField_200_Data_Options_Id struct {
+	union json.RawMessage
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectFieldResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectFieldResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectFieldOptionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *[]struct {
+			// Id The unique identifier of the option
+			Id int `json:"id"`
+
+			// Label The display label of the option
+			Label string `json:"label"`
+		} `json:"data,omitempty"`
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectFieldOptionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectFieldOptionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectFieldOptionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *[]struct {
+			// Id The unique identifier of the option
+			Id int `json:"id"`
+
+			// Label The display label of the option
+			Label string `json:"label"`
+		} `json:"data,omitempty"`
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectFieldOptionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectFieldOptionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddProjectFieldOptionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *[]struct {
+			// Id The unique identifier of the option
+			Id int `json:"id"`
+
+			// Label The display label of the option
+			Label string `json:"label"`
+		} `json:"data,omitempty"`
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r AddProjectFieldOptionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddProjectFieldOptionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectTemplatesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+		Data *[]struct {
+			// AddTime The creation date and time of the project template in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Description The description of the project template
+			Description *string `json:"description,omitempty"`
+
+			// Id The ID of the project template
+			Id *int `json:"id,omitempty"`
+
+			// OwnerId The ID of the owner of the project template
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// ProjectsBoardId The ID of the project board this template is associated with
+			ProjectsBoardId *int `json:"projects_board_id,omitempty"`
+
+			// Title The title of the project template
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the project template in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectTemplatesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectTemplatesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectTemplateResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *struct {
+			// AddTime The creation date and time of the project template in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// Description The description of the project template
+			Description *string `json:"description,omitempty"`
+
+			// Id The ID of the project template
+			Id *int `json:"id,omitempty"`
+
+			// OwnerId The ID of the owner of the project template
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// ProjectsBoardId The ID of the project board this template is associated with
+			ProjectsBoardId *int `json:"projects_board_id,omitempty"`
+
+			// Title The title of the project template
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the project template in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectTemplateResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectTemplateResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+
+		// Data Projects array
+		Data *[]struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r AddProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetArchivedProjectsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+
+		// Data Projects array
+		Data *[]struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetArchivedProjectsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetArchivedProjectsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type SearchProjectsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+		Data *struct {
+			// Items The array of found projects
+			Items *[]struct {
+				Item *struct {
+					// BoardId The ID of the board the project belongs to
+					BoardId *int `json:"board_id"`
+
+					// CustomFields Custom fields
+					CustomFields *[]string `json:"custom_fields,omitempty"`
+					Deal         *struct {
+						// Id The ID of the deal the project is associated with
+						Id *int `json:"id,omitempty"`
+
+						// Title The title of the deal the project is associated with
+						Title *string `json:"title"`
+					} `json:"deal"`
+
+					// DealCount The number of deals associated with the project
+					DealCount *int `json:"deal_count,omitempty"`
+
+					// Description The description of the project
+					Description *string `json:"description"`
+
+					// EndDate The end date of the project
+					EndDate *string `json:"end_date"`
+
+					// Id The ID of the project
+					Id *int `json:"id,omitempty"`
+
+					// Notes An array of notes
+					Notes        *[]string `json:"notes,omitempty"`
+					Organization *struct {
+						// Address The address of the organization the project is associated with
+						Address *string `json:"address"`
+
+						// Id The ID of the organization the project is associated with
+						Id *int `json:"id,omitempty"`
+
+						// Name The name of the organization the project is associated with
+						Name *string `json:"name"`
+					} `json:"organization"`
+					Owner *struct {
+						// Id The ID of the owner of the project
+						Id *int `json:"id"`
+					} `json:"owner,omitempty"`
+					Person *struct {
+						// Id The ID of the person the project is associated with
+						Id *int `json:"id,omitempty"`
+
+						// Name The name of the person the project is associated with
+						Name *string `json:"name"`
+					} `json:"person"`
+					Phase *struct {
+						// Id The ID of the phase
+						Id *int `json:"id,omitempty"`
+
+						// Name The name of the phase
+						Name *string `json:"name,omitempty"`
+					} `json:"phase"`
+
+					// Status The status of the project
+					Status *string `json:"status"`
+
+					// Title The title of the project
+					Title *string `json:"title,omitempty"`
+
+					// Type The type of the item
+					Type *string `json:"type,omitempty"`
+				} `json:"item,omitempty"`
+
+				// ResultScore Search result relevancy
+				ResultScore *float32 `json:"result_score,omitempty"`
+			} `json:"items,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r SearchProjectsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r SearchProjectsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// Id The ID of the deleted project
+			Id *int `json:"id,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ArchiveProjectResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Data *struct {
+			// AddTime The creation date and time of the project in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+			ArchiveTime *string `json:"archive_time"`
+
+			// BoardId The ID of the board this project is associated with
+			BoardId *int `json:"board_id,omitempty"`
+
+			// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+			CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+			// DealIds An array of IDs of the deals this project is associated with
+			DealIds *[]int `json:"deal_ids,omitempty"`
+
+			// Description The description of the project
+			Description *string `json:"description,omitempty"`
+
+			// EndDate The end date of the project. Format: YYYY-MM-DD
+			EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+			// HealthStatus The health status of the project
+			HealthStatus *int `json:"health_status"`
+
+			// Id The ID of the project
+			Id *int `json:"id,omitempty"`
+
+			// LabelIds An array of IDs of the labels this project has
+			LabelIds *[]int `json:"label_ids,omitempty"`
+
+			// OrgIds An array of IDs of the organizations this project is associated with
+			OrgIds *[]int `json:"org_ids,omitempty"`
+
+			// OwnerId The ID of the user who owns the project
+			OwnerId *int `json:"owner_id,omitempty"`
+
+			// PersonIds An array of IDs of the persons this project is associated with
+			PersonIds *[]int `json:"person_ids,omitempty"`
+
+			// PhaseId The ID of the phase this project is associated with
+			PhaseId *int `json:"phase_id,omitempty"`
+
+			// StartDate The start date of the project. Format: YYYY-MM-DD
+			StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+			// Status The status of the project
+			Status *string `json:"status,omitempty"`
+
+			// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+			StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+			// Title The title of the project
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The last updated date and time of the project in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r ArchiveProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ArchiveProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectChangelogResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+		Data *[]struct {
+			// ActorUserId The ID of the user who made the change
+			ActorUserId *int `json:"actor_user_id,omitempty"`
+
+			// ChangeSource The source of change, for example 'app', 'mobile', 'api', etc.
+			ChangeSource *string `json:"change_source"`
+
+			// ChangeSourceUserAgent The user agent from which the change was made
+			ChangeSourceUserAgent *string `json:"change_source_user_agent"`
+
+			// NewValues A map of field keys to their new values after the change
+			NewValues *map[string]interface{} `json:"new_values,omitempty"`
+
+			// OldValues A map of field keys to their previous values before the change
+			OldValues *map[string]interface{} `json:"old_values,omitempty"`
+
+			// Time The date and time of the change in ISO 8601 format
+			Time *string `json:"time,omitempty"`
+		} `json:"data,omitempty"`
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectChangelogResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectChangelogResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectUsersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// Data The list of permitted user IDs
+		Data *[]int `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectUsersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectUsersResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24886,6 +30928,333 @@ func (r UpdateStageResponse) StatusCode() int {
 	return 0
 }
 
+type GetTasksResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		// AdditionalData The additional data of the list
+		AdditionalData *struct {
+			// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+			NextCursor *string `json:"next_cursor,omitempty"`
+		} `json:"additional_data,omitempty"`
+		Data *[]struct {
+			// AddTime The creation date and time of the task in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// AssigneeIds The IDs of users assigned to the task
+			AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+			// CreatorId The ID of the user who created the task
+			CreatorId *int `json:"creator_id,omitempty"`
+
+			// Description The description of the task
+			Description *string `json:"description"`
+
+			// DueDate The due date of the task. Format: YYYY-MM-DD.
+			DueDate *openapi_types.Date `json:"due_date"`
+
+			// Id The ID of the task
+			Id *int `json:"id,omitempty"`
+
+			// IsDone Whether the task is done or not.
+			IsDone *bool `json:"is_done,omitempty"`
+
+			// IsMilestone Whether the task is a milestone or not.
+			IsMilestone *bool `json:"is_milestone,omitempty"`
+
+			// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+			MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+			// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+			ParentTaskId *int `json:"parent_task_id"`
+
+			// Priority The priority of the task
+			Priority *int `json:"priority"`
+
+			// ProjectId The ID of the project this task is associated with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// StartDate The start date of the task. Format: YYYY-MM-DD.
+			StartDate *openapi_types.Date `json:"start_date"`
+
+			// Title The title of the task
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the task in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetTasksResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetTasksResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AddTaskResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *struct {
+			// AddTime The creation date and time of the task in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// AssigneeIds The IDs of users assigned to the task
+			AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+			// CreatorId The ID of the user who created the task
+			CreatorId *int `json:"creator_id,omitempty"`
+
+			// Description The description of the task
+			Description *string `json:"description"`
+
+			// DueDate The due date of the task. Format: YYYY-MM-DD.
+			DueDate *openapi_types.Date `json:"due_date"`
+
+			// Id The ID of the task
+			Id *int `json:"id,omitempty"`
+
+			// IsDone Whether the task is done or not.
+			IsDone *bool `json:"is_done,omitempty"`
+
+			// IsMilestone Whether the task is a milestone or not.
+			IsMilestone *bool `json:"is_milestone,omitempty"`
+
+			// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+			MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+			// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+			ParentTaskId *int `json:"parent_task_id"`
+
+			// Priority The priority of the task
+			Priority *int `json:"priority"`
+
+			// ProjectId The ID of the project this task is associated with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// StartDate The start date of the task. Format: YYYY-MM-DD.
+			StartDate *openapi_types.Date `json:"start_date"`
+
+			// Title The title of the task
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the task in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r AddTaskResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AddTaskResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteTaskResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *struct {
+			// Id The ID of the deleted task
+			Id *int `json:"id,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteTaskResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteTaskResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetTaskResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *struct {
+			// AddTime The creation date and time of the task in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// AssigneeIds The IDs of users assigned to the task
+			AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+			// CreatorId The ID of the user who created the task
+			CreatorId *int `json:"creator_id,omitempty"`
+
+			// Description The description of the task
+			Description *string `json:"description"`
+
+			// DueDate The due date of the task. Format: YYYY-MM-DD.
+			DueDate *openapi_types.Date `json:"due_date"`
+
+			// Id The ID of the task
+			Id *int `json:"id,omitempty"`
+
+			// IsDone Whether the task is done or not.
+			IsDone *bool `json:"is_done,omitempty"`
+
+			// IsMilestone Whether the task is a milestone or not.
+			IsMilestone *bool `json:"is_milestone,omitempty"`
+
+			// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+			MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+			// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+			ParentTaskId *int `json:"parent_task_id"`
+
+			// Priority The priority of the task
+			Priority *int `json:"priority"`
+
+			// ProjectId The ID of the project this task is associated with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// StartDate The start date of the task. Format: YYYY-MM-DD.
+			StartDate *openapi_types.Date `json:"start_date"`
+
+			// Title The title of the task
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the task in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r GetTaskResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetTaskResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateTaskResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		AdditionalData *map[string]interface{} `json:"additional_data"`
+		Data           *struct {
+			// AddTime The creation date and time of the task in ISO 8601 format
+			AddTime *string `json:"add_time,omitempty"`
+
+			// AssigneeIds The IDs of users assigned to the task
+			AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+			// CreatorId The ID of the user who created the task
+			CreatorId *int `json:"creator_id,omitempty"`
+
+			// Description The description of the task
+			Description *string `json:"description"`
+
+			// DueDate The due date of the task. Format: YYYY-MM-DD.
+			DueDate *openapi_types.Date `json:"due_date"`
+
+			// Id The ID of the task
+			Id *int `json:"id,omitempty"`
+
+			// IsDone Whether the task is done or not.
+			IsDone *bool `json:"is_done,omitempty"`
+
+			// IsMilestone Whether the task is a milestone or not.
+			IsMilestone *bool `json:"is_milestone,omitempty"`
+
+			// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+			MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+			// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+			ParentTaskId *int `json:"parent_task_id"`
+
+			// Priority The priority of the task
+			Priority *int `json:"priority"`
+
+			// ProjectId The ID of the project this task is associated with
+			ProjectId *int `json:"project_id,omitempty"`
+
+			// StartDate The start date of the task. Format: YYYY-MM-DD.
+			StartDate *openapi_types.Date `json:"start_date"`
+
+			// Title The title of the task
+			Title *string `json:"title,omitempty"`
+
+			// UpdateTime The update date and time of the task in ISO 8601 format
+			UpdateTime *string `json:"update_time,omitempty"`
+		} `json:"data,omitempty"`
+
+		// Success If the response is successful or not
+		Success *bool `json:"success,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateTaskResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateTaskResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetUserFollowersResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -25003,6 +31372,67 @@ func (c *ClientWithResponses) GetActivityFieldWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseGetActivityFieldResponse(rsp)
+}
+
+// GetProjectsBoardsWithResponse request returning *GetProjectsBoardsResponse
+func (c *ClientWithResponses) GetProjectsBoardsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetProjectsBoardsResponse, error) {
+	rsp, err := c.GetProjectsBoards(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectsBoardsResponse(rsp)
+}
+
+// AddProjectBoardWithBodyWithResponse request with arbitrary body returning *AddProjectBoardResponse
+func (c *ClientWithResponses) AddProjectBoardWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectBoardResponse, error) {
+	rsp, err := c.AddProjectBoardWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectBoardResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddProjectBoardWithResponse(ctx context.Context, body AddProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectBoardResponse, error) {
+	rsp, err := c.AddProjectBoard(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectBoardResponse(rsp)
+}
+
+// DeleteProjectBoardWithResponse request returning *DeleteProjectBoardResponse
+func (c *ClientWithResponses) DeleteProjectBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectBoardResponse, error) {
+	rsp, err := c.DeleteProjectBoard(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectBoardResponse(rsp)
+}
+
+// GetProjectsBoardWithResponse request returning *GetProjectsBoardResponse
+func (c *ClientWithResponses) GetProjectsBoardWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsBoardResponse, error) {
+	rsp, err := c.GetProjectsBoard(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectsBoardResponse(rsp)
+}
+
+// UpdateProjectBoardWithBodyWithResponse request with arbitrary body returning *UpdateProjectBoardResponse
+func (c *ClientWithResponses) UpdateProjectBoardWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectBoardResponse, error) {
+	rsp, err := c.UpdateProjectBoardWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectBoardResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectBoardWithResponse(ctx context.Context, id int, body UpdateProjectBoardJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectBoardResponse, error) {
+	rsp, err := c.UpdateProjectBoard(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectBoardResponse(rsp)
 }
 
 // GetDealFieldsWithResponse request returning *GetDealFieldsResponse
@@ -25963,6 +32393,67 @@ func (c *ClientWithResponses) GetPersonPictureWithResponse(ctx context.Context, 
 	return ParseGetPersonPictureResponse(rsp)
 }
 
+// GetProjectsPhasesWithResponse request returning *GetProjectsPhasesResponse
+func (c *ClientWithResponses) GetProjectsPhasesWithResponse(ctx context.Context, params *GetProjectsPhasesParams, reqEditors ...RequestEditorFn) (*GetProjectsPhasesResponse, error) {
+	rsp, err := c.GetProjectsPhases(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectsPhasesResponse(rsp)
+}
+
+// AddProjectPhaseWithBodyWithResponse request with arbitrary body returning *AddProjectPhaseResponse
+func (c *ClientWithResponses) AddProjectPhaseWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectPhaseResponse, error) {
+	rsp, err := c.AddProjectPhaseWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectPhaseResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddProjectPhaseWithResponse(ctx context.Context, body AddProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectPhaseResponse, error) {
+	rsp, err := c.AddProjectPhase(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectPhaseResponse(rsp)
+}
+
+// DeleteProjectPhaseWithResponse request returning *DeleteProjectPhaseResponse
+func (c *ClientWithResponses) DeleteProjectPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectPhaseResponse, error) {
+	rsp, err := c.DeleteProjectPhase(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectPhaseResponse(rsp)
+}
+
+// GetProjectsPhaseWithResponse request returning *GetProjectsPhaseResponse
+func (c *ClientWithResponses) GetProjectsPhaseWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectsPhaseResponse, error) {
+	rsp, err := c.GetProjectsPhase(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectsPhaseResponse(rsp)
+}
+
+// UpdateProjectPhaseWithBodyWithResponse request with arbitrary body returning *UpdateProjectPhaseResponse
+func (c *ClientWithResponses) UpdateProjectPhaseWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectPhaseResponse, error) {
+	rsp, err := c.UpdateProjectPhaseWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectPhaseResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectPhaseWithResponse(ctx context.Context, id int, body UpdateProjectPhaseJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectPhaseResponse, error) {
+	rsp, err := c.UpdateProjectPhase(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectPhaseResponse(rsp)
+}
+
 // GetPipelinesWithResponse request returning *GetPipelinesResponse
 func (c *ClientWithResponses) GetPipelinesWithResponse(ctx context.Context, params *GetPipelinesParams, reqEditors ...RequestEditorFn) (*GetPipelinesResponse, error) {
 	rsp, err := c.GetPipelines(ctx, params, reqEditors...)
@@ -26347,6 +32838,242 @@ func (c *ClientWithResponses) UpdateProductVariationWithResponse(ctx context.Con
 	return ParseUpdateProductVariationResponse(rsp)
 }
 
+// GetProjectFieldsWithResponse request returning *GetProjectFieldsResponse
+func (c *ClientWithResponses) GetProjectFieldsWithResponse(ctx context.Context, params *GetProjectFieldsParams, reqEditors ...RequestEditorFn) (*GetProjectFieldsResponse, error) {
+	rsp, err := c.GetProjectFields(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectFieldsResponse(rsp)
+}
+
+// AddProjectFieldWithBodyWithResponse request with arbitrary body returning *AddProjectFieldResponse
+func (c *ClientWithResponses) AddProjectFieldWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectFieldResponse, error) {
+	rsp, err := c.AddProjectFieldWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectFieldResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddProjectFieldWithResponse(ctx context.Context, body AddProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectFieldResponse, error) {
+	rsp, err := c.AddProjectField(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectFieldResponse(rsp)
+}
+
+// DeleteProjectFieldWithResponse request returning *DeleteProjectFieldResponse
+func (c *ClientWithResponses) DeleteProjectFieldWithResponse(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*DeleteProjectFieldResponse, error) {
+	rsp, err := c.DeleteProjectField(ctx, fieldCode, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectFieldResponse(rsp)
+}
+
+// GetProjectFieldWithResponse request returning *GetProjectFieldResponse
+func (c *ClientWithResponses) GetProjectFieldWithResponse(ctx context.Context, fieldCode string, reqEditors ...RequestEditorFn) (*GetProjectFieldResponse, error) {
+	rsp, err := c.GetProjectField(ctx, fieldCode, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectFieldResponse(rsp)
+}
+
+// UpdateProjectFieldWithBodyWithResponse request with arbitrary body returning *UpdateProjectFieldResponse
+func (c *ClientWithResponses) UpdateProjectFieldWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectFieldResponse, error) {
+	rsp, err := c.UpdateProjectFieldWithBody(ctx, fieldCode, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectFieldResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectFieldWithResponse(ctx context.Context, fieldCode string, body UpdateProjectFieldJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectFieldResponse, error) {
+	rsp, err := c.UpdateProjectField(ctx, fieldCode, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectFieldResponse(rsp)
+}
+
+// DeleteProjectFieldOptionsWithBodyWithResponse request with arbitrary body returning *DeleteProjectFieldOptionsResponse
+func (c *ClientWithResponses) DeleteProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeleteProjectFieldOptionsResponse, error) {
+	rsp, err := c.DeleteProjectFieldOptionsWithBody(ctx, fieldCode, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectFieldOptionsResponse(rsp)
+}
+
+func (c *ClientWithResponses) DeleteProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body DeleteProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*DeleteProjectFieldOptionsResponse, error) {
+	rsp, err := c.DeleteProjectFieldOptions(ctx, fieldCode, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectFieldOptionsResponse(rsp)
+}
+
+// UpdateProjectFieldOptionsWithBodyWithResponse request with arbitrary body returning *UpdateProjectFieldOptionsResponse
+func (c *ClientWithResponses) UpdateProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectFieldOptionsResponse, error) {
+	rsp, err := c.UpdateProjectFieldOptionsWithBody(ctx, fieldCode, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectFieldOptionsResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body UpdateProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectFieldOptionsResponse, error) {
+	rsp, err := c.UpdateProjectFieldOptions(ctx, fieldCode, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectFieldOptionsResponse(rsp)
+}
+
+// AddProjectFieldOptionsWithBodyWithResponse request with arbitrary body returning *AddProjectFieldOptionsResponse
+func (c *ClientWithResponses) AddProjectFieldOptionsWithBodyWithResponse(ctx context.Context, fieldCode string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectFieldOptionsResponse, error) {
+	rsp, err := c.AddProjectFieldOptionsWithBody(ctx, fieldCode, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectFieldOptionsResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddProjectFieldOptionsWithResponse(ctx context.Context, fieldCode string, body AddProjectFieldOptionsJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectFieldOptionsResponse, error) {
+	rsp, err := c.AddProjectFieldOptions(ctx, fieldCode, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectFieldOptionsResponse(rsp)
+}
+
+// GetProjectTemplatesWithResponse request returning *GetProjectTemplatesResponse
+func (c *ClientWithResponses) GetProjectTemplatesWithResponse(ctx context.Context, params *GetProjectTemplatesParams, reqEditors ...RequestEditorFn) (*GetProjectTemplatesResponse, error) {
+	rsp, err := c.GetProjectTemplates(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectTemplatesResponse(rsp)
+}
+
+// GetProjectTemplateWithResponse request returning *GetProjectTemplateResponse
+func (c *ClientWithResponses) GetProjectTemplateWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectTemplateResponse, error) {
+	rsp, err := c.GetProjectTemplate(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectTemplateResponse(rsp)
+}
+
+// GetProjectsWithResponse request returning *GetProjectsResponse
+func (c *ClientWithResponses) GetProjectsWithResponse(ctx context.Context, params *GetProjectsParams, reqEditors ...RequestEditorFn) (*GetProjectsResponse, error) {
+	rsp, err := c.GetProjects(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectsResponse(rsp)
+}
+
+// AddProjectWithBodyWithResponse request with arbitrary body returning *AddProjectResponse
+func (c *ClientWithResponses) AddProjectWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddProjectResponse, error) {
+	rsp, err := c.AddProjectWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddProjectWithResponse(ctx context.Context, body AddProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*AddProjectResponse, error) {
+	rsp, err := c.AddProject(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddProjectResponse(rsp)
+}
+
+// GetArchivedProjectsWithResponse request returning *GetArchivedProjectsResponse
+func (c *ClientWithResponses) GetArchivedProjectsWithResponse(ctx context.Context, params *GetArchivedProjectsParams, reqEditors ...RequestEditorFn) (*GetArchivedProjectsResponse, error) {
+	rsp, err := c.GetArchivedProjects(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetArchivedProjectsResponse(rsp)
+}
+
+// SearchProjectsWithResponse request returning *SearchProjectsResponse
+func (c *ClientWithResponses) SearchProjectsWithResponse(ctx context.Context, params *SearchProjectsParams, reqEditors ...RequestEditorFn) (*SearchProjectsResponse, error) {
+	rsp, err := c.SearchProjects(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseSearchProjectsResponse(rsp)
+}
+
+// DeleteProjectWithResponse request returning *DeleteProjectResponse
+func (c *ClientWithResponses) DeleteProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteProjectResponse, error) {
+	rsp, err := c.DeleteProject(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectResponse(rsp)
+}
+
+// GetProjectWithResponse request returning *GetProjectResponse
+func (c *ClientWithResponses) GetProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectResponse, error) {
+	rsp, err := c.GetProject(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectResponse(rsp)
+}
+
+// UpdateProjectWithBodyWithResponse request with arbitrary body returning *UpdateProjectResponse
+func (c *ClientWithResponses) UpdateProjectWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error) {
+	rsp, err := c.UpdateProjectWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectWithResponse(ctx context.Context, id int, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResponse, error) {
+	rsp, err := c.UpdateProject(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectResponse(rsp)
+}
+
+// ArchiveProjectWithResponse request returning *ArchiveProjectResponse
+func (c *ClientWithResponses) ArchiveProjectWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*ArchiveProjectResponse, error) {
+	rsp, err := c.ArchiveProject(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseArchiveProjectResponse(rsp)
+}
+
+// GetProjectChangelogWithResponse request returning *GetProjectChangelogResponse
+func (c *ClientWithResponses) GetProjectChangelogWithResponse(ctx context.Context, id int, params *GetProjectChangelogParams, reqEditors ...RequestEditorFn) (*GetProjectChangelogResponse, error) {
+	rsp, err := c.GetProjectChangelog(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectChangelogResponse(rsp)
+}
+
+// GetProjectUsersWithResponse request returning *GetProjectUsersResponse
+func (c *ClientWithResponses) GetProjectUsersWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetProjectUsersResponse, error) {
+	rsp, err := c.GetProjectUsers(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectUsersResponse(rsp)
+}
+
 // GetStagesWithResponse request returning *GetStagesResponse
 func (c *ClientWithResponses) GetStagesWithResponse(ctx context.Context, params *GetStagesParams, reqEditors ...RequestEditorFn) (*GetStagesResponse, error) {
 	rsp, err := c.GetStages(ctx, params, reqEditors...)
@@ -26406,6 +33133,67 @@ func (c *ClientWithResponses) UpdateStageWithResponse(ctx context.Context, id in
 		return nil, err
 	}
 	return ParseUpdateStageResponse(rsp)
+}
+
+// GetTasksWithResponse request returning *GetTasksResponse
+func (c *ClientWithResponses) GetTasksWithResponse(ctx context.Context, params *GetTasksParams, reqEditors ...RequestEditorFn) (*GetTasksResponse, error) {
+	rsp, err := c.GetTasks(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetTasksResponse(rsp)
+}
+
+// AddTaskWithBodyWithResponse request with arbitrary body returning *AddTaskResponse
+func (c *ClientWithResponses) AddTaskWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AddTaskResponse, error) {
+	rsp, err := c.AddTaskWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddTaskResponse(rsp)
+}
+
+func (c *ClientWithResponses) AddTaskWithResponse(ctx context.Context, body AddTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*AddTaskResponse, error) {
+	rsp, err := c.AddTask(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAddTaskResponse(rsp)
+}
+
+// DeleteTaskWithResponse request returning *DeleteTaskResponse
+func (c *ClientWithResponses) DeleteTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*DeleteTaskResponse, error) {
+	rsp, err := c.DeleteTask(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteTaskResponse(rsp)
+}
+
+// GetTaskWithResponse request returning *GetTaskResponse
+func (c *ClientWithResponses) GetTaskWithResponse(ctx context.Context, id int, reqEditors ...RequestEditorFn) (*GetTaskResponse, error) {
+	rsp, err := c.GetTask(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetTaskResponse(rsp)
+}
+
+// UpdateTaskWithBodyWithResponse request with arbitrary body returning *UpdateTaskResponse
+func (c *ClientWithResponses) UpdateTaskWithBodyWithResponse(ctx context.Context, id int, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error) {
+	rsp, err := c.UpdateTaskWithBody(ctx, id, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateTaskResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateTaskWithResponse(ctx context.Context, id int, body UpdateTaskJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateTaskResponse, error) {
+	rsp, err := c.UpdateTask(ctx, id, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateTaskResponse(rsp)
 }
 
 // GetUserFollowersWithResponse request returning *GetUserFollowersResponse
@@ -27178,8 +33966,8 @@ func ParseGetActivityFieldsResponse(rsp *http.Response) (*GetActivityFieldsRespo
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetActivityFields_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -27263,8 +34051,8 @@ func ParseGetActivityFieldResponse(rsp *http.Response) (*GetActivityFieldRespons
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetActivityField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -27308,6 +34096,227 @@ func ParseGetActivityFieldResponse(rsp *http.Response) (*GetActivityFieldRespons
 	return response, nil
 }
 
+// ParseGetProjectsBoardsResponse parses an HTTP response from a GetProjectsBoardsWithResponse call
+func ParseGetProjectsBoardsResponse(rsp *http.Response) (*GetProjectsBoardsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectsBoardsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+
+			// Data The array of project boards
+			Data *[]struct {
+				// AddTime The creation date and time of the board in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Id The ID of the project board
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project board
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the board in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddProjectBoardResponse parses an HTTP response from a AddProjectBoardWithResponse call
+func ParseAddProjectBoardResponse(rsp *http.Response) (*AddProjectBoardResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddProjectBoardResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the board in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Id The ID of the project board
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project board
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the board in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectBoardResponse parses an HTTP response from a DeleteProjectBoardWithResponse call
+func ParseDeleteProjectBoardResponse(rsp *http.Response) (*DeleteProjectBoardResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectBoardResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// Id The ID of the deleted project board
+				Id *int `json:"id,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectsBoardResponse parses an HTTP response from a GetProjectsBoardWithResponse call
+func ParseGetProjectsBoardResponse(rsp *http.Response) (*GetProjectsBoardResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectsBoardResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the board in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Id The ID of the project board
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project board
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the board in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectBoardResponse parses an HTTP response from a UpdateProjectBoardWithResponse call
+func ParseUpdateProjectBoardResponse(rsp *http.Response) (*UpdateProjectBoardResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectBoardResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the board in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Id The ID of the project board
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project board
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the board in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetDealFieldsResponse parses an HTTP response from a GetDealFieldsWithResponse call
 func ParseGetDealFieldsResponse(rsp *http.Response) (*GetDealFieldsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -27330,7 +34339,7 @@ func ParseGetDealFieldsResponse(rsp *http.Response) (*GetDealFieldsResponse, err
 			} `json:"additional_data,omitempty"`
 			Data *[]struct {
 				// Description The description of the field
-				Description string `json:"description"`
+				Description *string `json:"description,omitempty"`
 
 				// FieldCode The unique identifier for the field (40-character hash for custom fields)
 				FieldCode string `json:"field_code"`
@@ -27364,8 +34373,8 @@ func ParseGetDealFieldsResponse(rsp *http.Response) (*GetDealFieldsResponse, err
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetDealFields_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -27451,7 +34460,7 @@ func ParseAddDealFieldResponse(rsp *http.Response) (*AddDealFieldResponse, error
 		var dest struct {
 			Data *struct {
 				// Description The description of the field
-				Description string `json:"description"`
+				Description *string `json:"description,omitempty"`
 
 				// FieldCode The unique identifier for the field (40-character hash for custom fields)
 				FieldCode string `json:"field_code"`
@@ -27485,8 +34494,8 @@ func ParseAddDealFieldResponse(rsp *http.Response) (*AddDealFieldResponse, error
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *AddDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -27572,7 +34581,7 @@ func ParseDeleteDealFieldResponse(rsp *http.Response) (*DeleteDealFieldResponse,
 		var dest struct {
 			Data *struct {
 				// Description The description of the field
-				Description string `json:"description"`
+				Description *string `json:"description,omitempty"`
 
 				// FieldCode The unique identifier for the field (40-character hash for custom fields)
 				FieldCode string `json:"field_code"`
@@ -27627,7 +34636,7 @@ func ParseGetDealFieldResponse(rsp *http.Response) (*GetDealFieldResponse, error
 		var dest struct {
 			Data *struct {
 				// Description The description of the field
-				Description string `json:"description"`
+				Description *string `json:"description,omitempty"`
 
 				// FieldCode The unique identifier for the field (40-character hash for custom fields)
 				FieldCode string `json:"field_code"`
@@ -27661,8 +34670,8 @@ func ParseGetDealFieldResponse(rsp *http.Response) (*GetDealFieldResponse, error
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -27748,7 +34757,7 @@ func ParseUpdateDealFieldResponse(rsp *http.Response) (*UpdateDealFieldResponse,
 		var dest struct {
 			Data *struct {
 				// Description The description of the field
-				Description string `json:"description"`
+				Description *string `json:"description,omitempty"`
 
 				// FieldCode The unique identifier for the field (40-character hash for custom fields)
 				FieldCode string `json:"field_code"`
@@ -27782,8 +34791,8 @@ func ParseUpdateDealFieldResponse(rsp *http.Response) (*UpdateDealFieldResponse,
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *UpdateDealField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -28012,7 +35021,7 @@ func ParseGetDealsResponse(rsp *http.Response) (*GetDealsResponse, error) {
 				// Currency The currency associated with the deal
 				Currency *string `json:"currency,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// ExpectedCloseDate The expected close date of the deal
@@ -28151,7 +35160,7 @@ func ParseAddDealResponse(rsp *http.Response) (*AddDealResponse, error) {
 				// Currency The currency associated with the deal
 				Currency *string `json:"currency,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// ExpectedCloseDate The expected close date of the deal
@@ -28297,7 +35306,7 @@ func ParseGetArchivedDealsResponse(rsp *http.Response) (*GetArchivedDealsRespons
 				// Currency The currency associated with the deal
 				Currency *string `json:"currency,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// ExpectedCloseDate The expected close date of the deal
@@ -28489,7 +35498,7 @@ func ParseGetDealsProductsResponse(rsp *http.Response) (*GetDealsProductsRespons
 				// BillingStartDate Only available in Growth and above plans
 				//
 				// The billing start date. Must be between 10 years in the past and 10 years in the future
-				BillingStartDate *string `json:"billing_start_date"`
+				BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 				// Comments The comments of the product
 				Comments *string `json:"comments,omitempty"`
@@ -28528,7 +35537,7 @@ func ParseGetDealsProductsResponse(rsp *http.Response) (*GetDealsProductsRespons
 				ProductVariationId *int `json:"product_variation_id"`
 
 				// Quantity The quantity of the product
-				Quantity *int `json:"quantity,omitempty"`
+				Quantity *float32 `json:"quantity,omitempty"`
 
 				// Sum The sum of all the products attached to the deal
 				Sum *float32 `json:"sum,omitempty"`
@@ -28735,7 +35744,7 @@ func ParseGetDealResponse(rsp *http.Response) (*GetDealResponse, error) {
 				// Currency The currency associated with the deal
 				Currency *string `json:"currency,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// ExpectedCloseDate The expected close date of the deal
@@ -28874,7 +35883,7 @@ func ParseUpdateDealResponse(rsp *http.Response) (*UpdateDealResponse, error) {
 				// Currency The currency associated with the deal
 				Currency *string `json:"currency,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// ExpectedCloseDate The expected close date of the deal
@@ -29670,7 +36679,7 @@ func ParseGetDealProductsResponse(rsp *http.Response) (*GetDealProductsResponse,
 				// BillingStartDate Only available in Growth and above plans
 				//
 				// The billing start date. Must be between 10 years in the past and 10 years in the future
-				BillingStartDate *string `json:"billing_start_date"`
+				BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 				// Comments The comments of the product
 				Comments *string `json:"comments,omitempty"`
@@ -29709,7 +36718,7 @@ func ParseGetDealProductsResponse(rsp *http.Response) (*GetDealProductsResponse,
 				ProductVariationId *int `json:"product_variation_id"`
 
 				// Quantity The quantity of the product
-				Quantity *int `json:"quantity,omitempty"`
+				Quantity *float32 `json:"quantity,omitempty"`
 
 				// Sum The sum of all the products attached to the deal
 				Sum *float32 `json:"sum,omitempty"`
@@ -29782,7 +36791,7 @@ func ParseAddDealProductResponse(rsp *http.Response) (*AddDealProductResponse, e
 				// BillingStartDate Only available in Growth and above plans
 				//
 				// The billing start date. Must be between 10 years in the past and 10 years in the future
-				BillingStartDate *string `json:"billing_start_date"`
+				BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 				// Comments The comments of the product
 				Comments *string `json:"comments,omitempty"`
@@ -29821,7 +36830,7 @@ func ParseAddDealProductResponse(rsp *http.Response) (*AddDealProductResponse, e
 				ProductVariationId *int `json:"product_variation_id"`
 
 				// Quantity The quantity of the product
-				Quantity *int `json:"quantity,omitempty"`
+				Quantity *float32 `json:"quantity,omitempty"`
 
 				// Sum The sum of all the products attached to the deal
 				Sum *float32 `json:"sum,omitempty"`
@@ -29895,7 +36904,7 @@ func ParseAddManyDealProductsResponse(rsp *http.Response) (*AddManyDealProductsR
 				// BillingStartDate Only available in Growth and above plans
 				//
 				// The billing start date. Must be between 10 years in the past and 10 years in the future
-				BillingStartDate *string `json:"billing_start_date"`
+				BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 				// Comments The comments of the product
 				Comments *string `json:"comments,omitempty"`
@@ -29934,7 +36943,7 @@ func ParseAddManyDealProductsResponse(rsp *http.Response) (*AddManyDealProductsR
 				ProductVariationId *int `json:"product_variation_id"`
 
 				// Quantity The quantity of the product
-				Quantity *int `json:"quantity,omitempty"`
+				Quantity *float32 `json:"quantity,omitempty"`
 
 				// Sum The sum of all the products attached to the deal
 				Sum *float32 `json:"sum,omitempty"`
@@ -30041,7 +37050,7 @@ func ParseUpdateDealProductResponse(rsp *http.Response) (*UpdateDealProductRespo
 				// BillingStartDate Only available in Growth and above plans
 				//
 				// The billing start date. Must be between 10 years in the past and 10 years in the future
-				BillingStartDate *string `json:"billing_start_date"`
+				BillingStartDate *openapi_types.Date `json:"billing_start_date"`
 
 				// Comments The comments of the product
 				Comments *string `json:"comments,omitempty"`
@@ -30080,7 +37089,7 @@ func ParseUpdateDealProductResponse(rsp *http.Response) (*UpdateDealProductRespo
 				ProductVariationId *int `json:"product_variation_id"`
 
 				// Quantity The quantity of the product
-				Quantity *int `json:"quantity,omitempty"`
+				Quantity *float32 `json:"quantity,omitempty"`
 
 				// Sum The sum of all the products attached to the deal
 				Sum *float32 `json:"sum,omitempty"`
@@ -30463,8 +37472,8 @@ func ParseGetOrganizationFieldsResponse(rsp *http.Response) (*GetOrganizationFie
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetOrganizationFields_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -30590,8 +37599,8 @@ func ParseAddOrganizationFieldResponse(rsp *http.Response) (*AddOrganizationFiel
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *AddOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -30769,8 +37778,8 @@ func ParseGetOrganizationFieldResponse(rsp *http.Response) (*GetOrganizationFiel
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -30896,8 +37905,8 @@ func ParseUpdateOrganizationFieldResponse(rsp *http.Response) (*UpdateOrganizati
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *UpdateOrganizationField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -31142,17 +38151,29 @@ func ParseGetOrganizationsResponse(rsp *http.Response) (*GetOrganizationsRespons
 					Value *string `json:"value,omitempty"`
 				} `json:"address,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// AnnualRevenue The annual revenue of the organization
+				AnnualRevenue *int `json:"annual_revenue"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// EmployeeCount The number of employees in the organization
+				EmployeeCount *int `json:"employee_count"`
 
 				// Id The ID of the organization
 				Id *int `json:"id,omitempty"`
+
+				// Industry The industry the organization belongs to
+				Industry *int `json:"industry"`
 
 				// IsDeleted Whether the organization is deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
 
 				// LabelIds The IDs of labels assigned to the organization
 				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// Linkedin The LinkedIn profile URL of the organization
+				Linkedin *string `json:"linkedin"`
 
 				// Name The name of the organization
 				Name *string `json:"name,omitempty"`
@@ -31165,6 +38186,9 @@ func ParseGetOrganizationsResponse(rsp *http.Response) (*GetOrganizationsRespons
 
 				// VisibleTo The visibility of the organization
 				VisibleTo *int `json:"visible_to,omitempty"`
+
+				// Website The website of the organization
+				Website *string `json:"website"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -31233,17 +38257,29 @@ func ParseAddOrganizationResponse(rsp *http.Response) (*AddOrganizationResponse,
 					Value *string `json:"value,omitempty"`
 				} `json:"address,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// AnnualRevenue The annual revenue of the organization
+				AnnualRevenue *int `json:"annual_revenue"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// EmployeeCount The number of employees in the organization
+				EmployeeCount *int `json:"employee_count"`
 
 				// Id The ID of the organization
 				Id *int `json:"id,omitempty"`
+
+				// Industry The industry the organization belongs to
+				Industry *int `json:"industry"`
 
 				// IsDeleted Whether the organization is deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
 
 				// LabelIds The IDs of labels assigned to the organization
 				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// Linkedin The LinkedIn profile URL of the organization
+				Linkedin *string `json:"linkedin"`
 
 				// Name The name of the organization
 				Name *string `json:"name,omitempty"`
@@ -31256,6 +38292,9 @@ func ParseAddOrganizationResponse(rsp *http.Response) (*AddOrganizationResponse,
 
 				// VisibleTo The visibility of the organization
 				VisibleTo *int `json:"visible_to,omitempty"`
+
+				// Website The website of the organization
+				Website *string `json:"website"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -31427,17 +38466,29 @@ func ParseGetOrganizationResponse(rsp *http.Response) (*GetOrganizationResponse,
 					Value *string `json:"value,omitempty"`
 				} `json:"address,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// AnnualRevenue The annual revenue of the organization
+				AnnualRevenue *int `json:"annual_revenue"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// EmployeeCount The number of employees in the organization
+				EmployeeCount *int `json:"employee_count"`
 
 				// Id The ID of the organization
 				Id *int `json:"id,omitempty"`
+
+				// Industry The industry the organization belongs to
+				Industry *int `json:"industry"`
 
 				// IsDeleted Whether the organization is deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
 
 				// LabelIds The IDs of labels assigned to the organization
 				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// Linkedin The LinkedIn profile URL of the organization
+				Linkedin *string `json:"linkedin"`
 
 				// Name The name of the organization
 				Name *string `json:"name,omitempty"`
@@ -31450,6 +38501,9 @@ func ParseGetOrganizationResponse(rsp *http.Response) (*GetOrganizationResponse,
 
 				// VisibleTo The visibility of the organization
 				VisibleTo *int `json:"visible_to,omitempty"`
+
+				// Website The website of the organization
+				Website *string `json:"website"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -31518,17 +38572,29 @@ func ParseUpdateOrganizationResponse(rsp *http.Response) (*UpdateOrganizationRes
 					Value *string `json:"value,omitempty"`
 				} `json:"address,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// AnnualRevenue The annual revenue of the organization
+				AnnualRevenue *int `json:"annual_revenue"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// EmployeeCount The number of employees in the organization
+				EmployeeCount *int `json:"employee_count"`
 
 				// Id The ID of the organization
 				Id *int `json:"id,omitempty"`
+
+				// Industry The industry the organization belongs to
+				Industry *int `json:"industry"`
 
 				// IsDeleted Whether the organization is deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
 
 				// LabelIds The IDs of labels assigned to the organization
 				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// Linkedin The LinkedIn profile URL of the organization
+				Linkedin *string `json:"linkedin"`
 
 				// Name The name of the organization
 				Name *string `json:"name,omitempty"`
@@ -31541,6 +38607,9 @@ func ParseUpdateOrganizationResponse(rsp *http.Response) (*UpdateOrganizationRes
 
 				// VisibleTo The visibility of the organization
 				VisibleTo *int `json:"visible_to,omitempty"`
+
+				// Website The website of the organization
+				Website *string `json:"website"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -31774,8 +38843,8 @@ func ParseGetPersonFieldsResponse(rsp *http.Response) (*GetPersonFieldsResponse,
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetPersonFields_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -31883,8 +38952,8 @@ func ParseAddPersonFieldResponse(rsp *http.Response) (*AddPersonFieldResponse, e
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *AddPersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -32044,8 +39113,8 @@ func ParseGetPersonFieldResponse(rsp *http.Response) (*GetPersonFieldResponse, e
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetPersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -32153,8 +39222,8 @@ func ParseUpdatePersonFieldResponse(rsp *http.Response) (*UpdatePersonFieldRespo
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *UpdatePersonField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -32351,7 +39420,7 @@ func ParseGetPersonsResponse(rsp *http.Response) (*GetPersonsResponse, error) {
 				// Birthday The birthday of the person, included if contact sync is enabled for the company
 				Birthday *string `json:"birthday,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// Emails The emails of the person
@@ -32499,7 +39568,7 @@ func ParseAddPersonResponse(rsp *http.Response) (*AddPersonResponse, error) {
 				// Birthday The birthday of the person, included if contact sync is enabled for the company
 				Birthday *string `json:"birthday,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// Emails The emails of the person
@@ -32760,7 +39829,7 @@ func ParseGetPersonResponse(rsp *http.Response) (*GetPersonResponse, error) {
 				// Birthday The birthday of the person, included if contact sync is enabled for the company
 				Birthday *string `json:"birthday,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// Emails The emails of the person
@@ -32908,7 +39977,7 @@ func ParseUpdatePersonResponse(rsp *http.Response) (*UpdatePersonResponse, error
 				// Birthday The birthday of the person, included if contact sync is enabled for the company
 				Birthday *string `json:"birthday,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
 				// Emails The emails of the person
@@ -33256,6 +40325,239 @@ func ParseGetPersonPictureResponse(rsp *http.Response) (*GetPersonPictureRespons
 	return response, nil
 }
 
+// ParseGetProjectsPhasesResponse parses an HTTP response from a GetProjectsPhasesWithResponse call
+func ParseGetProjectsPhasesResponse(rsp *http.Response) (*GetProjectsPhasesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectsPhasesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+
+			// Data The array of project phases
+			Data *[]struct {
+				// AddTime The creation date and time of the phase in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// BoardId The ID of the project board this phase belongs to
+				BoardId *int `json:"board_id,omitempty"`
+
+				// Id The ID of the project phase
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project phase
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the phase within its board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the phase in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddProjectPhaseResponse parses an HTTP response from a AddProjectPhaseWithResponse call
+func ParseAddProjectPhaseResponse(rsp *http.Response) (*AddProjectPhaseResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddProjectPhaseResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the phase in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// BoardId The ID of the project board this phase belongs to
+				BoardId *int `json:"board_id,omitempty"`
+
+				// Id The ID of the project phase
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project phase
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the phase within its board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the phase in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectPhaseResponse parses an HTTP response from a DeleteProjectPhaseWithResponse call
+func ParseDeleteProjectPhaseResponse(rsp *http.Response) (*DeleteProjectPhaseResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectPhaseResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// Id The ID of the deleted project phase
+				Id *int `json:"id,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectsPhaseResponse parses an HTTP response from a GetProjectsPhaseWithResponse call
+func ParseGetProjectsPhaseResponse(rsp *http.Response) (*GetProjectsPhaseResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectsPhaseResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the phase in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// BoardId The ID of the project board this phase belongs to
+				BoardId *int `json:"board_id,omitempty"`
+
+				// Id The ID of the project phase
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project phase
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the phase within its board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the phase in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectPhaseResponse parses an HTTP response from a UpdateProjectPhaseWithResponse call
+func ParseUpdateProjectPhaseResponse(rsp *http.Response) (*UpdateProjectPhaseResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectPhaseResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the phase in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// BoardId The ID of the project board this phase belongs to
+				BoardId *int `json:"board_id,omitempty"`
+
+				// Id The ID of the project phase
+				Id *int `json:"id,omitempty"`
+
+				// Name The name of the project phase
+				Name *string `json:"name,omitempty"`
+
+				// OrderNr The order of the phase within its board
+				OrderNr *int `json:"order_nr,omitempty"`
+
+				// UpdateTime The update date and time of the phase in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetPipelinesResponse parses an HTTP response from a GetPipelinesWithResponse call
 func ParseGetPipelinesResponse(rsp *http.Response) (*GetPipelinesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -33552,8 +40854,8 @@ func ParseGetProductFieldsResponse(rsp *http.Response) (*GetProductFieldsRespons
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetProductFields_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -33637,8 +40939,8 @@ func ParseAddProductFieldResponse(rsp *http.Response) (*AddProductFieldResponse,
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *AddProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -33774,8 +41076,8 @@ func ParseGetProductFieldResponse(rsp *http.Response) (*GetProductFieldResponse,
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -33859,8 +41161,8 @@ func ParseUpdateProductFieldResponse(rsp *http.Response) (*UpdateProductFieldRes
 					// Color Optional color code for the option
 					Color *string `json:"color"`
 
-					// Id The option ID
-					Id *int `json:"id,omitempty"`
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *UpdateProductField_200_Data_Options_Id `json:"id,omitempty"`
 
 					// Label The option display label
 					Label *string `json:"label,omitempty"`
@@ -34036,61 +41338,86 @@ func ParseGetProductsResponse(rsp *http.Response) (*GetProductsResponse, error) 
 
 			// Data Array containing data for all products
 			Data *[]struct {
-				Data *struct {
-					// BillingFrequency Only available in Growth and above plans
-					//
-					// How often a customer is billed for access to a service or product
-					BillingFrequency *GetProducts200DataDataBillingFrequency `json:"billing_frequency,omitempty"`
+				// AddTime The date and time when the product was added
+				AddTime *string `json:"add_time,omitempty"`
 
-					// BillingFrequencyCycles Only available in Growth and above plans
-					//
-					// The number of times the billing frequency repeats for a product in a deal
-					//
-					// When `billing_frequency` is set to `one-time`, this field must be `null`
-					//
-					// When `billing_frequency` is set to `weekly`, this field cannot be `null`
-					//
-					// For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
-					//
-					// Must be a positive integer less or equal to 208
-					BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
+				// BillingFrequency Only available in Growth and above plans
+				//
+				// How often a customer is billed for access to a service or product
+				BillingFrequency *GetProducts200DataBillingFrequency `json:"billing_frequency,omitempty"`
 
-					// Code The product code
-					Code *string `json:"code,omitempty"`
+				// BillingFrequencyCycles Only available in Growth and above plans
+				//
+				// The number of times the billing frequency repeats for a product in a deal
+				//
+				// When `billing_frequency` is set to `one-time`, this field must be `null`
+				//
+				// When `billing_frequency` is set to `weekly`, this field cannot be `null`
+				//
+				// For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
+				//
+				// Must be a positive integer less or equal to 208
+				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
-					// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
-					CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+				// Category The category of the product
+				Category *string `json:"category"`
 
-					// Id The ID of the product
-					Id *float32 `json:"id,omitempty"`
+				// Code The product code
+				Code *string `json:"code,omitempty"`
 
-					// IsDeleted Whether this product will be marked as deleted or not
-					IsDeleted *bool `json:"is_deleted,omitempty"`
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
-					// IsLinkable Whether this product can be added to a deal or not
-					IsLinkable *bool `json:"is_linkable,omitempty"`
+				// Description The description of the product
+				Description *string `json:"description,omitempty"`
 
-					// Name The name of the product
-					Name *string `json:"name,omitempty"`
+				// Id The ID of the product
+				Id *int `json:"id,omitempty"`
 
-					// OwnerId Information about the Pipedrive user who owns the product
-					OwnerId *int `json:"owner_id,omitempty"`
+				// IsDeleted Whether this product will be marked as deleted or not
+				IsDeleted *bool `json:"is_deleted,omitempty"`
 
-					// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-					Prices *[]map[string]interface{} `json:"prices,omitempty"`
+				// IsLinkable Whether this product can be added to a deal or not
+				IsLinkable *bool `json:"is_linkable,omitempty"`
 
-					// Tax The tax percentage
-					Tax *float32 `json:"tax,omitempty"`
+				// Name The name of the product
+				Name *string `json:"name,omitempty"`
 
-					// Unit The unit in which this product is sold
-					Unit *string `json:"unit,omitempty"`
+				// OwnerId The ID of the Pipedrive user who owns the product
+				OwnerId *int `json:"owner_id,omitempty"`
 
-					// VisibleTo Visibility of the product
-					VisibleTo *GetProducts200DataDataVisibleTo `json:"visible_to,omitempty"`
-				} `json:"data,omitempty"`
+				// Prices The prices of the product in different currencies
+				Prices *[]struct {
+					// Cost The cost of the product
+					Cost *float32 `json:"cost,omitempty"`
 
-				// Success If the response is successful or not
-				Success *bool `json:"success,omitempty"`
+					// Currency The currency of the price
+					Currency *string `json:"currency,omitempty"`
+
+					// DirectCost The direct cost of the product
+					DirectCost *float32 `json:"direct_cost"`
+
+					// Notes The notes about the price
+					Notes *string `json:"notes,omitempty"`
+
+					// Price The price of the product
+					Price *float32 `json:"price,omitempty"`
+
+					// ProductId The ID of the product
+					ProductId *int `json:"product_id,omitempty"`
+				} `json:"prices,omitempty"`
+
+				// Tax The tax percentage
+				Tax *float32 `json:"tax,omitempty"`
+
+				// Unit The unit in which this product is sold
+				Unit *string `json:"unit,omitempty"`
+
+				// UpdateTime The date and time when the product was last updated
+				UpdateTime *string `json:"update_time,omitempty"`
+
+				// VisibleTo Visibility of the product
+				VisibleTo *GetProducts200DataVisibleTo `json:"visible_to,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -34123,6 +41450,9 @@ func ParseAddProductResponse(rsp *http.Response) (*AddProductResponse, error) {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest struct {
 			Data *struct {
+				// AddTime The date and time when the product was added
+				AddTime *string `json:"add_time,omitempty"`
+
 				// BillingFrequency Only available in Growth and above plans
 				//
 				// How often a customer is billed for access to a service or product
@@ -34141,14 +41471,20 @@ func ParseAddProductResponse(rsp *http.Response) (*AddProductResponse, error) {
 				// Must be a positive integer less or equal to 208
 				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+				// Category The category of the product
+				Category *string `json:"category"`
+
 				// Code The product code
 				Code *string `json:"code,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+				// Description The description of the product
+				Description *string `json:"description,omitempty"`
+
 				// Id The ID of the product
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// IsDeleted Whether this product will be marked as deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -34159,17 +41495,38 @@ func ParseAddProductResponse(rsp *http.Response) (*AddProductResponse, error) {
 				// Name The name of the product
 				Name *string `json:"name,omitempty"`
 
-				// OwnerId Information about the Pipedrive user who owns the product
+				// OwnerId The ID of the Pipedrive user who owns the product
 				OwnerId *int `json:"owner_id,omitempty"`
 
-				// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-				Prices *[]map[string]interface{} `json:"prices,omitempty"`
+				// Prices The prices of the product in different currencies
+				Prices *[]struct {
+					// Cost The cost of the product
+					Cost *float32 `json:"cost,omitempty"`
+
+					// Currency The currency of the price
+					Currency *string `json:"currency,omitempty"`
+
+					// DirectCost The direct cost of the product
+					DirectCost *float32 `json:"direct_cost"`
+
+					// Notes The notes about the price
+					Notes *string `json:"notes,omitempty"`
+
+					// Price The price of the product
+					Price *float32 `json:"price,omitempty"`
+
+					// ProductId The ID of the product
+					ProductId *int `json:"product_id,omitempty"`
+				} `json:"prices,omitempty"`
 
 				// Tax The tax percentage
 				Tax *float32 `json:"tax,omitempty"`
 
 				// Unit The unit in which this product is sold
 				Unit *string `json:"unit,omitempty"`
+
+				// UpdateTime The date and time when the product was last updated
+				UpdateTime *string `json:"update_time,omitempty"`
 
 				// VisibleTo Visibility of the product
 				VisibleTo *AddProduct201DataVisibleTo `json:"visible_to,omitempty"`
@@ -34305,6 +41662,9 @@ func ParseGetProductResponse(rsp *http.Response) (*GetProductResponse, error) {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Data *struct {
+				// AddTime The date and time when the product was added
+				AddTime *string `json:"add_time,omitempty"`
+
 				// BillingFrequency Only available in Growth and above plans
 				//
 				// How often a customer is billed for access to a service or product
@@ -34323,14 +41683,20 @@ func ParseGetProductResponse(rsp *http.Response) (*GetProductResponse, error) {
 				// Must be a positive integer less or equal to 208
 				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+				// Category The category of the product
+				Category *string `json:"category"`
+
 				// Code The product code
 				Code *string `json:"code,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+				// Description The description of the product
+				Description *string `json:"description,omitempty"`
+
 				// Id The ID of the product
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// IsDeleted Whether this product will be marked as deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -34341,17 +41707,38 @@ func ParseGetProductResponse(rsp *http.Response) (*GetProductResponse, error) {
 				// Name The name of the product
 				Name *string `json:"name,omitempty"`
 
-				// OwnerId Information about the Pipedrive user who owns the product
+				// OwnerId The ID of the Pipedrive user who owns the product
 				OwnerId *int `json:"owner_id,omitempty"`
 
-				// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-				Prices *[]map[string]interface{} `json:"prices,omitempty"`
+				// Prices The prices of the product in different currencies
+				Prices *[]struct {
+					// Cost The cost of the product
+					Cost *float32 `json:"cost,omitempty"`
+
+					// Currency The currency of the price
+					Currency *string `json:"currency,omitempty"`
+
+					// DirectCost The direct cost of the product
+					DirectCost *float32 `json:"direct_cost"`
+
+					// Notes The notes about the price
+					Notes *string `json:"notes,omitempty"`
+
+					// Price The price of the product
+					Price *float32 `json:"price,omitempty"`
+
+					// ProductId The ID of the product
+					ProductId *int `json:"product_id,omitempty"`
+				} `json:"prices,omitempty"`
 
 				// Tax The tax percentage
 				Tax *float32 `json:"tax,omitempty"`
 
 				// Unit The unit in which this product is sold
 				Unit *string `json:"unit,omitempty"`
+
+				// UpdateTime The date and time when the product was last updated
+				UpdateTime *string `json:"update_time,omitempty"`
 
 				// VisibleTo Visibility of the product
 				VisibleTo *GetProduct200DataVisibleTo `json:"visible_to,omitempty"`
@@ -34387,6 +41774,9 @@ func ParseUpdateProductResponse(rsp *http.Response) (*UpdateProductResponse, err
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
 			Data *struct {
+				// AddTime The date and time when the product was added
+				AddTime *string `json:"add_time,omitempty"`
+
 				// BillingFrequency Only available in Growth and above plans
 				//
 				// How often a customer is billed for access to a service or product
@@ -34405,14 +41795,20 @@ func ParseUpdateProductResponse(rsp *http.Response) (*UpdateProductResponse, err
 				// Must be a positive integer less or equal to 208
 				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+				// Category The category of the product
+				Category *string `json:"category"`
+
 				// Code The product code
 				Code *string `json:"code,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+				// Description The description of the product
+				Description *string `json:"description,omitempty"`
+
 				// Id The ID of the product
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// IsDeleted Whether this product will be marked as deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -34423,17 +41819,38 @@ func ParseUpdateProductResponse(rsp *http.Response) (*UpdateProductResponse, err
 				// Name The name of the product
 				Name *string `json:"name,omitempty"`
 
-				// OwnerId Information about the Pipedrive user who owns the product
+				// OwnerId The ID of the Pipedrive user who owns the product
 				OwnerId *int `json:"owner_id,omitempty"`
 
-				// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-				Prices *[]map[string]interface{} `json:"prices,omitempty"`
+				// Prices The prices of the product in different currencies
+				Prices *[]struct {
+					// Cost The cost of the product
+					Cost *float32 `json:"cost,omitempty"`
+
+					// Currency The currency of the price
+					Currency *string `json:"currency,omitempty"`
+
+					// DirectCost The direct cost of the product
+					DirectCost *float32 `json:"direct_cost"`
+
+					// Notes The notes about the price
+					Notes *string `json:"notes,omitempty"`
+
+					// Price The price of the product
+					Price *float32 `json:"price,omitempty"`
+
+					// ProductId The ID of the product
+					ProductId *int `json:"product_id,omitempty"`
+				} `json:"prices,omitempty"`
 
 				// Tax The tax percentage
 				Tax *float32 `json:"tax,omitempty"`
 
 				// Unit The unit in which this product is sold
 				Unit *string `json:"unit,omitempty"`
+
+				// UpdateTime The date and time when the product was last updated
+				UpdateTime *string `json:"update_time,omitempty"`
 
 				// VisibleTo Visibility of the product
 				VisibleTo *UpdateProduct200DataVisibleTo `json:"visible_to,omitempty"`
@@ -34469,6 +41886,9 @@ func ParseDuplicateProductResponse(rsp *http.Response) (*DuplicateProductRespons
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
 		var dest struct {
 			Data *struct {
+				// AddTime The date and time when the product was added
+				AddTime *string `json:"add_time,omitempty"`
+
 				// BillingFrequency Only available in Growth and above plans
 				//
 				// How often a customer is billed for access to a service or product
@@ -34487,14 +41907,20 @@ func ParseDuplicateProductResponse(rsp *http.Response) (*DuplicateProductRespons
 				// Must be a positive integer less or equal to 208
 				BillingFrequencyCycles *int `json:"billing_frequency_cycles"`
 
+				// Category The category of the product
+				Category *string `json:"category"`
+
 				// Code The product code
 				Code *string `json:"code,omitempty"`
 
-				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
 				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
 
+				// Description The description of the product
+				Description *string `json:"description,omitempty"`
+
 				// Id The ID of the product
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// IsDeleted Whether this product will be marked as deleted or not
 				IsDeleted *bool `json:"is_deleted,omitempty"`
@@ -34505,17 +41931,38 @@ func ParseDuplicateProductResponse(rsp *http.Response) (*DuplicateProductRespons
 				// Name The name of the product
 				Name *string `json:"name,omitempty"`
 
-				// OwnerId Information about the Pipedrive user who owns the product
+				// OwnerId The ID of the Pipedrive user who owns the product
 				OwnerId *int `json:"owner_id,omitempty"`
 
-				// Prices Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)
-				Prices *[]map[string]interface{} `json:"prices,omitempty"`
+				// Prices The prices of the product in different currencies
+				Prices *[]struct {
+					// Cost The cost of the product
+					Cost *float32 `json:"cost,omitempty"`
+
+					// Currency The currency of the price
+					Currency *string `json:"currency,omitempty"`
+
+					// DirectCost The direct cost of the product
+					DirectCost *float32 `json:"direct_cost"`
+
+					// Notes The notes about the price
+					Notes *string `json:"notes,omitempty"`
+
+					// Price The price of the product
+					Price *float32 `json:"price,omitempty"`
+
+					// ProductId The ID of the product
+					ProductId *int `json:"product_id,omitempty"`
+				} `json:"prices,omitempty"`
 
 				// Tax The tax percentage
 				Tax *float32 `json:"tax,omitempty"`
 
 				// Unit The unit in which this product is sold
 				Unit *string `json:"unit,omitempty"`
+
+				// UpdateTime The date and time when the product was last updated
+				UpdateTime *string `json:"update_time,omitempty"`
 
 				// VisibleTo Visibility of the product
 				VisibleTo *DuplicateProduct201DataVisibleTo `json:"visible_to,omitempty"`
@@ -34813,7 +42260,7 @@ func ParseUploadProductImageResponse(rsp *http.Response) (*UploadProductImageRes
 				Id *int `json:"id,omitempty"`
 
 				// ProductId The ID of the product associated
-				ProductId *float32 `json:"product_id,omitempty"`
+				ProductId *int `json:"product_id,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -34856,7 +42303,7 @@ func ParseUpdateProductImageResponse(rsp *http.Response) (*UpdateProductImageRes
 				Id *int `json:"id,omitempty"`
 
 				// ProductId The ID of the product associated
-				ProductId *float32 `json:"product_id,omitempty"`
+				ProductId *int `json:"product_id,omitempty"`
 			} `json:"data,omitempty"`
 
 			// Success If the response is successful or not
@@ -34897,7 +42344,7 @@ func ParseGetProductVariationsResponse(rsp *http.Response) (*GetProductVariation
 			// Data Array containing data for all products
 			Data *[]struct {
 				// Id The ID of the product variation
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// Name The name of the product variation
 				Name *string `json:"name,omitempty"`
@@ -34940,7 +42387,7 @@ func ParseAddProductVariationResponse(rsp *http.Response) (*AddProductVariationR
 		var dest struct {
 			Data *struct {
 				// Id The ID of the product variation
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// Name The name of the product variation
 				Name *string `json:"name,omitempty"`
@@ -35017,7 +42464,7 @@ func ParseUpdateProductVariationResponse(rsp *http.Response) (*UpdateProductVari
 		var dest struct {
 			Data *struct {
 				// Id The ID of the product variation
-				Id *float32 `json:"id,omitempty"`
+				Id *int `json:"id,omitempty"`
 
 				// Name The name of the product variation
 				Name *string `json:"name,omitempty"`
@@ -35028,6 +42475,1449 @@ func ParseUpdateProductVariationResponse(rsp *http.Response) (*UpdateProductVari
 				// ProductId The ID of the product
 				ProductId *int `json:"product_id,omitempty"`
 			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectFieldsResponse parses an HTTP response from a GetProjectFieldsWithResponse call
+func ParseGetProjectFieldsResponse(rsp *http.Response) (*GetProjectFieldsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectFieldsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *struct {
+				// NextCursor Base64url-encoded cursor for fetching the next page of results, null if no more pages
+				NextCursor *string `json:"next_cursor"`
+			} `json:"additional_data,omitempty"`
+			Data *[]struct {
+				// FieldCode The unique identifier for the field (40-character hash for custom fields)
+				FieldCode string `json:"field_code"`
+
+				// FieldName The display name/label of the field
+				FieldName string `json:"field_name"`
+
+				// FieldType The type of the field
+				FieldType GetProjectFields200DataFieldType `json:"field_type"`
+
+				// ImportantFields Important fields configuration
+				ImportantFields *struct {
+					// Enabled Whether the field is marked as important
+					Enabled *bool `json:"enabled,omitempty"`
+
+					// StageIds Array of deal stage IDs where the field is important
+					StageIds *[]int `json:"stage_ids,omitempty"`
+				} `json:"important_fields,omitempty"`
+
+				// IsCustomField Whether this is a user-created custom field
+				IsCustomField bool `json:"is_custom_field"`
+
+				// IsOptionalResponseField Whether this field is not returned by default in entity responses
+				IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+				// Options Array of available options for enum/set fields, null for other field types
+				Options *[]struct {
+					// AddTime When the option was created
+					AddTime *time.Time `json:"add_time"`
+
+					// Color Optional color code for the option
+					Color *string `json:"color"`
+
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetProjectFields_200_Data_Options_Id `json:"id,omitempty"`
+
+					// Label The option display label
+					Label *string `json:"label,omitempty"`
+
+					// UpdateTime When the option was last updated
+					UpdateTime *time.Time `json:"update_time"`
+				} `json:"options"`
+
+				// RequiredFields Required fields configuration
+				RequiredFields *struct {
+					// Enabled Whether the field is required
+					Enabled *bool `json:"enabled,omitempty"`
+				} `json:"required_fields,omitempty"`
+
+				// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+				Subfields *[]struct {
+					// FieldCode The subfield identifier
+					FieldCode *string `json:"field_code,omitempty"`
+
+					// FieldName The subfield display name
+					FieldName *string `json:"field_name,omitempty"`
+
+					// FieldType The subfield type
+					FieldType *string `json:"field_type,omitempty"`
+				} `json:"subfields"`
+
+				// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+				UiVisibility *struct {
+					// AddVisibleFlag Whether the field is shown in the add modal
+					AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+					// DetailsVisibleFlag Whether the field is shown in the details view
+					DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+				} `json:"ui_visibility,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success Whether the request was successful
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddProjectFieldResponse parses an HTTP response from a AddProjectFieldWithResponse call
+func ParseAddProjectFieldResponse(rsp *http.Response) (*AddProjectFieldResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddProjectFieldResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// FieldCode The unique identifier for the field (40-character hash for custom fields)
+				FieldCode string `json:"field_code"`
+
+				// FieldName The display name/label of the field
+				FieldName string `json:"field_name"`
+
+				// FieldType The type of the field
+				FieldType AddProjectField200DataFieldType `json:"field_type"`
+
+				// ImportantFields Important fields configuration
+				ImportantFields *struct {
+					// Enabled Whether the field is marked as important
+					Enabled *bool `json:"enabled,omitempty"`
+
+					// StageIds Array of deal stage IDs where the field is important
+					StageIds *[]int `json:"stage_ids,omitempty"`
+				} `json:"important_fields,omitempty"`
+
+				// IsCustomField Whether this is a user-created custom field
+				IsCustomField bool `json:"is_custom_field"`
+
+				// IsOptionalResponseField Whether this field is not returned by default in entity responses
+				IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+				// Options Array of available options for enum/set fields, null for other field types
+				Options *[]struct {
+					// AddTime When the option was created
+					AddTime *time.Time `json:"add_time"`
+
+					// Color Optional color code for the option
+					Color *string `json:"color"`
+
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *AddProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+					// Label The option display label
+					Label *string `json:"label,omitempty"`
+
+					// UpdateTime When the option was last updated
+					UpdateTime *time.Time `json:"update_time"`
+				} `json:"options"`
+
+				// RequiredFields Required fields configuration
+				RequiredFields *struct {
+					// Enabled Whether the field is required
+					Enabled *bool `json:"enabled,omitempty"`
+				} `json:"required_fields,omitempty"`
+
+				// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+				Subfields *[]struct {
+					// FieldCode The subfield identifier
+					FieldCode *string `json:"field_code,omitempty"`
+
+					// FieldName The subfield display name
+					FieldName *string `json:"field_name,omitempty"`
+
+					// FieldType The subfield type
+					FieldType *string `json:"field_type,omitempty"`
+				} `json:"subfields"`
+
+				// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+				UiVisibility *struct {
+					// AddVisibleFlag Whether the field is shown in the add modal
+					AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+					// DetailsVisibleFlag Whether the field is shown in the details view
+					DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+				} `json:"ui_visibility,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success Whether the request was successful
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectFieldResponse parses an HTTP response from a DeleteProjectFieldWithResponse call
+func ParseDeleteProjectFieldResponse(rsp *http.Response) (*DeleteProjectFieldResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectFieldResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// FieldCode The unique identifier for the field (40-character hash for custom fields)
+				FieldCode string `json:"field_code"`
+
+				// FieldName The display name/label of the field
+				FieldName string `json:"field_name"`
+
+				// FieldType The type of the field
+				FieldType string `json:"field_type"`
+
+				// IsCustomField Whether this is a user-created custom field
+				IsCustomField bool `json:"is_custom_field"`
+
+				// IsOptionalResponseField Whether this field is not returned by default in entity responses
+				IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+				// Options Array of available options for enum/set fields, null for other field types
+				Options *[]map[string]interface{} `json:"options"`
+
+				// Subfields Array of subfields for complex field types, null for simple field types
+				Subfields *[]map[string]interface{} `json:"subfields"`
+			} `json:"data,omitempty"`
+
+			// Success Whether the request was successful
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectFieldResponse parses an HTTP response from a GetProjectFieldWithResponse call
+func ParseGetProjectFieldResponse(rsp *http.Response) (*GetProjectFieldResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectFieldResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// FieldCode The unique identifier for the field (40-character hash for custom fields)
+				FieldCode string `json:"field_code"`
+
+				// FieldName The display name/label of the field
+				FieldName string `json:"field_name"`
+
+				// FieldType The type of the field
+				FieldType GetProjectField200DataFieldType `json:"field_type"`
+
+				// ImportantFields Important fields configuration
+				ImportantFields *struct {
+					// Enabled Whether the field is marked as important
+					Enabled *bool `json:"enabled,omitempty"`
+
+					// StageIds Array of deal stage IDs where the field is important
+					StageIds *[]int `json:"stage_ids,omitempty"`
+				} `json:"important_fields,omitempty"`
+
+				// IsCustomField Whether this is a user-created custom field
+				IsCustomField bool `json:"is_custom_field"`
+
+				// IsOptionalResponseField Whether this field is not returned by default in entity responses
+				IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+				// Options Array of available options for enum/set fields, null for other field types
+				Options *[]struct {
+					// AddTime When the option was created
+					AddTime *time.Time `json:"add_time"`
+
+					// Color Optional color code for the option
+					Color *string `json:"color"`
+
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *GetProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+					// Label The option display label
+					Label *string `json:"label,omitempty"`
+
+					// UpdateTime When the option was last updated
+					UpdateTime *time.Time `json:"update_time"`
+				} `json:"options"`
+
+				// RequiredFields Required fields configuration
+				RequiredFields *struct {
+					// Enabled Whether the field is required
+					Enabled *bool `json:"enabled,omitempty"`
+				} `json:"required_fields,omitempty"`
+
+				// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+				Subfields *[]struct {
+					// FieldCode The subfield identifier
+					FieldCode *string `json:"field_code,omitempty"`
+
+					// FieldName The subfield display name
+					FieldName *string `json:"field_name,omitempty"`
+
+					// FieldType The subfield type
+					FieldType *string `json:"field_type,omitempty"`
+				} `json:"subfields"`
+
+				// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+				UiVisibility *struct {
+					// AddVisibleFlag Whether the field is shown in the add modal
+					AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+					// DetailsVisibleFlag Whether the field is shown in the details view
+					DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+				} `json:"ui_visibility,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success Whether the request was successful
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectFieldResponse parses an HTTP response from a UpdateProjectFieldWithResponse call
+func ParseUpdateProjectFieldResponse(rsp *http.Response) (*UpdateProjectFieldResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectFieldResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// FieldCode The unique identifier for the field (40-character hash for custom fields)
+				FieldCode string `json:"field_code"`
+
+				// FieldName The display name/label of the field
+				FieldName string `json:"field_name"`
+
+				// FieldType The type of the field
+				FieldType UpdateProjectField200DataFieldType `json:"field_type"`
+
+				// ImportantFields Important fields configuration
+				ImportantFields *struct {
+					// Enabled Whether the field is marked as important
+					Enabled *bool `json:"enabled,omitempty"`
+
+					// StageIds Array of deal stage IDs where the field is important
+					StageIds *[]int `json:"stage_ids,omitempty"`
+				} `json:"important_fields,omitempty"`
+
+				// IsCustomField Whether this is a user-created custom field
+				IsCustomField bool `json:"is_custom_field"`
+
+				// IsOptionalResponseField Whether this field is not returned by default in entity responses
+				IsOptionalResponseField bool `json:"is_optional_response_field"`
+
+				// Options Array of available options for enum/set fields, null for other field types
+				Options *[]struct {
+					// AddTime When the option was created
+					AddTime *time.Time `json:"add_time"`
+
+					// Color Optional color code for the option
+					Color *string `json:"color"`
+
+					// Id The option ID (integer for custom fields, string for built-in fields)
+					Id *UpdateProjectField_200_Data_Options_Id `json:"id,omitempty"`
+
+					// Label The option display label
+					Label *string `json:"label,omitempty"`
+
+					// UpdateTime When the option was last updated
+					UpdateTime *time.Time `json:"update_time"`
+				} `json:"options"`
+
+				// RequiredFields Required fields configuration
+				RequiredFields *struct {
+					// Enabled Whether the field is required
+					Enabled *bool `json:"enabled,omitempty"`
+				} `json:"required_fields,omitempty"`
+
+				// Subfields Array of subfields for complex field types (address, monetary), null for simple field types
+				Subfields *[]struct {
+					// FieldCode The subfield identifier
+					FieldCode *string `json:"field_code,omitempty"`
+
+					// FieldName The subfield display name
+					FieldName *string `json:"field_name,omitempty"`
+
+					// FieldType The subfield type
+					FieldType *string `json:"field_type,omitempty"`
+				} `json:"subfields"`
+
+				// UiVisibility UI visibility settings (only included when requested via include_fields parameter)
+				UiVisibility *struct {
+					// AddVisibleFlag Whether the field is shown in the add modal
+					AddVisibleFlag *bool `json:"add_visible_flag,omitempty"`
+
+					// DetailsVisibleFlag Whether the field is shown in the details view
+					DetailsVisibleFlag *bool `json:"details_visible_flag,omitempty"`
+				} `json:"ui_visibility,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success Whether the request was successful
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectFieldOptionsResponse parses an HTTP response from a DeleteProjectFieldOptionsWithResponse call
+func ParseDeleteProjectFieldOptionsResponse(rsp *http.Response) (*DeleteProjectFieldOptionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectFieldOptionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *[]struct {
+				// Id The unique identifier of the option
+				Id int `json:"id"`
+
+				// Label The display label of the option
+				Label string `json:"label"`
+			} `json:"data,omitempty"`
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectFieldOptionsResponse parses an HTTP response from a UpdateProjectFieldOptionsWithResponse call
+func ParseUpdateProjectFieldOptionsResponse(rsp *http.Response) (*UpdateProjectFieldOptionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectFieldOptionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *[]struct {
+				// Id The unique identifier of the option
+				Id int `json:"id"`
+
+				// Label The display label of the option
+				Label string `json:"label"`
+			} `json:"data,omitempty"`
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddProjectFieldOptionsResponse parses an HTTP response from a AddProjectFieldOptionsWithResponse call
+func ParseAddProjectFieldOptionsResponse(rsp *http.Response) (*AddProjectFieldOptionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddProjectFieldOptionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *[]struct {
+				// Id The unique identifier of the option
+				Id int `json:"id"`
+
+				// Label The display label of the option
+				Label string `json:"label"`
+			} `json:"data,omitempty"`
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectTemplatesResponse parses an HTTP response from a GetProjectTemplatesWithResponse call
+func ParseGetProjectTemplatesResponse(rsp *http.Response) (*GetProjectTemplatesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectTemplatesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+			Data *[]struct {
+				// AddTime The creation date and time of the project template in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Description The description of the project template
+				Description *string `json:"description,omitempty"`
+
+				// Id The ID of the project template
+				Id *int `json:"id,omitempty"`
+
+				// OwnerId The ID of the owner of the project template
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// ProjectsBoardId The ID of the project board this template is associated with
+				ProjectsBoardId *int `json:"projects_board_id,omitempty"`
+
+				// Title The title of the project template
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the project template in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectTemplateResponse parses an HTTP response from a GetProjectTemplateWithResponse call
+func ParseGetProjectTemplateResponse(rsp *http.Response) (*GetProjectTemplateResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectTemplateResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *struct {
+				// AddTime The creation date and time of the project template in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// Description The description of the project template
+				Description *string `json:"description,omitempty"`
+
+				// Id The ID of the project template
+				Id *int `json:"id,omitempty"`
+
+				// OwnerId The ID of the owner of the project template
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// ProjectsBoardId The ID of the project board this template is associated with
+				ProjectsBoardId *int `json:"projects_board_id,omitempty"`
+
+				// Title The title of the project template
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the project template in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectsResponse parses an HTTP response from a GetProjectsWithResponse call
+func ParseGetProjectsResponse(rsp *http.Response) (*GetProjectsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+
+			// Data Projects array
+			Data *[]struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddProjectResponse parses an HTTP response from a AddProjectWithResponse call
+func ParseAddProjectResponse(rsp *http.Response) (*AddProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetArchivedProjectsResponse parses an HTTP response from a GetArchivedProjectsWithResponse call
+func ParseGetArchivedProjectsResponse(rsp *http.Response) (*GetArchivedProjectsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetArchivedProjectsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+
+			// Data Projects array
+			Data *[]struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseSearchProjectsResponse parses an HTTP response from a SearchProjectsWithResponse call
+func ParseSearchProjectsResponse(rsp *http.Response) (*SearchProjectsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &SearchProjectsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+			Data *struct {
+				// Items The array of found projects
+				Items *[]struct {
+					Item *struct {
+						// BoardId The ID of the board the project belongs to
+						BoardId *int `json:"board_id"`
+
+						// CustomFields Custom fields
+						CustomFields *[]string `json:"custom_fields,omitempty"`
+						Deal         *struct {
+							// Id The ID of the deal the project is associated with
+							Id *int `json:"id,omitempty"`
+
+							// Title The title of the deal the project is associated with
+							Title *string `json:"title"`
+						} `json:"deal"`
+
+						// DealCount The number of deals associated with the project
+						DealCount *int `json:"deal_count,omitempty"`
+
+						// Description The description of the project
+						Description *string `json:"description"`
+
+						// EndDate The end date of the project
+						EndDate *string `json:"end_date"`
+
+						// Id The ID of the project
+						Id *int `json:"id,omitempty"`
+
+						// Notes An array of notes
+						Notes        *[]string `json:"notes,omitempty"`
+						Organization *struct {
+							// Address The address of the organization the project is associated with
+							Address *string `json:"address"`
+
+							// Id The ID of the organization the project is associated with
+							Id *int `json:"id,omitempty"`
+
+							// Name The name of the organization the project is associated with
+							Name *string `json:"name"`
+						} `json:"organization"`
+						Owner *struct {
+							// Id The ID of the owner of the project
+							Id *int `json:"id"`
+						} `json:"owner,omitempty"`
+						Person *struct {
+							// Id The ID of the person the project is associated with
+							Id *int `json:"id,omitempty"`
+
+							// Name The name of the person the project is associated with
+							Name *string `json:"name"`
+						} `json:"person"`
+						Phase *struct {
+							// Id The ID of the phase
+							Id *int `json:"id,omitempty"`
+
+							// Name The name of the phase
+							Name *string `json:"name,omitempty"`
+						} `json:"phase"`
+
+						// Status The status of the project
+						Status *string `json:"status"`
+
+						// Title The title of the project
+						Title *string `json:"title,omitempty"`
+
+						// Type The type of the item
+						Type *string `json:"type,omitempty"`
+					} `json:"item,omitempty"`
+
+					// ResultScore Search result relevancy
+					ResultScore *float32 `json:"result_score,omitempty"`
+				} `json:"items,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectResponse parses an HTTP response from a DeleteProjectWithResponse call
+func ParseDeleteProjectResponse(rsp *http.Response) (*DeleteProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// Id The ID of the deleted project
+				Id *int `json:"id,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectResponse parses an HTTP response from a GetProjectWithResponse call
+func ParseGetProjectResponse(rsp *http.Response) (*GetProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectResponse parses an HTTP response from a UpdateProjectWithResponse call
+func ParseUpdateProjectResponse(rsp *http.Response) (*UpdateProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseArchiveProjectResponse parses an HTTP response from a ArchiveProjectWithResponse call
+func ParseArchiveProjectResponse(rsp *http.Response) (*ArchiveProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ArchiveProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Data *struct {
+				// AddTime The creation date and time of the project in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// ArchiveTime The date and time the project was archived in ISO 8601 format. If not archived, this field is null.
+				ArchiveTime *string `json:"archive_time"`
+
+				// BoardId The ID of the board this project is associated with
+				BoardId *int `json:"board_id,omitempty"`
+
+				// CustomFields An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.
+				CustomFields *map[string]interface{} `json:"custom_fields,omitempty"`
+
+				// DealIds An array of IDs of the deals this project is associated with
+				DealIds *[]int `json:"deal_ids,omitempty"`
+
+				// Description The description of the project
+				Description *string `json:"description,omitempty"`
+
+				// EndDate The end date of the project. Format: YYYY-MM-DD
+				EndDate *openapi_types.Date `json:"end_date,omitempty"`
+
+				// HealthStatus The health status of the project
+				HealthStatus *int `json:"health_status"`
+
+				// Id The ID of the project
+				Id *int `json:"id,omitempty"`
+
+				// LabelIds An array of IDs of the labels this project has
+				LabelIds *[]int `json:"label_ids,omitempty"`
+
+				// OrgIds An array of IDs of the organizations this project is associated with
+				OrgIds *[]int `json:"org_ids,omitempty"`
+
+				// OwnerId The ID of the user who owns the project
+				OwnerId *int `json:"owner_id,omitempty"`
+
+				// PersonIds An array of IDs of the persons this project is associated with
+				PersonIds *[]int `json:"person_ids,omitempty"`
+
+				// PhaseId The ID of the phase this project is associated with
+				PhaseId *int `json:"phase_id,omitempty"`
+
+				// StartDate The start date of the project. Format: YYYY-MM-DD
+				StartDate *openapi_types.Date `json:"start_date,omitempty"`
+
+				// Status The status of the project
+				Status *string `json:"status,omitempty"`
+
+				// StatusChangeTime The date and time of the last status change of the project in ISO 8601 format
+				StatusChangeTime *string `json:"status_change_time,omitempty"`
+
+				// Title The title of the project
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The last updated date and time of the project in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectChangelogResponse parses an HTTP response from a GetProjectChangelogWithResponse call
+func ParseGetProjectChangelogResponse(rsp *http.Response) (*GetProjectChangelogResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectChangelogResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+			Data *[]struct {
+				// ActorUserId The ID of the user who made the change
+				ActorUserId *int `json:"actor_user_id,omitempty"`
+
+				// ChangeSource The source of change, for example 'app', 'mobile', 'api', etc.
+				ChangeSource *string `json:"change_source"`
+
+				// ChangeSourceUserAgent The user agent from which the change was made
+				ChangeSourceUserAgent *string `json:"change_source_user_agent"`
+
+				// NewValues A map of field keys to their new values after the change
+				NewValues *map[string]interface{} `json:"new_values,omitempty"`
+
+				// OldValues A map of field keys to their previous values before the change
+				OldValues *map[string]interface{} `json:"old_values,omitempty"`
+
+				// Time The date and time of the change in ISO 8601 format
+				Time *string `json:"time,omitempty"`
+			} `json:"data,omitempty"`
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectUsersResponse parses an HTTP response from a GetProjectUsersWithResponse call
+func ParseGetProjectUsersResponse(rsp *http.Response) (*GetProjectUsersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectUsersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// Data The list of permitted user IDs
+			Data *[]int `json:"data,omitempty"`
 
 			// Success If the response is successful or not
 			Success *bool `json:"success,omitempty"`
@@ -35314,6 +44204,353 @@ func ParseUpdateStageResponse(rsp *http.Response) (*UpdateStageResponse, error) 
 				PipelineId *int `json:"pipeline_id,omitempty"`
 
 				// UpdateTime The stage update time
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetTasksResponse parses an HTTP response from a GetTasksWithResponse call
+func ParseGetTasksResponse(rsp *http.Response) (*GetTasksResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetTasksResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			// AdditionalData The additional data of the list
+			AdditionalData *struct {
+				// NextCursor The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+				NextCursor *string `json:"next_cursor,omitempty"`
+			} `json:"additional_data,omitempty"`
+			Data *[]struct {
+				// AddTime The creation date and time of the task in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// AssigneeIds The IDs of users assigned to the task
+				AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+				// CreatorId The ID of the user who created the task
+				CreatorId *int `json:"creator_id,omitempty"`
+
+				// Description The description of the task
+				Description *string `json:"description"`
+
+				// DueDate The due date of the task. Format: YYYY-MM-DD.
+				DueDate *openapi_types.Date `json:"due_date"`
+
+				// Id The ID of the task
+				Id *int `json:"id,omitempty"`
+
+				// IsDone Whether the task is done or not.
+				IsDone *bool `json:"is_done,omitempty"`
+
+				// IsMilestone Whether the task is a milestone or not.
+				IsMilestone *bool `json:"is_milestone,omitempty"`
+
+				// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+				MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+				// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+				ParentTaskId *int `json:"parent_task_id"`
+
+				// Priority The priority of the task
+				Priority *int `json:"priority"`
+
+				// ProjectId The ID of the project this task is associated with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// StartDate The start date of the task. Format: YYYY-MM-DD.
+				StartDate *openapi_types.Date `json:"start_date"`
+
+				// Title The title of the task
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the task in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAddTaskResponse parses an HTTP response from a AddTaskWithResponse call
+func ParseAddTaskResponse(rsp *http.Response) (*AddTaskResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AddTaskResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *struct {
+				// AddTime The creation date and time of the task in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// AssigneeIds The IDs of users assigned to the task
+				AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+				// CreatorId The ID of the user who created the task
+				CreatorId *int `json:"creator_id,omitempty"`
+
+				// Description The description of the task
+				Description *string `json:"description"`
+
+				// DueDate The due date of the task. Format: YYYY-MM-DD.
+				DueDate *openapi_types.Date `json:"due_date"`
+
+				// Id The ID of the task
+				Id *int `json:"id,omitempty"`
+
+				// IsDone Whether the task is done or not.
+				IsDone *bool `json:"is_done,omitempty"`
+
+				// IsMilestone Whether the task is a milestone or not.
+				IsMilestone *bool `json:"is_milestone,omitempty"`
+
+				// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+				MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+				// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+				ParentTaskId *int `json:"parent_task_id"`
+
+				// Priority The priority of the task
+				Priority *int `json:"priority"`
+
+				// ProjectId The ID of the project this task is associated with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// StartDate The start date of the task. Format: YYYY-MM-DD.
+				StartDate *openapi_types.Date `json:"start_date"`
+
+				// Title The title of the task
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the task in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteTaskResponse parses an HTTP response from a DeleteTaskWithResponse call
+func ParseDeleteTaskResponse(rsp *http.Response) (*DeleteTaskResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteTaskResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *struct {
+				// Id The ID of the deleted task
+				Id *int `json:"id,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetTaskResponse parses an HTTP response from a GetTaskWithResponse call
+func ParseGetTaskResponse(rsp *http.Response) (*GetTaskResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetTaskResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *struct {
+				// AddTime The creation date and time of the task in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// AssigneeIds The IDs of users assigned to the task
+				AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+				// CreatorId The ID of the user who created the task
+				CreatorId *int `json:"creator_id,omitempty"`
+
+				// Description The description of the task
+				Description *string `json:"description"`
+
+				// DueDate The due date of the task. Format: YYYY-MM-DD.
+				DueDate *openapi_types.Date `json:"due_date"`
+
+				// Id The ID of the task
+				Id *int `json:"id,omitempty"`
+
+				// IsDone Whether the task is done or not.
+				IsDone *bool `json:"is_done,omitempty"`
+
+				// IsMilestone Whether the task is a milestone or not.
+				IsMilestone *bool `json:"is_milestone,omitempty"`
+
+				// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+				MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+				// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+				ParentTaskId *int `json:"parent_task_id"`
+
+				// Priority The priority of the task
+				Priority *int `json:"priority"`
+
+				// ProjectId The ID of the project this task is associated with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// StartDate The start date of the task. Format: YYYY-MM-DD.
+				StartDate *openapi_types.Date `json:"start_date"`
+
+				// Title The title of the task
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the task in ISO 8601 format
+				UpdateTime *string `json:"update_time,omitempty"`
+			} `json:"data,omitempty"`
+
+			// Success If the response is successful or not
+			Success *bool `json:"success,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateTaskResponse parses an HTTP response from a UpdateTaskWithResponse call
+func ParseUpdateTaskResponse(rsp *http.Response) (*UpdateTaskResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateTaskResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			AdditionalData *map[string]interface{} `json:"additional_data"`
+			Data           *struct {
+				// AddTime The creation date and time of the task in ISO 8601 format
+				AddTime *string `json:"add_time,omitempty"`
+
+				// AssigneeIds The IDs of users assigned to the task
+				AssigneeIds *[]int `json:"assignee_ids,omitempty"`
+
+				// CreatorId The ID of the user who created the task
+				CreatorId *int `json:"creator_id,omitempty"`
+
+				// Description The description of the task
+				Description *string `json:"description"`
+
+				// DueDate The due date of the task. Format: YYYY-MM-DD.
+				DueDate *openapi_types.Date `json:"due_date"`
+
+				// Id The ID of the task
+				Id *int `json:"id,omitempty"`
+
+				// IsDone Whether the task is done or not.
+				IsDone *bool `json:"is_done,omitempty"`
+
+				// IsMilestone Whether the task is a milestone or not.
+				IsMilestone *bool `json:"is_milestone,omitempty"`
+
+				// MarkedAsDoneTime The date and time the task was marked as done in ISO 8601 format
+				MarkedAsDoneTime *string `json:"marked_as_done_time"`
+
+				// ParentTaskId The ID of the parent task. If `null`, the task is a root-level task.
+				ParentTaskId *int `json:"parent_task_id"`
+
+				// Priority The priority of the task
+				Priority *int `json:"priority"`
+
+				// ProjectId The ID of the project this task is associated with
+				ProjectId *int `json:"project_id,omitempty"`
+
+				// StartDate The start date of the task. Format: YYYY-MM-DD.
+				StartDate *openapi_types.Date `json:"start_date"`
+
+				// Title The title of the task
+				Title *string `json:"title,omitempty"`
+
+				// UpdateTime The update date and time of the task in ISO 8601 format
 				UpdateTime *string `json:"update_time,omitempty"`
 			} `json:"data,omitempty"`
 

--- a/openapi/derived/v1-legacy.gap.txt
+++ b/openapi/derived/v1-legacy.gap.txt
@@ -1,6 +1,6 @@
 Spec: openapi/derived/v1-legacy.yaml
-Total operations: 177
-Wrapped operations: 177
+Total operations: 160
+Wrapped operations: 160
 Missing operations: 0
 
 Missing by tag:

--- a/openapi/derived/v1-legacy.report.json
+++ b/openapi/derived/v1-legacy.report.json
@@ -1,6 +1,6 @@
 {
   "V1Operations": 213,
-  "V2Operations": 123,
-  "RemovedOperations": 36,
-  "LegacyOperations": 177
+  "V2Operations": 158,
+  "RemovedOperations": 53,
+  "LegacyOperations": 160
 }

--- a/openapi/derived/v1-legacy.yaml
+++ b/openapi/derived/v1-legacy.yaml
@@ -104,6 +104,12 @@ tags:
     - name: Projects
       description: |
         Projects represent ongoing, completed or canceled projects attached to an organization, person or to deals. Each project has an owner and must be placed in a phase. Each project consists of standard data fields but can also contain a number of custom fields. The custom fields can be recognized by long hashes as keys.
+    - name: ProjectBoards
+      description: |
+        Project boards are used to organize projects into different phases. Each board contains phases that define the workflow for projects.
+    - name: ProjectPhases
+      description: |
+        Project phases represent the stages within a project board. Each phase belongs to a board and defines a step in the project workflow.
     - name: ProjectTemplates
       description: |
         Project templates allow you to have reusable and dynamic structure to simplify creation of a project. Project template can contain information about activities, tasks and groups that will be used when creating a project.
@@ -4128,6 +4134,7 @@ paths:
                                       product_id: 1
                                       activity_id: 1
                                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                      project_id: 1
                                       log_id: null
                                       add_time: '2020-09-16 11:19:36'
                                       update_time: '2020-09-16 11:19:36'
@@ -4148,6 +4155,7 @@ paths:
                                       org_name: Pipedrive Inc.
                                       product_name: ''
                                       lead_name: nice lead
+                                      project_name: My project
                                       url: 'https://app.pipedrive.com/api/v1/files/304/download'
                                       name: 95781006_794143070992462_4330873630616453120_n.jpg
                                       description: ''
@@ -4494,6 +4502,7 @@ paths:
                                               product_id: 1
                                               activity_id: 1
                                               lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                              project_id: 1
                                               log_id: null
                                               add_time: '2020-09-16 11:19:36'
                                               update_time: '2020-09-16 11:19:36'
@@ -4514,6 +4523,7 @@ paths:
                                               org_name: Pipedrive Inc.
                                               product_name: ''
                                               lead_name: nice lead
+                                              project_name: My project
                                               url: 'https://app.pipedrive.com/api/v1/files/304/download'
                                               name: 95781006_794143070992462_4330873630616453120_n.jpg
                                               description: ''
@@ -4742,6 +4752,16 @@ paths:
                   description: Items shown per page
                   schema:
                     type: integer
+                - in: query
+                  name: include_body
+                  schema:
+                    title: numberBooleanDefault0
+                    type: number
+                    default: 0
+                    enum:
+                        - 0
+                        - 1
+                  description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
             responses:
                 '200':
                     description: Success
@@ -4878,6 +4898,9 @@ paths:
                                                                 body_url:
                                                                     type: string
                                                                     description: The mail message body URL
+                                                                body:
+                                                                    type: string
+                                                                    description: The mail message body content. Only present when `include_body=1` is passed.
                                                                 account_id:
                                                                     type: string
                                                                     description: The connection account ID
@@ -5986,10 +6009,13 @@ paths:
                                                                                         - projects
                                                                                         - account_settings
                                                                                         - partnership
+                                                                                    description: The granular app access level
                                                                                 admin:
                                                                                     type: boolean
+                                                                                    description: Whether the user has admin access or not
                                                                                 permission_set_id:
                                                                                     type: string
+                                                                                    description: The ID of the permission set
                                                                     active_flag:
                                                                         type: boolean
                                                                         description: Boolean that indicates whether the user is activated
@@ -6763,10 +6789,13 @@ paths:
                                                                                     - projects
                                                                                     - account_settings
                                                                                     - partnership
+                                                                                description: The granular app access level
                                                                             admin:
                                                                                 type: boolean
+                                                                                description: Whether the user has admin access or not
                                                                             permission_set_id:
                                                                                 type: string
+                                                                                description: The ID of the permission set
                                                                 active_flag:
                                                                     type: boolean
                                                                     description: Boolean that indicates whether the user is activated
@@ -7212,6 +7241,9 @@ paths:
                                                     type: string
                                                     description: The ID of the lead to associate the file with
                                                     format: uuid
+                                                project_id:
+                                                    type: integer
+                                                    description: The ID of the project to associate the file with
                                                 add_time:
                                                     type: string
                                                     description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -7263,6 +7295,9 @@ paths:
                                                 lead_name:
                                                     type: string
                                                     description: The name of the lead associated with the file
+                                                project_name:
+                                                    type: string
+                                                    description: The name of the project associated with the file
                                                 url:
                                                     type: string
                                                     description: The URL of the download file
@@ -7309,6 +7344,7 @@ paths:
                                       product_id: 1
                                       activity_id: 1
                                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                      project_id: 1
                                       log_id: null
                                       add_time: '2020-02-20 14:36:35'
                                       update_time: '2020-02-20 14:57:33'
@@ -7326,6 +7362,7 @@ paths:
                                       deal_name: ''
                                       person_name: Person
                                       lead_name: Test lead name
+                                      project_name: My project
                                       org_name: ''
                                       product_name: ''
                                       url: 'https://2a7f.pipedrive.com/v1/files/123/download'
@@ -7339,6 +7376,7 @@ paths:
                                       product_id: 1
                                       activity_id: 1
                                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                      project_id: 1
                                       log_id: null
                                       add_time: '2020-02-20 14:36:35'
                                       update_time: '2020-02-20 14:57:33'
@@ -7358,6 +7396,7 @@ paths:
                                       org_name: ''
                                       product_name: ''
                                       lead_name: Test lead name
+                                      project_name: My project
                                       url: 'https://2a7f.pipedrive.com/v1/files/123321/download'
                                       name: second test file name
                                       description: second test file description
@@ -7412,6 +7451,9 @@ paths:
                                     type: string
                                     format: uuid
                                     description: The ID of the lead to associate file(s) with
+                                project_id:
+                                    type: integer
+                                    description: The ID of the project to associate file(s) with
             responses:
                 '200':
                     description: 'Add a file from computer or Google Drive and associate it with deal, person, organization, activity or product'
@@ -7453,6 +7495,9 @@ paths:
                                                 type: string
                                                 description: The ID of the lead to associate the file with
                                                 format: uuid
+                                            project_id:
+                                                type: integer
+                                                description: The ID of the project to associate the file with
                                             add_time:
                                                 type: string
                                                 description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -7504,6 +7549,9 @@ paths:
                                             lead_name:
                                                 type: string
                                                 description: The name of the lead associated with the file
+                                            project_name:
+                                                type: string
+                                                description: The name of the project associated with the file
                                             url:
                                                 type: string
                                                 description: The URL of the download file
@@ -7524,6 +7572,7 @@ paths:
                                     product_id: 1
                                     activity_id: 1
                                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                    project_id: 1
                                     log_id: null
                                     add_time: '2020-02-20 14:36:35'
                                     update_time: '2020-02-20 14:36:31'
@@ -7543,6 +7592,7 @@ paths:
                                     org_name: ''
                                     product_name: ''
                                     lead_name: Test lead name
+                                    project_name: My project
                                     url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                                     name: IMG_8189.jpg
                                     description: ''
@@ -7641,6 +7691,9 @@ paths:
                                                 type: string
                                                 description: The ID of the lead to associate the file with
                                                 format: uuid
+                                            project_id:
+                                                type: integer
+                                                description: The ID of the project to associate the file with
                                             add_time:
                                                 type: string
                                                 description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -7692,6 +7745,9 @@ paths:
                                             lead_name:
                                                 type: string
                                                 description: The name of the lead associated with the file
+                                            project_name:
+                                                type: string
+                                                description: The name of the project associated with the file
                                             url:
                                                 type: string
                                                 description: The URL of the download file
@@ -7712,6 +7768,7 @@ paths:
                                     product_id: 1
                                     activity_id: 1
                                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                    project_id: 1
                                     log_id: null
                                     add_time: '2020-02-21 11:52:28'
                                     update_time: '2020-02-21 11:52:24'
@@ -7731,6 +7788,7 @@ paths:
                                     org_name: test org
                                     product_name: ''
                                     lead_name: Test lead name 1
+                                    project_name: My project
                                     url: 'https://app.pipedrive.com/api/v1/files/7195/download'
                                     name: Test title for remote file
                                     description: ''
@@ -7819,6 +7877,9 @@ paths:
                                                 type: string
                                                 description: The ID of the lead to associate the file with
                                                 format: uuid
+                                            project_id:
+                                                type: integer
+                                                description: The ID of the project to associate the file with
                                             add_time:
                                                 type: string
                                                 description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -7870,6 +7931,9 @@ paths:
                                             lead_name:
                                                 type: string
                                                 description: The name of the lead associated with the file
+                                            project_name:
+                                                type: string
+                                                description: The name of the project associated with the file
                                             url:
                                                 type: string
                                                 description: The URL of the download file
@@ -7890,6 +7954,7 @@ paths:
                                     product_id: 1
                                     activity_id: 1
                                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                    project_id: 1
                                     log_id: null
                                     add_time: '2020-02-21 12:02:37'
                                     update_time: '2020-02-21 12:02:37'
@@ -7909,6 +7974,7 @@ paths:
                                     org_name: ''
                                     product_name: ''
                                     lead_name: Test lead name
+                                    project_name: My project
                                     url: 'https://app.pipedrive.com/api/v1/files/7196/download'
                                     name: Test title for remote file
                                     description: ''
@@ -8019,6 +8085,9 @@ paths:
                                                 type: string
                                                 description: The ID of the lead to associate the file with
                                                 format: uuid
+                                            project_id:
+                                                type: integer
+                                                description: The ID of the project to associate the file with
                                             add_time:
                                                 type: string
                                                 description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -8070,6 +8139,9 @@ paths:
                                             lead_name:
                                                 type: string
                                                 description: The name of the lead associated with the file
+                                            project_name:
+                                                type: string
+                                                description: The name of the project associated with the file
                                             url:
                                                 type: string
                                                 description: The URL of the download file
@@ -8090,6 +8162,7 @@ paths:
                                     product_id: 1
                                     activity_id: 1
                                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                    project_id: 1
                                     log_id: null
                                     add_time: '2020-02-20 14:36:35'
                                     update_time: '2020-02-20 14:57:33'
@@ -8109,6 +8182,7 @@ paths:
                                     org_name: ''
                                     product_name: ''
                                     lead_name: Test lead name
+                                    project_name: My project
                                     url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                                     name: test file name
                                     description: test file description
@@ -8186,6 +8260,9 @@ paths:
                                                 type: string
                                                 description: The ID of the lead to associate the file with
                                                 format: uuid
+                                            project_id:
+                                                type: integer
+                                                description: The ID of the project to associate the file with
                                             add_time:
                                                 type: string
                                                 description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -8237,6 +8314,9 @@ paths:
                                             lead_name:
                                                 type: string
                                                 description: The name of the lead associated with the file
+                                            project_name:
+                                                type: string
+                                                description: The name of the project associated with the file
                                             url:
                                                 type: string
                                                 description: The URL of the download file
@@ -8257,6 +8337,7 @@ paths:
                                     product_id: 1
                                     activity_id: 1
                                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                    project_id: 1
                                     log_id: null
                                     add_time: '2020-02-20 14:36:35'
                                     update_time: '2020-02-20 14:57:33'
@@ -8276,6 +8357,7 @@ paths:
                                     org_name: ''
                                     product_name: ''
                                     lead_name: Test lead name
+                                    project_name: My project
                                     url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                                     name: test file name
                                     description: test file description
@@ -8423,12 +8505,30 @@ paths:
                                                     name:
                                                         type: string
                                                         description: The name of the filter
+                                                    filter_code:
+                                                        type: string
+                                                        nullable: true
+                                                        description: The system code of the filter
+                                                    is_editable:
+                                                        type: boolean
+                                                        description: Whether the filter can be edited by the requesting user
                                                     active_flag:
                                                         type: boolean
                                                         description: The active flag of the filter
                                                     type:
                                                         type: string
-                                                        description: The type of the item
+                                                        enum:
+                                                            - deals
+                                                            - leads
+                                                            - org
+                                                            - people
+                                                            - products
+                                                            - activity
+                                                            - projects
+                                                    temporary_flag:
+                                                        type: boolean
+                                                        nullable: true
+                                                        description: Whether the filter is temporary
                                                     user_id:
                                                         type: integer
                                                         description: The owner of the filter
@@ -8437,26 +8537,41 @@ paths:
                                                         description: The date and time when the filter was added
                                                     update_time:
                                                         type: string
+                                                        nullable: true
                                                         description: The date and time when the filter was updated
                                                     visible_to:
-                                                        type: integer
-                                                        description: The visibility group ID of who can see then filter
+                                                        allOf:
+                                                            - type: string
+                                                              enum:
+                                                                - '1'
+                                                                - '3'
+                                                                - '5'
+                                                                - '7'
+                                                        description: The visibility group ID of who can see the filter
+                                                    last_used_time:
+                                                        type: string
+                                                        nullable: true
+                                                        description: The date and time when the filter was last used
                                                     custom_view_id:
                                                         type: integer
-                                                        description: Used by Pipedrive webapp
+                                                        nullable: true
+                                                        description: The custom view ID linked to the filter
                             example:
                                 success: true
                                 data:
                                     - id: 1
                                       name: All open deals
+                                      filter_code: null
+                                      is_editable: true
                                       active_flag: true
                                       type: deals
                                       temporary_flag: null
                                       user_id: 927097
                                       add_time: '2019-10-15 11:01:53'
                                       update_time: '2019-10-15 11:01:53'
-                                      visible_to: 7
-                                      custom_view_id: 1
+                                      visible_to: '7'
+                                      last_used_time: null
+                                      custom_view_id: null
         post:
             summary: Add a new filter
             description: 'Adds a new filter, returns the ID upon success. Note that in the conditions JSON object only one first-level condition group is supported, and it must be glued with ''AND'', and only two second level condition groups are supported of which one must be glued with ''AND'' and the second with ''OR''. Other combinations do not work (yet) but the syntax supports introducing them in future. For more information, see the tutorial for <a href="https://pipedrive.readme.io/docs/adding-a-filter" target="_blank" rel="noopener noreferrer">adding a filter</a>.'
@@ -8470,6 +8585,13 @@ paths:
                     - 'deals:full'
                     - 'activities:full'
                     - 'contacts:full'
+            parameters:
+                - in: query
+                  name: include_field_code
+                  required: false
+                  schema:
+                    type: boolean
+                  description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
             requestBody:
                 content:
                     application/json:
@@ -8522,13 +8644,20 @@ paths:
                                             properties:
                                                 id:
                                                     type: integer
-                                                    description: The ID of the created filter
+                                                    description: The ID of the filter
                                                 name:
                                                     type: string
-                                                    description: The name of the created filter
+                                                    description: The name of the filter
+                                                filter_code:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The system code of the filter
+                                                is_editable:
+                                                    type: boolean
+                                                    description: Whether the filter can be edited by the requesting user
                                                 active_flag:
                                                     type: boolean
-                                                    description: The activity flag of the created filter
+                                                    description: The activity flag of the filter
                                                 type:
                                                     type: string
                                                     enum:
@@ -8541,38 +8670,104 @@ paths:
                                                         - projects
                                                 temporary_flag:
                                                     type: boolean
-                                                    description: If the created filter is temporary or not
+                                                    nullable: true
+                                                    description: Whether the filter is temporary
                                                 user_id:
                                                     type: integer
-                                                    description: The user ID of the created filter
+                                                    description: The user ID of the filter owner
                                                 add_time:
                                                     type: string
-                                                    description: The add time of the created filter
+                                                    description: The date and time when the filter was added
                                                 update_time:
                                                     type: string
-                                                    description: The update time of the created filter
+                                                    nullable: true
+                                                    description: The date and time when the filter was last updated
                                                 visible_to:
-                                                    type: integer
-                                                    description: The visibility group ID of the created filter
+                                                    allOf:
+                                                        - type: string
+                                                          enum:
+                                                            - '1'
+                                                            - '3'
+                                                            - '5'
+                                                            - '7'
+                                                    description: The visibility group ID of the filter
+                                                last_used_time:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The date and time when the filter was last used
                                                 custom_view_id:
                                                     type: integer
-                                                    description: The custom view ID of the created filter
+                                                    nullable: true
+                                                    description: The custom view ID linked to the filter
                                                 conditions:
                                                     type: object
-                                                    description: The created filter conditions object
+                                                    description: The conditions object of a filter
+                                                    properties:
+                                                        glue:
+                                                            type: string
+                                                            enum:
+                                                                - and
+                                                            description: The top-level glue is always "and"
+                                                        conditions:
+                                                            type: array
+                                                            description: The condition groups
+                                                            items:
+                                                                type: object
+                                                                description: A group of conditions joined by a logical operator
+                                                                properties:
+                                                                    glue:
+                                                                        type: string
+                                                                        enum:
+                                                                            - and
+                                                                            - or
+                                                                        description: The logical operator joining conditions within this group
+                                                                    conditions:
+                                                                        type: array
+                                                                        description: The individual conditions in this group
+                                                                        items:
+                                                                            type: object
+                                                                            description: A single filter condition
+                                                                            properties:
+                                                                                object:
+                                                                                    type: string
+                                                                                    description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                                                                field_id:
+                                                                                    type: string
+                                                                                    description: The ID of the field
+                                                                                operator:
+                                                                                    type: string
+                                                                                    description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                                                                value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The value of the condition
+                                                                                extra_value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: An extra value for conditions that require two values
+                                                                                json_value_flag:
+                                                                                    type: boolean
+                                                                                    description: Whether the value is JSON-encoded
+                                                                                field_code:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
                             example:
                                 success: true
                                 data:
                                     id: 1
                                     name: Deal title is 'my title'
+                                    filter_code: null
+                                    is_editable: true
                                     active_flag: true
                                     type: deals
                                     temporary_flag: false
                                     user_id: 1
                                     add_time: '2018-01-27 08:49:26'
                                     update_time: '2018-01-27 08:49:26'
-                                    visible_to: 1
-                                    custom_view_id: 1
+                                    visible_to: '1'
+                                    last_used_time: null
+                                    custom_view_id: null
                                     conditions:
                                         glue: and
                                         conditions:
@@ -8582,9 +8777,11 @@ paths:
                                                   field_id: '123141'
                                                   operator: '='
                                                   value: my title
+                                                  extra_value: null
+                                                  json_value_flag: false
+                                                  field_code: title
                                             - glue: or
-                                              conditions:
-                                                - null
+                                              conditions: []
     /filters/helpers:
         get:
             summary: Get all filter helpers
@@ -8890,6 +9087,12 @@ paths:
                   required: true
                   schema:
                     type: integer
+                - in: query
+                  name: include_field_code
+                  required: false
+                  schema:
+                    type: boolean
+                  description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
             responses:
                 '200':
                     description: Success
@@ -8907,7 +9110,7 @@ paths:
                                     - type: object
                                       properties:
                                         data:
-                                            description: The filter object
+                                            description: The filter object including conditions
                                             type: object
                                             properties:
                                                 id:
@@ -8916,12 +9119,30 @@ paths:
                                                 name:
                                                     type: string
                                                     description: The name of the filter
+                                                filter_code:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The system code of the filter
+                                                is_editable:
+                                                    type: boolean
+                                                    description: Whether the filter can be edited by the requesting user
                                                 active_flag:
                                                     type: boolean
                                                     description: The active flag of the filter
                                                 type:
                                                     type: string
-                                                    description: The type of the item
+                                                    enum:
+                                                        - deals
+                                                        - leads
+                                                        - org
+                                                        - people
+                                                        - products
+                                                        - activity
+                                                        - projects
+                                                temporary_flag:
+                                                    type: boolean
+                                                    nullable: true
+                                                    description: Whether the filter is temporary
                                                 user_id:
                                                     type: integer
                                                     description: The owner of the filter
@@ -8930,26 +9151,108 @@ paths:
                                                     description: The date and time when the filter was added
                                                 update_time:
                                                     type: string
+                                                    nullable: true
                                                     description: The date and time when the filter was updated
                                                 visible_to:
-                                                    type: integer
-                                                    description: The visibility group ID of who can see then filter
+                                                    allOf:
+                                                        - type: string
+                                                          enum:
+                                                            - '1'
+                                                            - '3'
+                                                            - '5'
+                                                            - '7'
+                                                    description: The visibility group ID of who can see the filter
+                                                last_used_time:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The date and time when the filter was last used
                                                 custom_view_id:
                                                     type: integer
-                                                    description: Used by Pipedrive webapp
+                                                    nullable: true
+                                                    description: The custom view ID linked to the filter
+                                                conditions:
+                                                    type: object
+                                                    description: The conditions object of a filter
+                                                    properties:
+                                                        glue:
+                                                            type: string
+                                                            enum:
+                                                                - and
+                                                            description: The top-level glue is always "and"
+                                                        conditions:
+                                                            type: array
+                                                            description: The condition groups
+                                                            items:
+                                                                type: object
+                                                                description: A group of conditions joined by a logical operator
+                                                                properties:
+                                                                    glue:
+                                                                        type: string
+                                                                        enum:
+                                                                            - and
+                                                                            - or
+                                                                        description: The logical operator joining conditions within this group
+                                                                    conditions:
+                                                                        type: array
+                                                                        description: The individual conditions in this group
+                                                                        items:
+                                                                            type: object
+                                                                            description: A single filter condition
+                                                                            properties:
+                                                                                object:
+                                                                                    type: string
+                                                                                    description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                                                                field_id:
+                                                                                    type: string
+                                                                                    description: The ID of the field
+                                                                                operator:
+                                                                                    type: string
+                                                                                    description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                                                                value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The value of the condition
+                                                                                extra_value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: An extra value for conditions that require two values
+                                                                                json_value_flag:
+                                                                                    type: boolean
+                                                                                    description: Whether the value is JSON-encoded
+                                                                                field_code:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
                             example:
                                 success: true
                                 data:
                                     id: 1
                                     name: All open deals
+                                    filter_code: null
+                                    is_editable: true
                                     active_flag: true
                                     type: deals
                                     temporary_flag: null
                                     user_id: 927097
                                     add_time: '2019-10-15 11:01:53'
                                     update_time: '2019-10-15 11:01:53'
-                                    visible_to: 7
-                                    custom_view_id: 1
+                                    visible_to: '7'
+                                    last_used_time: null
+                                    custom_view_id: null
+                                    conditions:
+                                        glue: and
+                                        conditions:
+                                            - glue: and
+                                              conditions:
+                                                - object: deal
+                                                  field_id: '123'
+                                                  operator: IS NOT NULL
+                                                  extra_value: null
+                                                  value: null
+                                                  json_value_flag: false
+                                                  field_code: status
+                                            - glue: or
+                                              conditions: []
         put:
             summary: Update filter
             description: Updates an existing filter.
@@ -8970,6 +9273,12 @@ paths:
                   required: true
                   schema:
                     type: integer
+                - in: query
+                  name: include_field_code
+                  required: false
+                  schema:
+                    type: boolean
+                  description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
             requestBody:
                 content:
                     application/json:
@@ -9007,13 +9316,20 @@ paths:
                                             properties:
                                                 id:
                                                     type: integer
-                                                    description: The ID of the created filter
+                                                    description: The ID of the filter
                                                 name:
                                                     type: string
-                                                    description: The name of the created filter
+                                                    description: The name of the filter
+                                                filter_code:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The system code of the filter
+                                                is_editable:
+                                                    type: boolean
+                                                    description: Whether the filter can be edited by the requesting user
                                                 active_flag:
                                                     type: boolean
-                                                    description: The activity flag of the created filter
+                                                    description: The activity flag of the filter
                                                 type:
                                                     type: string
                                                     enum:
@@ -9026,38 +9342,104 @@ paths:
                                                         - projects
                                                 temporary_flag:
                                                     type: boolean
-                                                    description: If the created filter is temporary or not
+                                                    nullable: true
+                                                    description: Whether the filter is temporary
                                                 user_id:
                                                     type: integer
-                                                    description: The user ID of the created filter
+                                                    description: The user ID of the filter owner
                                                 add_time:
                                                     type: string
-                                                    description: The add time of the created filter
+                                                    description: The date and time when the filter was added
                                                 update_time:
                                                     type: string
-                                                    description: The update time of the created filter
+                                                    nullable: true
+                                                    description: The date and time when the filter was last updated
                                                 visible_to:
-                                                    type: integer
-                                                    description: The visibility group ID of the created filter
+                                                    allOf:
+                                                        - type: string
+                                                          enum:
+                                                            - '1'
+                                                            - '3'
+                                                            - '5'
+                                                            - '7'
+                                                    description: The visibility group ID of the filter
+                                                last_used_time:
+                                                    type: string
+                                                    nullable: true
+                                                    description: The date and time when the filter was last used
                                                 custom_view_id:
                                                     type: integer
-                                                    description: The custom view ID of the created filter
+                                                    nullable: true
+                                                    description: The custom view ID linked to the filter
                                                 conditions:
                                                     type: object
-                                                    description: The created filter conditions object
+                                                    description: The conditions object of a filter
+                                                    properties:
+                                                        glue:
+                                                            type: string
+                                                            enum:
+                                                                - and
+                                                            description: The top-level glue is always "and"
+                                                        conditions:
+                                                            type: array
+                                                            description: The condition groups
+                                                            items:
+                                                                type: object
+                                                                description: A group of conditions joined by a logical operator
+                                                                properties:
+                                                                    glue:
+                                                                        type: string
+                                                                        enum:
+                                                                            - and
+                                                                            - or
+                                                                        description: The logical operator joining conditions within this group
+                                                                    conditions:
+                                                                        type: array
+                                                                        description: The individual conditions in this group
+                                                                        items:
+                                                                            type: object
+                                                                            description: A single filter condition
+                                                                            properties:
+                                                                                object:
+                                                                                    type: string
+                                                                                    description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                                                                field_id:
+                                                                                    type: string
+                                                                                    description: The ID of the field
+                                                                                operator:
+                                                                                    type: string
+                                                                                    description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                                                                value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The value of the condition
+                                                                                extra_value:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: An extra value for conditions that require two values
+                                                                                json_value_flag:
+                                                                                    type: boolean
+                                                                                    description: Whether the value is JSON-encoded
+                                                                                field_code:
+                                                                                    type: string
+                                                                                    nullable: true
+                                                                                    description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
                             example:
                                 success: true
                                 data:
                                     id: 1
                                     name: Deal title is 'my title'
+                                    filter_code: null
+                                    is_editable: true
                                     active_flag: true
                                     type: deals
                                     temporary_flag: false
                                     user_id: 1
                                     add_time: '2018-01-27 08:49:26'
                                     update_time: '2018-01-27 08:49:26'
-                                    visible_to: 1
-                                    custom_view_id: 1
+                                    visible_to: '1'
+                                    last_used_time: null
+                                    custom_view_id: null
                                     conditions:
                                         glue: and
                                         conditions:
@@ -9067,9 +9449,11 @@ paths:
                                                   field_id: '123141'
                                                   operator: '='
                                                   value: my title
+                                                  extra_value: null
+                                                  json_value_flag: false
+                                                  field_code: title
                                             - glue: or
-                                              conditions:
-                                                - null
+                                              conditions: []
     /goals:
         post:
             summary: Add a new goal
@@ -12911,6 +13295,9 @@ paths:
                                                 body_url:
                                                     type: string
                                                     description: The mail message body URL
+                                                body:
+                                                    type: string
+                                                    description: The mail message body content. Only present when `include_body=1` is passed.
                                                 account_id:
                                                     type: string
                                                     description: The connection account ID
@@ -14948,6 +15335,11 @@ paths:
                     type: integer
                   description: 'The ID of the project which notes to fetch. If omitted, notes about all projects will be returned.'
                 - in: query
+                  name: task_id
+                  schema:
+                    type: integer
+                  description: 'The ID of the task which notes to fetch. If omitted, notes about all tasks will be returned.'
+                - in: query
                   name: start
                   description: Pagination start
                   schema:
@@ -15027,6 +15419,15 @@ paths:
                         - 0
                         - 1
                   description: 'If set, the results are filtered by note to project pinning state'
+                - in: query
+                  name: pinned_to_task_flag
+                  schema:
+                    title: numberBoolean
+                    type: number
+                    enum:
+                        - 0
+                        - 1
+                  description: 'If set, the results are filtered by note to task pinning state'
             responses:
                 '200':
                     description: Get all notes
@@ -15105,6 +15506,16 @@ paths:
                                                         title:
                                                             type: string
                                                             description: The title of the project the note is attached to
+                                                task_id:
+                                                    type: integer
+                                                    description: The ID of the task the note is attached to
+                                                task:
+                                                    type: object
+                                                    description: The task the note is attached to
+                                                    properties:
+                                                        title:
+                                                            type: string
+                                                            description: The title of the task the note is attached to
                                                 pinned_to_deal_flag:
                                                     type: boolean
                                                     description: 'If true, the results are filtered by note to deal pinning state'
@@ -15117,6 +15528,9 @@ paths:
                                                 pinned_to_project_flag:
                                                     type: boolean
                                                     description: 'If true, the results are filtered by note to project pinning state'
+                                                pinned_to_task_flag:
+                                                    type: boolean
+                                                    description: 'If true, the results are filtered by note to task pinning state'
                                                 update_time:
                                                     type: string
                                                     description: The last updated date and time of the note
@@ -15226,19 +15640,22 @@ paths:
                                     lead_id:
                                         type: string
                                         format: uuid
-                                        description: The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id`) is specified.
+                                        description: The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id/task_id`) is specified.
                                     deal_id:
                                         type: integer
-                                        description: The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id`) is specified.
+                                        description: The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id/task_id`) is specified.
                                     person_id:
                                         type: integer
-                                        description: The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id`) is specified.
+                                        description: The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id/task_id`) is specified.
                                     org_id:
                                         type: integer
-                                        description: The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id`) is specified.
+                                        description: The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id/task_id`) is specified.
                                     project_id:
                                         type: integer
-                                        description: The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id`) is specified.
+                                        description: The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/task_id`) is specified.
+                                    task_id:
+                                        type: integer
+                                        description: The ID of the task the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/project_id`) is specified.
                                 - type: object
                                   properties:
                                     user_id:
@@ -15287,6 +15704,14 @@ paths:
                                                 - 0
                                                 - 1
                                         description: 'If set, the results are filtered by note to project pinning state (`project_id` is also required)'
+                                    pinned_to_task_flag:
+                                        allOf:
+                                            - title: numberBoolean
+                                              type: number
+                                              enum:
+                                                - 0
+                                                - 1
+                                        description: 'If set, the results are filtered by note to task pinning state (`task_id` is also required)'
             responses:
                 '200':
                     description: 'Add, update or get a note'
@@ -15362,6 +15787,16 @@ paths:
                                                     title:
                                                         type: string
                                                         description: The title of the project the note is attached to
+                                            task_id:
+                                                type: integer
+                                                description: The ID of the task the note is attached to
+                                            task:
+                                                type: object
+                                                description: The task the note is attached to
+                                                properties:
+                                                    title:
+                                                        type: string
+                                                        description: The title of the task the note is attached to
                                             pinned_to_deal_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to deal pinning state'
@@ -15374,6 +15809,9 @@ paths:
                                             pinned_to_project_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to project pinning state'
+                                            pinned_to_task_flag:
+                                                type: boolean
+                                                description: 'If true, the results are filtered by note to task pinning state'
                                             update_time:
                                                 type: string
                                                 description: The last updated date and time of the note
@@ -15563,6 +16001,16 @@ paths:
                                                     title:
                                                         type: string
                                                         description: The title of the project the note is attached to
+                                            task_id:
+                                                type: integer
+                                                description: The ID of the task the note is attached to
+                                            task:
+                                                type: object
+                                                description: The task the note is attached to
+                                                properties:
+                                                    title:
+                                                        type: string
+                                                        description: The title of the task the note is attached to
                                             pinned_to_deal_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to deal pinning state'
@@ -15575,6 +16023,9 @@ paths:
                                             pinned_to_project_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to project pinning state'
+                                            pinned_to_task_flag:
+                                                type: boolean
+                                                description: 'If true, the results are filtered by note to task pinning state'
                                             update_time:
                                                 type: string
                                                 description: The last updated date and time of the note
@@ -15679,6 +16130,9 @@ paths:
                                     project_id:
                                         type: integer
                                         description: The ID of the project the note will be attached to
+                                    task_id:
+                                        type: integer
+                                        description: The ID of the task the note will be attached to
                                 - type: object
                                   properties:
                                     user_id:
@@ -15727,6 +16181,14 @@ paths:
                                                 - 0
                                                 - 1
                                         description: 'If set, the results are filtered by note to project pinning state (`project_id` is also required)'
+                                    pinned_to_task_flag:
+                                        allOf:
+                                            - title: numberBoolean
+                                              type: number
+                                              enum:
+                                                - 0
+                                                - 1
+                                        description: 'If set, the results are filtered by note to task pinning state (`task_id` is also required)'
             responses:
                 '200':
                     description: 'Add, update or get a note'
@@ -15802,6 +16264,16 @@ paths:
                                                     title:
                                                         type: string
                                                         description: The title of the project the note is attached to
+                                            task_id:
+                                                type: integer
+                                                description: The ID of the task the note is attached to
+                                            task:
+                                                type: object
+                                                description: The task the note is attached to
+                                                properties:
+                                                    title:
+                                                        type: string
+                                                        description: The title of the task the note is attached to
                                             pinned_to_deal_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to deal pinning state'
@@ -15814,6 +16286,9 @@ paths:
                                             pinned_to_project_flag:
                                                 type: boolean
                                                 description: 'If true, the results are filtered by note to project pinning state'
+                                            pinned_to_task_flag:
+                                                type: boolean
+                                                description: 'If true, the results are filtered by note to task pinning state'
                                             update_time:
                                                 type: string
                                                 description: The last updated date and time of the note
@@ -16520,7 +16995,7 @@ paths:
                     content:
                         text/html:
                             example: |
-                                As a result of the request, the customer will see a page with the confirmation dialog, which will present the details of your app (title, company name, icon) and explain the permission scopes that you have set for the app. Customers should confirm their wish to install the app by clicking "Allow and install" or deny authorization by clicking "Cancel".
+                                As a result of the request, the customer will see a page with the confirmation dialog, which will present your app details (title, company name, icon) and explain the permission scopes that you have set for the app. Customers should confirm their wish to install the app by clicking "Allow and install" or deny authorization by clicking "Cancel".
     /oauth/token:
         post:
             summary: Getting the tokens
@@ -16939,6 +17414,7 @@ paths:
                                       product_id: 1
                                       activity_id: 1
                                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                      project_id: 1
                                       log_id: null
                                       add_time: '2020-09-16 11:19:36'
                                       update_time: '2020-09-16 11:19:36'
@@ -16959,6 +17435,7 @@ paths:
                                       org_name: Pipedrive Inc.
                                       product_name: ''
                                       lead_name: nice lead
+                                      project_name: My project
                                       url: 'https://app.pipedrive.com/api/v1/files/304/download'
                                       name: 95781006_794143070992462_4330873630616453120_n.jpg
                                       description: ''
@@ -17222,6 +17699,7 @@ paths:
                                         product_id: 1
                                         activity_id: 1
                                         lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                        project_id: 1
                                         log_id: null
                                         add_time: '2020-09-16 11:19:36'
                                         update_time: '2020-09-16 11:19:36'
@@ -17242,6 +17720,7 @@ paths:
                                         org_name: Pipedrive Inc.
                                         product_name: ''
                                         lead_name: nice lead
+                                        project_name: My project
                                         url: 'https://app.pipedrive.com/api/v1/files/304/download'
                                         name: 95781006_794143070992462_4330873630616453120_n.jpg
                                         description: ''
@@ -17300,6 +17779,16 @@ paths:
                   description: Items shown per page
                   schema:
                     type: integer
+                - in: query
+                  name: include_body
+                  schema:
+                    title: numberBooleanDefault0
+                    type: number
+                    default: 0
+                    enum:
+                        - 0
+                        - 1
+                  description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
             responses:
                 '200':
                     description: Success
@@ -17436,6 +17925,9 @@ paths:
                                                                 body_url:
                                                                     type: string
                                                                     description: The mail message body URL
+                                                                body:
+                                                                    type: string
+                                                                    description: The mail message body content. Only present when `include_body=1` is passed.
                                                                 account_id:
                                                                     type: string
                                                                     description: The connection account ID
@@ -19246,6 +19738,7 @@ paths:
                                       product_id: 1
                                       activity_id: 1
                                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                                      project_id: 1
                                       log_id: null
                                       add_time: '2020-09-16 11:19:36'
                                       update_time: '2020-09-16 11:19:36'
@@ -19266,6 +19759,7 @@ paths:
                                       org_name: Pipedrive Inc.
                                       product_name: ''
                                       lead_name: nice lead
+                                      project_name: My project
                                       url: 'https://app.pipedrive.com/api/v1/files/304/download'
                                       name: 95781006_794143070992462_4330873630616453120_n.jpg
                                       description: ''
@@ -19670,6 +20164,16 @@ paths:
                   description: Items shown per page
                   schema:
                     type: integer
+                - in: query
+                  name: include_body
+                  schema:
+                    title: numberBooleanDefault0
+                    type: number
+                    default: 0
+                    enum:
+                        - 0
+                        - 1
+                  description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
             responses:
                 '200':
                     description: Success
@@ -19806,6 +20310,9 @@ paths:
                                                                 body_url:
                                                                     type: string
                                                                     description: The mail message body URL
+                                                                body:
+                                                                    type: string
+                                                                    description: The mail message body content. Only present when `include_body=1` is passed.
                                                                 account_id:
                                                                     type: string
                                                                     description: The connection account ID
@@ -22814,855 +23321,6 @@ paths:
                                     id:
                                         - 32
                                         - 35
-    /projects:
-        get:
-            summary: Get all projects
-            description: 'Returns all projects. This is a cursor-paginated endpoint. For more information, please refer to our documentation on <a href="https://pipedrive.readme.io/docs/core-api-concepts-pagination" target="_blank" rel="noopener noreferrer">pagination</a>.'
-            x-token-cost: 20
-            operationId: getProjects
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: query
-                  name: cursor
-                  required: false
-                  description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
-                  schema:
-                    type: string
-                - in: query
-                  name: limit
-                  required: false
-                  description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned.'
-                  schema:
-                    type: integer
-                    example: 100
-                - in: query
-                  name: filter_id
-                  required: false
-                  schema:
-                    type: integer
-                  description: The ID of the filter to use
-                - in: query
-                  name: status
-                  required: false
-                  description: 'If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.'
-                  schema:
-                    type: string
-                    example: 'open,completed'
-                - in: query
-                  name: phase_id
-                  required: false
-                  schema:
-                    type: integer
-                  description: 'If supplied, only projects in specified phase are returned'
-                - in: query
-                  name: include_archived
-                  required: false
-                  schema:
-                    type: boolean
-                  description: If supplied with `true` then archived projects are also included in the response. By default only not archived projects are returned.
-            responses:
-                '200':
-                    description: A list of projects.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectsResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: array
-                                        items:
-                                            title: projectResponseObject
-                                            allOf:
-                                                - type: object
-                                                  title: ProjectId
-                                                  properties:
-                                                    id:
-                                                        type: integer
-                                                        description: 'The ID of the project, generated when the task was created'
-                                                - title: Project
-                                                  type: object
-                                                  allOf:
-                                                    - type: object
-                                                      properties:
-                                                        title:
-                                                            description: The title of the project
-                                                            type: string
-                                                    - type: object
-                                                      properties:
-                                                        board_id:
-                                                            description: The ID of the board this project is associated with
-                                                            type: number
-                                                        phase_id:
-                                                            description: The ID of the phase this project is associated with
-                                                            type: number
-                                                        description:
-                                                            description: The description of the project
-                                                            type: string
-                                                        status:
-                                                            description: The status of the project
-                                                            type: string
-                                                        owner_id:
-                                                            description: The ID of a project owner
-                                                            type: number
-                                                        start_date:
-                                                            description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                                            type: string
-                                                            format: date
-                                                        end_date:
-                                                            description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                                            type: string
-                                                            format: date
-                                                        deal_ids:
-                                                            description: An array of IDs of the deals this project is associated with
-                                                            type: array
-                                                            items:
-                                                                type: integer
-                                                        org_id:
-                                                            description: The ID of the organization this project is associated with
-                                                            type: number
-                                                        person_id:
-                                                            description: The ID of the person this project is associated with
-                                                            type: number
-                                                        labels:
-                                                            description: An array of IDs of the labels this project has
-                                                            type: array
-                                                            items:
-                                                                type: integer
-                                                    - type: object
-                                                      properties:
-                                                        add_time:
-                                                            type: string
-                                                            description: 'The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                        update_time:
-                                                            type: string
-                                                            description: 'The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                        status_change_time:
-                                                            type: string
-                                                            description: 'The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                        archive_time:
-                                                            type: string
-                                                            description: 'The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then ''null''.'
-                                    additional_data:
-                                        description: The additional data of the list
-                                        type: object
-                                        properties:
-                                            next_cursor:
-                                                type: string
-                                                description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-                            example:
-                                success: true
-                                data:
-                                    - id: 8
-                                      title: Project
-                                      description: Project Description
-                                      status: open
-                                      status_change_time: '2023-09-12 11:12:18.110'
-                                      start_date: '2023-09-18'
-                                      end_date: '2024-03-04'
-                                      owner_id: 19
-                                      add_time: '2023-09-12 11:12:18.110'
-                                      update_time: '2023-09-14 05:45:40.084'
-                                      labels:
-                                        - 13
-                                        - 14
-                                      archive_time: '2023-09-15 11:12:18.110'
-                                      deal_ids:
-                                        - 1
-                                        - 2
-                                      person_id: 2
-                                      org_id: 3
-                                      board_id: 1
-                                      phase_id: 1
-                                additional_data:
-                                    next_cursor: eyJhY3Rpdml0aWVzIjoyN30
-        post:
-            summary: Add a project
-            description: Adds a new project. Note that you can supply additional custom fields along with the request that are not described here. These custom fields are different for each Pipedrive account and can be recognized by long hashes as keys.
-            x-token-cost: 10
-            operationId: addProject
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            title: addProjectRequest
-                            allOf:
-                                - title: requiredPostProjectParameters
-                                  type: object
-                                  required:
-                                    - title
-                                  properties:
-                                    title:
-                                        description: The title of the project
-                                        type: string
-                                - type: object
-                                  properties:
-                                    board_id:
-                                        description: The ID of the board this project is associated with
-                                        type: number
-                                    phase_id:
-                                        description: The ID of the phase this project is associated with
-                                        type: number
-                                    description:
-                                        description: The description of the project
-                                        type: string
-                                    status:
-                                        description: The status of the project
-                                        type: string
-                                    owner_id:
-                                        description: The ID of a project owner
-                                        type: number
-                                    start_date:
-                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-                                    end_date:
-                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-                                    deal_ids:
-                                        description: An array of IDs of the deals this project is associated with
-                                        type: array
-                                        items:
-                                            type: integer
-                                    org_id:
-                                        description: The ID of the organization this project is associated with
-                                        type: number
-                                    person_id:
-                                        description: The ID of the person this project is associated with
-                                        type: number
-                                    labels:
-                                        description: An array of IDs of the labels this project has
-                                        type: array
-                                        items:
-                                            type: integer
-                                - type: object
-                                  properties:
-                                    template_id:
-                                        description: The ID of the template the project will be based on
-                                        type: number
-            responses:
-                '201':
-                    description: Created project.
-                    content:
-                        application/json:
-                            schema:
-                                title: AddProjectResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: projectResponseObject
-                                        allOf:
-                                            - type: object
-                                              title: ProjectId
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the project, generated when the task was created'
-                                            - title: Project
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the project
-                                                        type: string
-                                                - type: object
-                                                  properties:
-                                                    board_id:
-                                                        description: The ID of the board this project is associated with
-                                                        type: number
-                                                    phase_id:
-                                                        description: The ID of the phase this project is associated with
-                                                        type: number
-                                                    description:
-                                                        description: The description of the project
-                                                        type: string
-                                                    status:
-                                                        description: The status of the project
-                                                        type: string
-                                                    owner_id:
-                                                        description: The ID of a project owner
-                                                        type: number
-                                                    start_date:
-                                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    end_date:
-                                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    deal_ids:
-                                                        description: An array of IDs of the deals this project is associated with
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                    org_id:
-                                                        description: The ID of the organization this project is associated with
-                                                        type: number
-                                                    person_id:
-                                                        description: The ID of the person this project is associated with
-                                                        type: number
-                                                    labels:
-                                                        description: An array of IDs of the labels this project has
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                - type: object
-                                                  properties:
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    status_change_time:
-                                                        type: string
-                                                        description: 'The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    archive_time:
-                                                        type: string
-                                                        description: 'The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then ''null''.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 8
-                                    title: Project
-                                    description: Project Description
-                                    status: open
-                                    status_change_time: '2023-09-12 11:12:18.110'
-                                    start_date: '2023-09-18'
-                                    end_date: '2024-03-04'
-                                    owner_id: 19
-                                    add_time: '2023-09-12 11:12:18.110'
-                                    update_time: '2023-09-14 05:45:40.084'
-                                    labels:
-                                        - 13
-                                        - 14
-                                    archive_time: '2023-09-15 11:12:18.110'
-                                    deal_ids:
-                                        - 1
-                                        - 2
-                                    person_id: 2
-                                    org_id: 3
-                                    board_id: 1
-                                    phase_id: 1
-                                additional_data: null
-    '/projects/{id}':
-        get:
-            summary: Get details of a project
-            description: Returns the details of a specific project. Also note that custom fields appear as long hashes in the resulting data. These hashes can be mapped against the `key` value of project fields.
-            x-token-cost: 2
-            operationId: getProject
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Get a project.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: projectResponseObject
-                                        allOf:
-                                            - type: object
-                                              title: ProjectId
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the project, generated when the task was created'
-                                            - title: Project
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the project
-                                                        type: string
-                                                - type: object
-                                                  properties:
-                                                    board_id:
-                                                        description: The ID of the board this project is associated with
-                                                        type: number
-                                                    phase_id:
-                                                        description: The ID of the phase this project is associated with
-                                                        type: number
-                                                    description:
-                                                        description: The description of the project
-                                                        type: string
-                                                    status:
-                                                        description: The status of the project
-                                                        type: string
-                                                    owner_id:
-                                                        description: The ID of a project owner
-                                                        type: number
-                                                    start_date:
-                                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    end_date:
-                                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    deal_ids:
-                                                        description: An array of IDs of the deals this project is associated with
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                    org_id:
-                                                        description: The ID of the organization this project is associated with
-                                                        type: number
-                                                    person_id:
-                                                        description: The ID of the person this project is associated with
-                                                        type: number
-                                                    labels:
-                                                        description: An array of IDs of the labels this project has
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                - type: object
-                                                  properties:
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    status_change_time:
-                                                        type: string
-                                                        description: 'The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    archive_time:
-                                                        type: string
-                                                        description: 'The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then ''null''.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 8
-                                    title: Project
-                                    description: Project Description
-                                    status: open
-                                    status_change_time: '2023-09-12 11:12:18.110'
-                                    start_date: '2023-09-18'
-                                    end_date: '2024-03-04'
-                                    owner_id: 19
-                                    add_time: '2023-09-12 11:12:18.110'
-                                    update_time: '2023-09-14 05:45:40.084'
-                                    labels:
-                                        - 13
-                                        - 14
-                                    archive_time: '2023-09-15 11:12:18.110'
-                                    deal_ids:
-                                        - 1
-                                        - 2
-                                    person_id: 2
-                                    org_id: 3
-                                    board_id: 1
-                                    phase_id: 1
-                                additional_data: null
-        put:
-            summary: Update a project
-            description: Updates a project.
-            x-token-cost: 10
-            operationId: updateProject
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project
-                  required: true
-                  schema:
-                    type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            title: updateProjectRequest
-                            allOf:
-                                - type: object
-                                  properties:
-                                    title:
-                                        description: The title of the project
-                                        type: string
-                                - type: object
-                                  properties:
-                                    board_id:
-                                        description: The ID of the board this project is associated with
-                                        type: number
-                                    phase_id:
-                                        description: The ID of the phase this project is associated with
-                                        type: number
-                                    description:
-                                        description: The description of the project
-                                        type: string
-                                    status:
-                                        description: The status of the project
-                                        type: string
-                                    owner_id:
-                                        description: The ID of a project owner
-                                        type: number
-                                    start_date:
-                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-                                    end_date:
-                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-                                    deal_ids:
-                                        description: An array of IDs of the deals this project is associated with
-                                        type: array
-                                        items:
-                                            type: integer
-                                    org_id:
-                                        description: The ID of the organization this project is associated with
-                                        type: number
-                                    person_id:
-                                        description: The ID of the person this project is associated with
-                                        type: number
-                                    labels:
-                                        description: An array of IDs of the labels this project has
-                                        type: array
-                                        items:
-                                            type: integer
-            responses:
-                '200':
-                    description: Updated project.
-                    content:
-                        application/json:
-                            schema:
-                                title: UpdateProjectResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: projectResponseObject
-                                        allOf:
-                                            - type: object
-                                              title: ProjectId
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the project, generated when the task was created'
-                                            - title: Project
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the project
-                                                        type: string
-                                                - type: object
-                                                  properties:
-                                                    board_id:
-                                                        description: The ID of the board this project is associated with
-                                                        type: number
-                                                    phase_id:
-                                                        description: The ID of the phase this project is associated with
-                                                        type: number
-                                                    description:
-                                                        description: The description of the project
-                                                        type: string
-                                                    status:
-                                                        description: The status of the project
-                                                        type: string
-                                                    owner_id:
-                                                        description: The ID of a project owner
-                                                        type: number
-                                                    start_date:
-                                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    end_date:
-                                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    deal_ids:
-                                                        description: An array of IDs of the deals this project is associated with
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                    org_id:
-                                                        description: The ID of the organization this project is associated with
-                                                        type: number
-                                                    person_id:
-                                                        description: The ID of the person this project is associated with
-                                                        type: number
-                                                    labels:
-                                                        description: An array of IDs of the labels this project has
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                - type: object
-                                                  properties:
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    status_change_time:
-                                                        type: string
-                                                        description: 'The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    archive_time:
-                                                        type: string
-                                                        description: 'The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then ''null''.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 8
-                                    title: Project
-                                    description: Project Description
-                                    status: open
-                                    status_change_time: '2023-09-12 11:12:18.110'
-                                    start_date: '2023-09-18'
-                                    end_date: '2024-03-04'
-                                    owner_id: 19
-                                    add_time: '2023-09-12 11:12:18.110'
-                                    update_time: '2023-09-14 05:45:40.084'
-                                    labels:
-                                        - 13
-                                        - 14
-                                    archive_time: '2023-09-15 11:12:18.110'
-                                    deal_ids:
-                                        - 1
-                                        - 2
-                                    person_id: 2
-                                    org_id: 3
-                                    board_id: 1
-                                    phase_id: 1
-                                additional_data: null
-        delete:
-            summary: Delete a project
-            description: Marks a project as deleted.
-            x-token-cost: 6
-            operationId: deleteProject
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Delete a project.
-                    content:
-                        application/json:
-                            schema:
-                                title: DeleteProjectResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: deleteProject
-                                        type: object
-                                        properties:
-                                            success:
-                                                type: boolean
-                                                description: If the request was successful or not
-                                            data:
-                                                type: object
-                                                properties:
-                                                    id:
-                                                        type: integer
-                                                        description: The ID of the project that was deleted
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 8
-                                additional_data: null
-    '/projects/{id}/archive':
-        post:
-            summary: Archive a project
-            description: Archives a project.
-            x-token-cost: 10
-            operationId: archiveProject
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Updated project.
-                    content:
-                        application/json:
-                            schema:
-                                title: UpdateProjectResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: projectResponseObject
-                                        allOf:
-                                            - type: object
-                                              title: ProjectId
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the project, generated when the task was created'
-                                            - title: Project
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the project
-                                                        type: string
-                                                - type: object
-                                                  properties:
-                                                    board_id:
-                                                        description: The ID of the board this project is associated with
-                                                        type: number
-                                                    phase_id:
-                                                        description: The ID of the phase this project is associated with
-                                                        type: number
-                                                    description:
-                                                        description: The description of the project
-                                                        type: string
-                                                    status:
-                                                        description: The status of the project
-                                                        type: string
-                                                    owner_id:
-                                                        description: The ID of a project owner
-                                                        type: number
-                                                    start_date:
-                                                        description: 'The start date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    end_date:
-                                                        description: 'The end date of the project. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                    deal_ids:
-                                                        description: An array of IDs of the deals this project is associated with
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                    org_id:
-                                                        description: The ID of the organization this project is associated with
-                                                        type: number
-                                                    person_id:
-                                                        description: The ID of the person this project is associated with
-                                                        type: number
-                                                    labels:
-                                                        description: An array of IDs of the labels this project has
-                                                        type: array
-                                                        items:
-                                                            type: integer
-                                                - type: object
-                                                  properties:
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    status_change_time:
-                                                        type: string
-                                                        description: 'The status changed date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    archive_time:
-                                                        type: string
-                                                        description: 'The archived date and time of the project in UTC. Format: YYYY-MM-DD HH:MM:SS. If not archived then ''null''.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 8
-                                    title: Project
-                                    description: Project Description
-                                    status: open
-                                    status_change_time: '2023-09-12 11:12:18.110'
-                                    start_date: '2023-09-18'
-                                    end_date: '2024-03-04'
-                                    owner_id: 19
-                                    add_time: '2023-09-12 11:12:18.110'
-                                    update_time: '2023-09-14 05:45:40.084'
-                                    labels:
-                                        - 13
-                                        - 14
-                                    archive_time: '2023-09-15 11:12:18.110'
-                                    deal_ids:
-                                        - 1
-                                        - 2
-                                    person_id: 2
-                                    org_id: 3
-                                    board_id: 1
-                                    phase_id: 1
-                                additional_data: null
     '/projects/{id}/plan':
         get:
             summary: Returns project plan
@@ -23998,7 +23656,14 @@ paths:
                                                             type: number
                                                         assignee_id:
                                                             type: number
-                                                            description: The ID of the user who will be the assignee of the task
+                                                            description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                                                        assignee_ids:
+                                                            type: array
+                                                            items:
+                                                                type: number
+                                                            maxItems: 10
+                                                            uniqueItems: true
+                                                            description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                                                         done:
                                                             description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                                             allOf:
@@ -24043,6 +23708,10 @@ paths:
                                       due_date: '2023-10-11'
                                       parent_task_id: 2
                                       assignee_id: 2
+                                      assignee_ids:
+                                        - 2
+                                        - 3
+                                        - 4
                                       add_time: '2023-09-14 08:14:40.288'
                                       update_time: '2023-09-14 08:14:40.288'
                                       marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -24249,418 +23918,6 @@ paths:
                                       location_formatted_address: 'Mustamäe tee 3, 10616 Tallinn, Estonia'
                                 additional_data:
                                     next_cursor: eyJhY3Rpdml0aWVzIjoyN30
-    /projects/boards:
-        get:
-            summary: Get all project boards
-            description: Returns all projects boards that are not deleted.
-            x-token-cost: 20
-            operationId: getProjectsBoards
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            responses:
-                '200':
-                    description: A list of project board.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectBoardsResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: array
-                                        items:
-                                            type: object
-                                            properties:
-                                                id:
-                                                    type: integer
-                                                    description: The ID of the project board
-                                                name:
-                                                    description: Name of a project board
-                                                    type: string
-                                                order_nr:
-                                                    description: The order of a board
-                                                    type: number
-                                                add_time:
-                                                    type: string
-                                                    description: 'The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                update_time:
-                                                    type: string
-                                                    description: 'The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    - id: 1
-                                      name: Project Board
-                                      order_nr: 1
-                                      add_time: '2023-09-12 11:12:18'
-                                      update_time: '2023-09-14 05:45:40'
-                                additional_data: null
-    '/projects/boards/{id}':
-        get:
-            summary: Get details of a board
-            description: Returns the details of a specific project board.
-            x-token-cost: 2
-            operationId: getProjectsBoard
-            tags:
-                - ProjectTemplates
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project board
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Get a project board.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectBoardResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: object
-                                        properties:
-                                            id:
-                                                type: integer
-                                                description: The ID of the project board
-                                            name:
-                                                description: Name of a project board
-                                                type: string
-                                            order_nr:
-                                                description: The order of a board
-                                                type: number
-                                            add_time:
-                                                type: string
-                                                description: 'The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                            update_time:
-                                                type: string
-                                                description: 'The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                    name: Project Board
-                                    order_nr: 1
-                                    add_time: '2023-09-12 11:12:18'
-                                    update_time: '2023-09-14 05:45:40'
-                                additional_data: null
-    /projects/phases:
-        get:
-            summary: Get project phases
-            description: Returns all active project phases under a specific board.
-            x-token-cost: 20
-            operationId: getProjectsPhases
-            tags:
-                - Projects
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: query
-                  name: board_id
-                  required: true
-                  description: ID of the board for which phases are requested
-                  schema:
-                    type: integer
-                    example: 1
-            responses:
-                '200':
-                    description: A list of project phases.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectPhasesResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: array
-                                        items:
-                                            type: object
-                                            properties:
-                                                id:
-                                                    type: integer
-                                                    description: The ID of the project phase
-                                                name:
-                                                    description: Name of a project phase
-                                                    type: string
-                                                board_id:
-                                                    description: The ID of the project board this phase is linked to
-                                                    type: number
-                                                order_nr:
-                                                    description: The order of a phase
-                                                    type: number
-                                                add_time:
-                                                    type: string
-                                                    description: 'The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                update_time:
-                                                    type: string
-                                                    description: 'The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    - id: 2
-                                      name: Project Phase
-                                      board_id: 1
-                                      order_nr: 2
-                                      add_time: '2023-09-12 11:12:18'
-                                      update_time: '2023-09-14 05:45:40'
-                                additional_data: null
-    '/projects/phases/{id}':
-        get:
-            summary: Get details of a phase
-            description: Returns the details of a specific project phase.
-            x-token-cost: 2
-            operationId: getProjectsPhase
-            tags:
-                - ProjectTemplates
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project phase
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Get a project phase.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectPhaseResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: object
-                                        properties:
-                                            id:
-                                                type: integer
-                                                description: The ID of the project phase
-                                            name:
-                                                description: Name of a project phase
-                                                type: string
-                                            board_id:
-                                                description: The ID of the project board this phase is linked to
-                                                type: number
-                                            order_nr:
-                                                description: The order of a phase
-                                                type: number
-                                            add_time:
-                                                type: string
-                                                description: 'The creation date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                            update_time:
-                                                type: string
-                                                description: 'The update date and time of the board in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 2
-                                    name: Project Phase
-                                    board_id: 1
-                                    order_nr: 2
-                                    add_time: '2023-09-12 11:12:18'
-                                    update_time: '2023-09-14 05:45:40'
-                                additional_data: null
-    /projectTemplates:
-        get:
-            summary: Get all project templates
-            description: 'Returns all not deleted project templates. This is a cursor-paginated endpoint. For more information, please refer to our documentation on <a href="https://pipedrive.readme.io/docs/core-api-concepts-pagination" target="_blank" rel="noopener noreferrer">pagination</a>.'
-            x-token-cost: 20
-            operationId: getProjectTemplates
-            tags:
-                - ProjectTemplates
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: query
-                  name: cursor
-                  required: false
-                  description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
-                  schema:
-                    type: string
-                - in: query
-                  name: limit
-                  required: false
-                  description: 'For pagination, the limit of entries to be returned. If not provided, up to 500 items will be returned.'
-                  schema:
-                    type: integer
-                    example: 500
-            responses:
-                '200':
-                    description: A list of project template.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectTemplatesResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: array
-                                        items:
-                                            title: TemplateResponseObject
-                                            allOf:
-                                                - title: ProjectTemplate
-                                                  type: object
-                                                  properties:
-                                                    id:
-                                                        description: The ID of a template
-                                                        type: number
-                                                    title:
-                                                        description: The title of a template
-                                                        type: string
-                                                    description:
-                                                        description: The description of a template
-                                                        type: string
-                                                    projects_board_id:
-                                                        description: The ID of the project board this template is associated with
-                                                        type: number
-                                                    owner_id:
-                                                        description: The ID of a template owner
-                                                        type: number
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        description: The additional data of the list
-                                        type: object
-                                        properties:
-                                            next_cursor:
-                                                type: string
-                                                description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-                            example:
-                                success: true
-                                data:
-                                    - id: 1
-                                      title: Template Title
-                                      description: Template Description
-                                      projects_board_id: 2
-                                      owner_id: 3
-                                      add_time: '2023-09-14 08:14:40.288'
-                                      update_time: '2023-09-14 08:14:40.288'
-                                additional_data:
-                                    next_cursor: eyJhY3Rpdml0aWVzIjoyN30
-    '/projectTemplates/{id}':
-        get:
-            summary: Get details of a template
-            description: Returns the details of a specific project template.
-            x-token-cost: 2
-            operationId: getProjectTemplate
-            tags:
-                - ProjectTemplates
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the project template
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Get a project template.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetProjectTemplateResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: TemplateResponseObject
-                                        allOf:
-                                            - title: ProjectTemplate
-                                              type: object
-                                              properties:
-                                                id:
-                                                    description: The ID of a template
-                                                    type: number
-                                                title:
-                                                    description: The title of a template
-                                                    type: string
-                                                description:
-                                                    description: The description of a template
-                                                    type: string
-                                                projects_board_id:
-                                                    description: The ID of the project board this template is associated with
-                                                    type: number
-                                                owner_id:
-                                                    description: The ID of a template owner
-                                                    type: number
-                                                add_time:
-                                                    type: string
-                                                    description: 'The creation date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                update_time:
-                                                    type: string
-                                                    description: 'The update date and time of the template in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                    title: Template Title
-                                    description: Template Description
-                                    projects_board_id: 2
-                                    owner_id: 3
-                                    add_time: '2023-09-14 08:14:40.288'
-                                    update_time: '2023-09-14 08:14:40.288'
-                                additional_data: null
     /recents:
         get:
             summary: Get recents
@@ -25404,12 +24661,30 @@ paths:
                                                             name:
                                                                 type: string
                                                                 description: The name of the filter
+                                                            filter_code:
+                                                                type: string
+                                                                nullable: true
+                                                                description: The system code of the filter
+                                                            is_editable:
+                                                                type: boolean
+                                                                description: Whether the filter can be edited by the requesting user
                                                             active_flag:
                                                                 type: boolean
                                                                 description: The active flag of the filter
                                                             type:
                                                                 type: string
-                                                                description: The type of the item
+                                                                enum:
+                                                                    - deals
+                                                                    - leads
+                                                                    - org
+                                                                    - people
+                                                                    - products
+                                                                    - activity
+                                                                    - projects
+                                                            temporary_flag:
+                                                                type: boolean
+                                                                nullable: true
+                                                                description: Whether the filter is temporary
                                                             user_id:
                                                                 type: integer
                                                                 description: The owner of the filter
@@ -25418,13 +24693,25 @@ paths:
                                                                 description: The date and time when the filter was added
                                                             update_time:
                                                                 type: string
+                                                                nullable: true
                                                                 description: The date and time when the filter was updated
                                                             visible_to:
-                                                                type: integer
-                                                                description: The visibility group ID of who can see then filter
+                                                                allOf:
+                                                                    - type: string
+                                                                      enum:
+                                                                        - '1'
+                                                                        - '3'
+                                                                        - '5'
+                                                                        - '7'
+                                                                description: The visibility group ID of who can see the filter
+                                                            last_used_time:
+                                                                type: string
+                                                                nullable: true
+                                                                description: The date and time when the filter was last used
                                                             custom_view_id:
                                                                 type: integer
-                                                                description: Used by Pipedrive webapp
+                                                                nullable: true
+                                                                description: The custom view ID linked to the filter
                                                 - type: object
                                                   properties:
                                                     item:
@@ -25496,6 +24783,16 @@ paths:
                                                                     title:
                                                                         type: string
                                                                         description: The title of the project the note is attached to
+                                                            task_id:
+                                                                type: integer
+                                                                description: The ID of the task the note is attached to
+                                                            task:
+                                                                type: object
+                                                                description: The task the note is attached to
+                                                                properties:
+                                                                    title:
+                                                                        type: string
+                                                                        description: The title of the task the note is attached to
                                                             pinned_to_deal_flag:
                                                                 type: boolean
                                                                 description: 'If true, the results are filtered by note to deal pinning state'
@@ -25508,6 +24805,9 @@ paths:
                                                             pinned_to_project_flag:
                                                                 type: boolean
                                                                 description: 'If true, the results are filtered by note to project pinning state'
+                                                            pinned_to_task_flag:
+                                                                type: boolean
+                                                                description: 'If true, the results are filtered by note to task pinning state'
                                                             update_time:
                                                                 type: string
                                                                 description: The last updated date and time of the note
@@ -26226,10 +25526,13 @@ paths:
                                                                                 - projects
                                                                                 - account_settings
                                                                                 - partnership
+                                                                            description: The granular app access level
                                                                         admin:
                                                                             type: boolean
+                                                                            description: Whether the user has admin access or not
                                                                         permission_set_id:
                                                                             type: string
+                                                                            description: The ID of the permission set
                                                             active_flag:
                                                                 type: boolean
                                                                 description: Boolean that indicates whether the user is activated
@@ -27749,597 +27052,6 @@ paths:
                                         start: 0
                                         limit: 100
                                         more_items_in_collection: false
-    /tasks:
-        get:
-            summary: Get all tasks
-            description: 'Returns all tasks. This is a cursor-paginated endpoint. For more information, please refer to our documentation on <a href="https://pipedrive.readme.io/docs/core-api-concepts-pagination" target="_blank" rel="noopener noreferrer">pagination</a>.'
-            x-token-cost: 20
-            operationId: getTasks
-            tags:
-                - Tasks
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: query
-                  name: cursor
-                  required: false
-                  schema:
-                    type: string
-                  description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
-                - in: query
-                  name: limit
-                  description: 'For pagination, the limit of entries to be returned. If not provided, up to 500 items will be returned.'
-                  schema:
-                    type: integer
-                    example: 500
-                - in: query
-                  name: assignee_id
-                  required: false
-                  schema:
-                    type: integer
-                  description: 'If supplied, only tasks that are assigned to this user are returned'
-                - in: query
-                  name: project_id
-                  required: false
-                  schema:
-                    type: integer
-                  description: 'If supplied, only tasks that are assigned to this project are returned'
-                - in: query
-                  name: parent_task_id
-                  required: false
-                  schema:
-                    type: integer
-                  description: If `null` is supplied then only parent tasks are returned. If integer is supplied then only subtasks of a specific task are returned. By default all tasks are returned.
-                - in: query
-                  name: done
-                  required: false
-                  schema:
-                    title: numberBoolean
-                    type: number
-                    enum:
-                        - 0
-                        - 1
-                  description: 'Whether the task is done or not. `0` = Not done, `1` = Done. If not omitted then returns both done and not done tasks.'
-            responses:
-                '200':
-                    description: A list of tasks.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetTasksResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        type: array
-                                        items:
-                                            title: TaskResponseObject
-                                            type: object
-                                            allOf:
-                                                - type: object
-                                                  properties:
-                                                    id:
-                                                        type: integer
-                                                        description: 'The ID of the task, generated when the task was created'
-                                                - title: updateProjectRequest
-                                                  type: object
-                                                  allOf:
-                                                    - type: object
-                                                      properties:
-                                                        title:
-                                                            description: The title of the task
-                                                            type: string
-                                                        project_id:
-                                                            description: The ID of the project this task is associated with
-                                                            type: number
-                                                    - type: object
-                                                      properties:
-                                                        description:
-                                                            description: The description of the task
-                                                            type: string
-                                                        parent_task_id:
-                                                            description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                                            type: number
-                                                        assignee_id:
-                                                            type: number
-                                                            description: The ID of the user who will be the assignee of the task
-                                                        done:
-                                                            description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                                            allOf:
-                                                                - title: numberBoolean
-                                                                  type: number
-                                                                  enum:
-                                                                    - 0
-                                                                    - 1
-                                                        due_date:
-                                                            description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                                            type: string
-                                                            format: date
-                                                    - type: object
-                                                      properties:
-                                                        creator_id:
-                                                            type: number
-                                                            description: The creator of a task
-                                                        add_time:
-                                                            type: string
-                                                            description: 'The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                        update_time:
-                                                            type: string
-                                                            description: 'The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                        marked_as_done_time:
-                                                            type: string
-                                                            description: 'The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        description: The additional data of the list
-                                        type: object
-                                        properties:
-                                            next_cursor:
-                                                type: string
-                                                description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
-                            example:
-                                success: true
-                                data:
-                                    - id: 1
-                                      title: Task 1
-                                      creator_id: 2
-                                      description: Task description
-                                      done: 0
-                                      due_date: '2023-10-11'
-                                      parent_task_id: 2
-                                      assignee_id: 2
-                                      add_time: '2023-09-14 08:14:40.288'
-                                      update_time: '2023-09-14 08:14:40.288'
-                                      marked_as_done_time: '2023-09-22 08:14:40.288'
-                                      project_id: 1
-                                additional_data:
-                                    next_cursor: eyJhY3Rpdml0aWVzIjoyN30
-        post:
-            summary: Add a task
-            description: Adds a new task.
-            x-token-cost: 10
-            operationId: addTask
-            tags:
-                - Tasks
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            title: addTaskRequest
-                            allOf:
-                                - title: requiredPostProjectParameters
-                                  type: object
-                                  required:
-                                    - title
-                                    - project_id
-                                  properties:
-                                    title:
-                                        description: The title of the task
-                                        type: string
-                                    project_id:
-                                        description: The ID of a project
-                                        type: number
-                                - type: object
-                                  properties:
-                                    description:
-                                        description: The description of the task
-                                        type: string
-                                    parent_task_id:
-                                        description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                        type: number
-                                    assignee_id:
-                                        type: number
-                                        description: The ID of the user who will be the assignee of the task
-                                    done:
-                                        description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                        allOf:
-                                            - title: numberBoolean
-                                              type: number
-                                              enum:
-                                                - 0
-                                                - 1
-                                    due_date:
-                                        description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-            responses:
-                '201':
-                    description: Created task.
-                    content:
-                        application/json:
-                            schema:
-                                title: AddTaskResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: TaskResponseObject
-                                        type: object
-                                        allOf:
-                                            - type: object
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the task, generated when the task was created'
-                                            - title: updateProjectRequest
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the task
-                                                        type: string
-                                                    project_id:
-                                                        description: The ID of the project this task is associated with
-                                                        type: number
-                                                - type: object
-                                                  properties:
-                                                    description:
-                                                        description: The description of the task
-                                                        type: string
-                                                    parent_task_id:
-                                                        description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                                        type: number
-                                                    assignee_id:
-                                                        type: number
-                                                        description: The ID of the user who will be the assignee of the task
-                                                    done:
-                                                        description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                                        allOf:
-                                                            - title: numberBoolean
-                                                              type: number
-                                                              enum:
-                                                                - 0
-                                                                - 1
-                                                    due_date:
-                                                        description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                - type: object
-                                                  properties:
-                                                    creator_id:
-                                                        type: number
-                                                        description: The creator of a task
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    marked_as_done_time:
-                                                        type: string
-                                                        description: 'The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                    title: Task 1
-                                    creator_id: 2
-                                    description: Task description
-                                    done: 0
-                                    due_date: '2023-10-11'
-                                    parent_task_id: 2
-                                    assignee_id: 2
-                                    add_time: '2023-09-14 08:14:40.288'
-                                    update_time: '2023-09-14 08:14:40.288'
-                                    marked_as_done_time: '2023-09-22 08:14:40.288'
-                                    project_id: 1
-                                additional_data: null
-    '/tasks/{id}':
-        get:
-            summary: Get details of a task
-            description: Returns the details of a specific task.
-            x-token-cost: 2
-            operationId: getTask
-            tags:
-                - Tasks
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:read'
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the task
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Get a task.
-                    content:
-                        application/json:
-                            schema:
-                                title: GetTaskResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: TaskResponseObject
-                                        type: object
-                                        allOf:
-                                            - type: object
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the task, generated when the task was created'
-                                            - title: updateProjectRequest
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the task
-                                                        type: string
-                                                    project_id:
-                                                        description: The ID of the project this task is associated with
-                                                        type: number
-                                                - type: object
-                                                  properties:
-                                                    description:
-                                                        description: The description of the task
-                                                        type: string
-                                                    parent_task_id:
-                                                        description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                                        type: number
-                                                    assignee_id:
-                                                        type: number
-                                                        description: The ID of the user who will be the assignee of the task
-                                                    done:
-                                                        description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                                        allOf:
-                                                            - title: numberBoolean
-                                                              type: number
-                                                              enum:
-                                                                - 0
-                                                                - 1
-                                                    due_date:
-                                                        description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                - type: object
-                                                  properties:
-                                                    creator_id:
-                                                        type: number
-                                                        description: The creator of a task
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    marked_as_done_time:
-                                                        type: string
-                                                        description: 'The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                    title: Task 1
-                                    creator_id: 2
-                                    description: Task description
-                                    done: 0
-                                    due_date: '2023-10-11'
-                                    parent_task_id: 2
-                                    assignee_id: 2
-                                    add_time: '2023-09-14 08:14:40.288'
-                                    update_time: '2023-09-14 08:14:40.288'
-                                    marked_as_done_time: '2023-09-22 08:14:40.288'
-                                    project_id: 1
-                                additional_data: null
-        put:
-            summary: Update a task
-            description: Updates a task.
-            x-token-cost: 10
-            operationId: updateTask
-            tags:
-                - Tasks
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the task
-                  required: true
-                  schema:
-                    type: integer
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            title: updateProjectRequest
-                            type: object
-                            allOf:
-                                - type: object
-                                  properties:
-                                    title:
-                                        description: The title of the task
-                                        type: string
-                                    project_id:
-                                        description: The ID of the project this task is associated with
-                                        type: number
-                                - type: object
-                                  properties:
-                                    description:
-                                        description: The description of the task
-                                        type: string
-                                    parent_task_id:
-                                        description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                        type: number
-                                    assignee_id:
-                                        type: number
-                                        description: The ID of the user who will be the assignee of the task
-                                    done:
-                                        description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                        allOf:
-                                            - title: numberBoolean
-                                              type: number
-                                              enum:
-                                                - 0
-                                                - 1
-                                    due_date:
-                                        description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                        type: string
-                                        format: date
-            responses:
-                '200':
-                    description: Updated task.
-                    content:
-                        application/json:
-                            schema:
-                                title: UpdateTaskResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: TaskResponseObject
-                                        type: object
-                                        allOf:
-                                            - type: object
-                                              properties:
-                                                id:
-                                                    type: integer
-                                                    description: 'The ID of the task, generated when the task was created'
-                                            - title: updateProjectRequest
-                                              type: object
-                                              allOf:
-                                                - type: object
-                                                  properties:
-                                                    title:
-                                                        description: The title of the task
-                                                        type: string
-                                                    project_id:
-                                                        description: The ID of the project this task is associated with
-                                                        type: number
-                                                - type: object
-                                                  properties:
-                                                    description:
-                                                        description: The description of the task
-                                                        type: string
-                                                    parent_task_id:
-                                                        description: The ID of a parent task. Can not be ID of a task which is already a subtask.
-                                                        type: number
-                                                    assignee_id:
-                                                        type: number
-                                                        description: The ID of the user who will be the assignee of the task
-                                                    done:
-                                                        description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
-                                                        allOf:
-                                                            - title: numberBoolean
-                                                              type: number
-                                                              enum:
-                                                                - 0
-                                                                - 1
-                                                    due_date:
-                                                        description: 'The due date of the task. Format: YYYY-MM-DD.'
-                                                        type: string
-                                                        format: date
-                                                - type: object
-                                                  properties:
-                                                    creator_id:
-                                                        type: number
-                                                        description: The creator of a task
-                                                    add_time:
-                                                        type: string
-                                                        description: 'The creation date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    update_time:
-                                                        type: string
-                                                        description: 'The update date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                                    marked_as_done_time:
-                                                        type: string
-                                                        description: 'The marked as done date and time of the task in UTC. Format: YYYY-MM-DD HH:MM:SS.'
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                    title: Task 1
-                                    creator_id: 2
-                                    description: Task description
-                                    done: 0
-                                    due_date: '2023-10-11'
-                                    parent_task_id: 2
-                                    assignee_id: 2
-                                    add_time: '2023-09-14 08:14:40.288'
-                                    update_time: '2023-09-14 08:14:40.288'
-                                    marked_as_done_time: '2023-09-22 08:14:40.288'
-                                    project_id: 1
-                                additional_data: null
-        delete:
-            summary: Delete a task
-            description: Marks a task as deleted. If the task has subtasks then those will also be deleted.
-            x-token-cost: 6
-            operationId: deleteTask
-            tags:
-                - Tasks
-            security:
-                - api_key: []
-                - oauth2:
-                    - 'projects:full'
-            parameters:
-                - in: path
-                  name: id
-                  description: The ID of the task
-                  required: true
-                  schema:
-                    type: integer
-            responses:
-                '200':
-                    description: Deleted task.
-                    content:
-                        application/json:
-                            schema:
-                                title: DeleteTaskResponse
-                                type: object
-                                properties:
-                                    success:
-                                        type: boolean
-                                    data:
-                                        title: deleteTask
-                                        type: object
-                                        properties:
-                                            success:
-                                                type: boolean
-                                                description: If the request was successful or not
-                                            data:
-                                                type: object
-                                                properties:
-                                                    id:
-                                                        type: integer
-                                                        description: The ID of the task that was deleted
-                                    additional_data:
-                                        type: object
-                                        nullable: true
-                                        example: null
-                            example:
-                                success: true
-                                data:
-                                    id: 1
-                                additional_data: null
     /users:
         get:
             summary: Get all users
@@ -28427,10 +27139,13 @@ paths:
                                                                         - projects
                                                                         - account_settings
                                                                         - partnership
+                                                                    description: The granular app access level
                                                                 admin:
                                                                     type: boolean
+                                                                    description: Whether the user has admin access or not
                                                                 permission_set_id:
                                                                     type: string
+                                                                    description: The ID of the permission set
                                                     active_flag:
                                                         type: boolean
                                                         description: Boolean that indicates whether the user is activated
@@ -28549,10 +27264,13 @@ paths:
                                                     - projects
                                                     - account_settings
                                                     - partnership
+                                                description: The granular app access level
                                             admin:
                                                 type: boolean
+                                                description: Whether the user has admin access or not
                                             permission_set_id:
                                                 type: string
+                                                description: The ID of the permission set
                                         required:
                                             - app
                                     description: |
@@ -28637,10 +27355,13 @@ paths:
                                                                     - projects
                                                                     - account_settings
                                                                     - partnership
+                                                                description: The granular app access level
                                                             admin:
                                                                 type: boolean
+                                                                description: Whether the user has admin access or not
                                                             permission_set_id:
                                                                 type: string
+                                                                description: The ID of the permission set
                                                 active_flag:
                                                     type: boolean
                                                     description: Boolean that indicates whether the user is activated
@@ -28816,10 +27537,13 @@ paths:
                                                                         - projects
                                                                         - account_settings
                                                                         - partnership
+                                                                    description: The granular app access level
                                                                 admin:
                                                                     type: boolean
+                                                                    description: Whether the user has admin access or not
                                                                 permission_set_id:
                                                                     type: string
+                                                                    description: The ID of the permission set
                                                     active_flag:
                                                         type: boolean
                                                         description: Boolean that indicates whether the user is activated
@@ -28986,10 +27710,13 @@ paths:
                                                                         - projects
                                                                         - account_settings
                                                                         - partnership
+                                                                    description: The granular app access level
                                                                 admin:
                                                                     type: boolean
+                                                                    description: Whether the user has admin access or not
                                                                 permission_set_id:
                                                                     type: string
+                                                                    description: The ID of the permission set
                                                     active_flag:
                                                         type: boolean
                                                         description: Boolean that indicates whether the user is activated
@@ -29193,10 +27920,13 @@ paths:
                                                                     - projects
                                                                     - account_settings
                                                                     - partnership
+                                                                description: The granular app access level
                                                             admin:
                                                                 type: boolean
+                                                                description: Whether the user has admin access or not
                                                             permission_set_id:
                                                                 type: string
+                                                                description: The ID of the permission set
                                                 active_flag:
                                                     type: boolean
                                                     description: Boolean that indicates whether the user is activated
@@ -29369,10 +28099,13 @@ paths:
                                                                     - projects
                                                                     - account_settings
                                                                     - partnership
+                                                                description: The granular app access level
                                                             admin:
                                                                 type: boolean
+                                                                description: Whether the user has admin access or not
                                                             permission_set_id:
                                                                 type: string
+                                                                description: The ID of the permission set
                                                 active_flag:
                                                     type: boolean
                                                     description: Boolean that indicates whether the user is activated

--- a/openapi/upstream/v1.yaml
+++ b/openapi/upstream/v1.yaml
@@ -104,6 +104,12 @@ tags:
   - name: Projects
     description: |
       Projects represent ongoing, completed or canceled projects attached to an organization, person or to deals. Each project has an owner and must be placed in a phase. Each project consists of standard data fields but can also contain a number of custom fields. The custom fields can be recognized by long hashes as keys.
+  - name: ProjectBoards
+    description: |
+      Project boards are used to organize projects into different phases. Each board contains phases that define the workflow for projects.
+  - name: ProjectPhases
+    description: |
+      Project phases represent the stages within a project board. Each phase belongs to a board and defines a step in the project workflow.
   - name: ProjectTemplates
     description: |
       Project templates allow you to have reusable and dynamic structure to simplify creation of a project. Project template can contain information about activities, tasks and groups that will be used when creating a project.
@@ -5174,6 +5180,7 @@ paths:
                     product_id: 1
                     activity_id: 1
                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                    project_id: 1
                     log_id: null
                     add_time: '2020-09-16 11:19:36'
                     update_time: '2020-09-16 11:19:36'
@@ -5194,6 +5201,7 @@ paths:
                     org_name: Pipedrive Inc.
                     product_name: ''
                     lead_name: nice lead
+                    project_name: My project
                     url: 'https://app.pipedrive.com/api/v1/files/304/download'
                     name: 95781006_794143070992462_4330873630616453120_n.jpg
                     description: ''
@@ -5540,6 +5548,7 @@ paths:
                           product_id: 1
                           activity_id: 1
                           lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                          project_id: 1
                           log_id: null
                           add_time: '2020-09-16 11:19:36'
                           update_time: '2020-09-16 11:19:36'
@@ -5560,6 +5569,7 @@ paths:
                           org_name: Pipedrive Inc.
                           product_name: ''
                           lead_name: nice lead
+                          project_name: My project
                           url: 'https://app.pipedrive.com/api/v1/files/304/download'
                           name: 95781006_794143070992462_4330873630616453120_n.jpg
                           description: ''
@@ -5978,6 +5988,16 @@ paths:
           description: Items shown per page
           schema:
             type: integer
+        - in: query
+          name: include_body
+          schema:
+            title: numberBooleanDefault0
+            type: number
+            default: 0
+            enum:
+              - 0
+              - 1
+          description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
       responses:
         '200':
           description: Success
@@ -6114,6 +6134,9 @@ paths:
                                     body_url:
                                       type: string
                                       description: The mail message body URL
+                                    body:
+                                      type: string
+                                      description: The mail message body content. Only present when `include_body=1` is passed.
                                     account_id:
                                       type: string
                                       description: The connection account ID
@@ -7222,10 +7245,13 @@ paths:
                                               - projects
                                               - account_settings
                                               - partnership
+                                            description: The granular app access level
                                           admin:
                                             type: boolean
+                                            description: Whether the user has admin access or not
                                           permission_set_id:
                                             type: string
+                                            description: The ID of the permission set
                                     active_flag:
                                       type: boolean
                                       description: Boolean that indicates whether the user is activated
@@ -7999,10 +8025,13 @@ paths:
                                             - projects
                                             - account_settings
                                             - partnership
+                                          description: The granular app access level
                                         admin:
                                           type: boolean
+                                          description: Whether the user has admin access or not
                                         permission_set_id:
                                           type: string
+                                          description: The ID of the permission set
                                   active_flag:
                                     type: boolean
                                     description: Boolean that indicates whether the user is activated
@@ -9468,6 +9497,9 @@ paths:
                           type: string
                           description: The ID of the lead to associate the file with
                           format: uuid
+                        project_id:
+                          type: integer
+                          description: The ID of the project to associate the file with
                         add_time:
                           type: string
                           description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -9519,6 +9551,9 @@ paths:
                         lead_name:
                           type: string
                           description: The name of the lead associated with the file
+                        project_name:
+                          type: string
+                          description: The name of the project associated with the file
                         url:
                           type: string
                           description: The URL of the download file
@@ -9565,6 +9600,7 @@ paths:
                     product_id: 1
                     activity_id: 1
                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                    project_id: 1
                     log_id: null
                     add_time: '2020-02-20 14:36:35'
                     update_time: '2020-02-20 14:57:33'
@@ -9582,6 +9618,7 @@ paths:
                     deal_name: ''
                     person_name: Person
                     lead_name: Test lead name
+                    project_name: My project
                     org_name: ''
                     product_name: ''
                     url: 'https://2a7f.pipedrive.com/v1/files/123/download'
@@ -9595,6 +9632,7 @@ paths:
                     product_id: 1
                     activity_id: 1
                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                    project_id: 1
                     log_id: null
                     add_time: '2020-02-20 14:36:35'
                     update_time: '2020-02-20 14:57:33'
@@ -9614,6 +9652,7 @@ paths:
                     org_name: ''
                     product_name: ''
                     lead_name: Test lead name
+                    project_name: My project
                     url: 'https://2a7f.pipedrive.com/v1/files/123321/download'
                     name: second test file name
                     description: second test file description
@@ -9668,6 +9707,9 @@ paths:
                   type: string
                   format: uuid
                   description: The ID of the lead to associate file(s) with
+                project_id:
+                  type: integer
+                  description: The ID of the project to associate file(s) with
       responses:
         '200':
           description: 'Add a file from computer or Google Drive and associate it with deal, person, organization, activity or product'
@@ -9709,6 +9751,9 @@ paths:
                         type: string
                         description: The ID of the lead to associate the file with
                         format: uuid
+                      project_id:
+                        type: integer
+                        description: The ID of the project to associate the file with
                       add_time:
                         type: string
                         description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -9760,6 +9805,9 @@ paths:
                       lead_name:
                         type: string
                         description: The name of the lead associated with the file
+                      project_name:
+                        type: string
+                        description: The name of the project associated with the file
                       url:
                         type: string
                         description: The URL of the download file
@@ -9780,6 +9828,7 @@ paths:
                   product_id: 1
                   activity_id: 1
                   lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                  project_id: 1
                   log_id: null
                   add_time: '2020-02-20 14:36:35'
                   update_time: '2020-02-20 14:36:31'
@@ -9799,6 +9848,7 @@ paths:
                   org_name: ''
                   product_name: ''
                   lead_name: Test lead name
+                  project_name: My project
                   url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                   name: IMG_8189.jpg
                   description: ''
@@ -9897,6 +9947,9 @@ paths:
                         type: string
                         description: The ID of the lead to associate the file with
                         format: uuid
+                      project_id:
+                        type: integer
+                        description: The ID of the project to associate the file with
                       add_time:
                         type: string
                         description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -9948,6 +10001,9 @@ paths:
                       lead_name:
                         type: string
                         description: The name of the lead associated with the file
+                      project_name:
+                        type: string
+                        description: The name of the project associated with the file
                       url:
                         type: string
                         description: The URL of the download file
@@ -9968,6 +10024,7 @@ paths:
                   product_id: 1
                   activity_id: 1
                   lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                  project_id: 1
                   log_id: null
                   add_time: '2020-02-21 11:52:28'
                   update_time: '2020-02-21 11:52:24'
@@ -9987,6 +10044,7 @@ paths:
                   org_name: test org
                   product_name: ''
                   lead_name: Test lead name 1
+                  project_name: My project
                   url: 'https://app.pipedrive.com/api/v1/files/7195/download'
                   name: Test title for remote file
                   description: ''
@@ -10075,6 +10133,9 @@ paths:
                         type: string
                         description: The ID of the lead to associate the file with
                         format: uuid
+                      project_id:
+                        type: integer
+                        description: The ID of the project to associate the file with
                       add_time:
                         type: string
                         description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -10126,6 +10187,9 @@ paths:
                       lead_name:
                         type: string
                         description: The name of the lead associated with the file
+                      project_name:
+                        type: string
+                        description: The name of the project associated with the file
                       url:
                         type: string
                         description: The URL of the download file
@@ -10146,6 +10210,7 @@ paths:
                   product_id: 1
                   activity_id: 1
                   lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                  project_id: 1
                   log_id: null
                   add_time: '2020-02-21 12:02:37'
                   update_time: '2020-02-21 12:02:37'
@@ -10165,6 +10230,7 @@ paths:
                   org_name: ''
                   product_name: ''
                   lead_name: Test lead name
+                  project_name: My project
                   url: 'https://app.pipedrive.com/api/v1/files/7196/download'
                   name: Test title for remote file
                   description: ''
@@ -10275,6 +10341,9 @@ paths:
                         type: string
                         description: The ID of the lead to associate the file with
                         format: uuid
+                      project_id:
+                        type: integer
+                        description: The ID of the project to associate the file with
                       add_time:
                         type: string
                         description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -10326,6 +10395,9 @@ paths:
                       lead_name:
                         type: string
                         description: The name of the lead associated with the file
+                      project_name:
+                        type: string
+                        description: The name of the project associated with the file
                       url:
                         type: string
                         description: The URL of the download file
@@ -10346,6 +10418,7 @@ paths:
                   product_id: 1
                   activity_id: 1
                   lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                  project_id: 1
                   log_id: null
                   add_time: '2020-02-20 14:36:35'
                   update_time: '2020-02-20 14:57:33'
@@ -10365,6 +10438,7 @@ paths:
                   org_name: ''
                   product_name: ''
                   lead_name: Test lead name
+                  project_name: My project
                   url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                   name: test file name
                   description: test file description
@@ -10442,6 +10516,9 @@ paths:
                         type: string
                         description: The ID of the lead to associate the file with
                         format: uuid
+                      project_id:
+                        type: integer
+                        description: The ID of the project to associate the file with
                       add_time:
                         type: string
                         description: 'The date and time when the file was added/created. Format: YYYY-MM-DD HH:MM:SS'
@@ -10493,6 +10570,9 @@ paths:
                       lead_name:
                         type: string
                         description: The name of the lead associated with the file
+                      project_name:
+                        type: string
+                        description: The name of the project associated with the file
                       url:
                         type: string
                         description: The URL of the download file
@@ -10513,6 +10593,7 @@ paths:
                   product_id: 1
                   activity_id: 1
                   lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                  project_id: 1
                   log_id: null
                   add_time: '2020-02-20 14:36:35'
                   update_time: '2020-02-20 14:57:33'
@@ -10532,6 +10613,7 @@ paths:
                   org_name: ''
                   product_name: ''
                   lead_name: Test lead name
+                  project_name: My project
                   url: 'https://2a7f.pipedrive.com/v1/files/123/download'
                   name: test file name
                   description: test file description
@@ -10679,12 +10761,30 @@ paths:
                             name:
                               type: string
                               description: The name of the filter
+                            filter_code:
+                              type: string
+                              nullable: true
+                              description: The system code of the filter
+                            is_editable:
+                              type: boolean
+                              description: Whether the filter can be edited by the requesting user
                             active_flag:
                               type: boolean
                               description: The active flag of the filter
                             type:
                               type: string
-                              description: The type of the item
+                              enum:
+                                - deals
+                                - leads
+                                - org
+                                - people
+                                - products
+                                - activity
+                                - projects
+                            temporary_flag:
+                              type: boolean
+                              nullable: true
+                              description: Whether the filter is temporary
                             user_id:
                               type: integer
                               description: The owner of the filter
@@ -10693,26 +10793,41 @@ paths:
                               description: The date and time when the filter was added
                             update_time:
                               type: string
+                              nullable: true
                               description: The date and time when the filter was updated
                             visible_to:
-                              type: integer
-                              description: The visibility group ID of who can see then filter
+                              allOf:
+                                - type: string
+                                  enum:
+                                    - '1'
+                                    - '3'
+                                    - '5'
+                                    - '7'
+                              description: The visibility group ID of who can see the filter
+                            last_used_time:
+                              type: string
+                              nullable: true
+                              description: The date and time when the filter was last used
                             custom_view_id:
                               type: integer
-                              description: Used by Pipedrive webapp
+                              nullable: true
+                              description: The custom view ID linked to the filter
               example:
                 success: true
                 data:
                   - id: 1
                     name: All open deals
+                    filter_code: null
+                    is_editable: true
                     active_flag: true
                     type: deals
                     temporary_flag: null
                     user_id: 927097
                     add_time: '2019-10-15 11:01:53'
                     update_time: '2019-10-15 11:01:53'
-                    visible_to: 7
-                    custom_view_id: 1
+                    visible_to: '7'
+                    last_used_time: null
+                    custom_view_id: null
     post:
       summary: Add a new filter
       description: 'Adds a new filter, returns the ID upon success. Note that in the conditions JSON object only one first-level condition group is supported, and it must be glued with ''AND'', and only two second level condition groups are supported of which one must be glued with ''AND'' and the second with ''OR''. Other combinations do not work (yet) but the syntax supports introducing them in future. For more information, see the tutorial for <a href="https://pipedrive.readme.io/docs/adding-a-filter" target="_blank" rel="noopener noreferrer">adding a filter</a>.'
@@ -10726,6 +10841,13 @@ paths:
             - 'deals:full'
             - 'activities:full'
             - 'contacts:full'
+      parameters:
+        - in: query
+          name: include_field_code
+          required: false
+          schema:
+            type: boolean
+          description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
       requestBody:
         content:
           application/json:
@@ -10778,13 +10900,20 @@ paths:
                         properties:
                           id:
                             type: integer
-                            description: The ID of the created filter
+                            description: The ID of the filter
                           name:
                             type: string
-                            description: The name of the created filter
+                            description: The name of the filter
+                          filter_code:
+                            type: string
+                            nullable: true
+                            description: The system code of the filter
+                          is_editable:
+                            type: boolean
+                            description: Whether the filter can be edited by the requesting user
                           active_flag:
                             type: boolean
-                            description: The activity flag of the created filter
+                            description: The activity flag of the filter
                           type:
                             type: string
                             enum:
@@ -10797,38 +10926,104 @@ paths:
                               - projects
                           temporary_flag:
                             type: boolean
-                            description: If the created filter is temporary or not
+                            nullable: true
+                            description: Whether the filter is temporary
                           user_id:
                             type: integer
-                            description: The user ID of the created filter
+                            description: The user ID of the filter owner
                           add_time:
                             type: string
-                            description: The add time of the created filter
+                            description: The date and time when the filter was added
                           update_time:
                             type: string
-                            description: The update time of the created filter
+                            nullable: true
+                            description: The date and time when the filter was last updated
                           visible_to:
-                            type: integer
-                            description: The visibility group ID of the created filter
+                            allOf:
+                              - type: string
+                                enum:
+                                  - '1'
+                                  - '3'
+                                  - '5'
+                                  - '7'
+                            description: The visibility group ID of the filter
+                          last_used_time:
+                            type: string
+                            nullable: true
+                            description: The date and time when the filter was last used
                           custom_view_id:
                             type: integer
-                            description: The custom view ID of the created filter
+                            nullable: true
+                            description: The custom view ID linked to the filter
                           conditions:
                             type: object
-                            description: The created filter conditions object
+                            description: The conditions object of a filter
+                            properties:
+                              glue:
+                                type: string
+                                enum:
+                                  - and
+                                description: The top-level glue is always "and"
+                              conditions:
+                                type: array
+                                description: The condition groups
+                                items:
+                                  type: object
+                                  description: A group of conditions joined by a logical operator
+                                  properties:
+                                    glue:
+                                      type: string
+                                      enum:
+                                        - and
+                                        - or
+                                      description: The logical operator joining conditions within this group
+                                    conditions:
+                                      type: array
+                                      description: The individual conditions in this group
+                                      items:
+                                        type: object
+                                        description: A single filter condition
+                                        properties:
+                                          object:
+                                            type: string
+                                            description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                          field_id:
+                                            type: string
+                                            description: The ID of the field
+                                          operator:
+                                            type: string
+                                            description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                          value:
+                                            type: string
+                                            nullable: true
+                                            description: The value of the condition
+                                          extra_value:
+                                            type: string
+                                            nullable: true
+                                            description: An extra value for conditions that require two values
+                                          json_value_flag:
+                                            type: boolean
+                                            description: Whether the value is JSON-encoded
+                                          field_code:
+                                            type: string
+                                            nullable: true
+                                            description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
               example:
                 success: true
                 data:
                   id: 1
                   name: Deal title is 'my title'
+                  filter_code: null
+                  is_editable: true
                   active_flag: true
                   type: deals
                   temporary_flag: false
                   user_id: 1
                   add_time: '2018-01-27 08:49:26'
                   update_time: '2018-01-27 08:49:26'
-                  visible_to: 1
-                  custom_view_id: 1
+                  visible_to: '1'
+                  last_used_time: null
+                  custom_view_id: null
                   conditions:
                     glue: and
                     conditions:
@@ -10838,9 +11033,11 @@ paths:
                             field_id: '123141'
                             operator: '='
                             value: my title
+                            extra_value: null
+                            json_value_flag: false
+                            field_code: title
                       - glue: or
-                        conditions:
-                          - null
+                        conditions: []
   /filters/helpers:
     get:
       summary: Get all filter helpers
@@ -11146,6 +11343,12 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: include_field_code
+          required: false
+          schema:
+            type: boolean
+          description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
       responses:
         '200':
           description: Success
@@ -11163,7 +11366,7 @@ paths:
                   - type: object
                     properties:
                       data:
-                        description: The filter object
+                        description: The filter object including conditions
                         type: object
                         properties:
                           id:
@@ -11172,12 +11375,30 @@ paths:
                           name:
                             type: string
                             description: The name of the filter
+                          filter_code:
+                            type: string
+                            nullable: true
+                            description: The system code of the filter
+                          is_editable:
+                            type: boolean
+                            description: Whether the filter can be edited by the requesting user
                           active_flag:
                             type: boolean
                             description: The active flag of the filter
                           type:
                             type: string
-                            description: The type of the item
+                            enum:
+                              - deals
+                              - leads
+                              - org
+                              - people
+                              - products
+                              - activity
+                              - projects
+                          temporary_flag:
+                            type: boolean
+                            nullable: true
+                            description: Whether the filter is temporary
                           user_id:
                             type: integer
                             description: The owner of the filter
@@ -11186,26 +11407,108 @@ paths:
                             description: The date and time when the filter was added
                           update_time:
                             type: string
+                            nullable: true
                             description: The date and time when the filter was updated
                           visible_to:
-                            type: integer
-                            description: The visibility group ID of who can see then filter
+                            allOf:
+                              - type: string
+                                enum:
+                                  - '1'
+                                  - '3'
+                                  - '5'
+                                  - '7'
+                            description: The visibility group ID of who can see the filter
+                          last_used_time:
+                            type: string
+                            nullable: true
+                            description: The date and time when the filter was last used
                           custom_view_id:
                             type: integer
-                            description: Used by Pipedrive webapp
+                            nullable: true
+                            description: The custom view ID linked to the filter
+                          conditions:
+                            type: object
+                            description: The conditions object of a filter
+                            properties:
+                              glue:
+                                type: string
+                                enum:
+                                  - and
+                                description: The top-level glue is always "and"
+                              conditions:
+                                type: array
+                                description: The condition groups
+                                items:
+                                  type: object
+                                  description: A group of conditions joined by a logical operator
+                                  properties:
+                                    glue:
+                                      type: string
+                                      enum:
+                                        - and
+                                        - or
+                                      description: The logical operator joining conditions within this group
+                                    conditions:
+                                      type: array
+                                      description: The individual conditions in this group
+                                      items:
+                                        type: object
+                                        description: A single filter condition
+                                        properties:
+                                          object:
+                                            type: string
+                                            description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                          field_id:
+                                            type: string
+                                            description: The ID of the field
+                                          operator:
+                                            type: string
+                                            description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                          value:
+                                            type: string
+                                            nullable: true
+                                            description: The value of the condition
+                                          extra_value:
+                                            type: string
+                                            nullable: true
+                                            description: An extra value for conditions that require two values
+                                          json_value_flag:
+                                            type: boolean
+                                            description: Whether the value is JSON-encoded
+                                          field_code:
+                                            type: string
+                                            nullable: true
+                                            description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
               example:
                 success: true
                 data:
                   id: 1
                   name: All open deals
+                  filter_code: null
+                  is_editable: true
                   active_flag: true
                   type: deals
                   temporary_flag: null
                   user_id: 927097
                   add_time: '2019-10-15 11:01:53'
                   update_time: '2019-10-15 11:01:53'
-                  visible_to: 7
-                  custom_view_id: 1
+                  visible_to: '7'
+                  last_used_time: null
+                  custom_view_id: null
+                  conditions:
+                    glue: and
+                    conditions:
+                      - glue: and
+                        conditions:
+                          - object: deal
+                            field_id: '123'
+                            operator: IS NOT NULL
+                            extra_value: null
+                            value: null
+                            json_value_flag: false
+                            field_code: status
+                      - glue: or
+                        conditions: []
     put:
       summary: Update filter
       description: Updates an existing filter.
@@ -11226,6 +11529,12 @@ paths:
           required: true
           schema:
             type: integer
+        - in: query
+          name: include_field_code
+          required: false
+          schema:
+            type: boolean
+          description: 'If set to `true`, each condition in the response includes a `field_code` field identifying the field by its code name'
       requestBody:
         content:
           application/json:
@@ -11263,13 +11572,20 @@ paths:
                         properties:
                           id:
                             type: integer
-                            description: The ID of the created filter
+                            description: The ID of the filter
                           name:
                             type: string
-                            description: The name of the created filter
+                            description: The name of the filter
+                          filter_code:
+                            type: string
+                            nullable: true
+                            description: The system code of the filter
+                          is_editable:
+                            type: boolean
+                            description: Whether the filter can be edited by the requesting user
                           active_flag:
                             type: boolean
-                            description: The activity flag of the created filter
+                            description: The activity flag of the filter
                           type:
                             type: string
                             enum:
@@ -11282,38 +11598,104 @@ paths:
                               - projects
                           temporary_flag:
                             type: boolean
-                            description: If the created filter is temporary or not
+                            nullable: true
+                            description: Whether the filter is temporary
                           user_id:
                             type: integer
-                            description: The user ID of the created filter
+                            description: The user ID of the filter owner
                           add_time:
                             type: string
-                            description: The add time of the created filter
+                            description: The date and time when the filter was added
                           update_time:
                             type: string
-                            description: The update time of the created filter
+                            nullable: true
+                            description: The date and time when the filter was last updated
                           visible_to:
-                            type: integer
-                            description: The visibility group ID of the created filter
+                            allOf:
+                              - type: string
+                                enum:
+                                  - '1'
+                                  - '3'
+                                  - '5'
+                                  - '7'
+                            description: The visibility group ID of the filter
+                          last_used_time:
+                            type: string
+                            nullable: true
+                            description: The date and time when the filter was last used
                           custom_view_id:
                             type: integer
-                            description: The custom view ID of the created filter
+                            nullable: true
+                            description: The custom view ID linked to the filter
                           conditions:
                             type: object
-                            description: The created filter conditions object
+                            description: The conditions object of a filter
+                            properties:
+                              glue:
+                                type: string
+                                enum:
+                                  - and
+                                description: The top-level glue is always "and"
+                              conditions:
+                                type: array
+                                description: The condition groups
+                                items:
+                                  type: object
+                                  description: A group of conditions joined by a logical operator
+                                  properties:
+                                    glue:
+                                      type: string
+                                      enum:
+                                        - and
+                                        - or
+                                      description: The logical operator joining conditions within this group
+                                    conditions:
+                                      type: array
+                                      description: The individual conditions in this group
+                                      items:
+                                        type: object
+                                        description: A single filter condition
+                                        properties:
+                                          object:
+                                            type: string
+                                            description: 'The type of entity the condition applies to (e.g. "deal", "person")'
+                                          field_id:
+                                            type: string
+                                            description: The ID of the field
+                                          operator:
+                                            type: string
+                                            description: 'The operator used in the condition (e.g. "=", "IS NOT NULL")'
+                                          value:
+                                            type: string
+                                            nullable: true
+                                            description: The value of the condition
+                                          extra_value:
+                                            type: string
+                                            nullable: true
+                                            description: An extra value for conditions that require two values
+                                          json_value_flag:
+                                            type: boolean
+                                            description: Whether the value is JSON-encoded
+                                          field_code:
+                                            type: string
+                                            nullable: true
+                                            description: The code name of the field. Present when `include_field_code=true` is passed as a query parameter; `null` if the field code cannot be resolved
               example:
                 success: true
                 data:
                   id: 1
                   name: Deal title is 'my title'
+                  filter_code: null
+                  is_editable: true
                   active_flag: true
                   type: deals
                   temporary_flag: false
                   user_id: 1
                   add_time: '2018-01-27 08:49:26'
                   update_time: '2018-01-27 08:49:26'
-                  visible_to: 1
-                  custom_view_id: 1
+                  visible_to: '1'
+                  last_used_time: null
+                  custom_view_id: null
                   conditions:
                     glue: and
                     conditions:
@@ -11323,9 +11705,11 @@ paths:
                             field_id: '123141'
                             operator: '='
                             value: my title
+                            extra_value: null
+                            json_value_flag: false
+                            field_code: title
                       - glue: or
-                        conditions:
-                          - null
+                        conditions: []
   /goals:
     post:
       summary: Add a new goal
@@ -15383,6 +15767,9 @@ paths:
                           body_url:
                             type: string
                             description: The mail message body URL
+                          body:
+                            type: string
+                            description: The mail message body content. Only present when `include_body=1` is passed.
                           account_id:
                             type: string
                             description: The connection account ID
@@ -17420,6 +17807,11 @@ paths:
             type: integer
           description: 'The ID of the project which notes to fetch. If omitted, notes about all projects will be returned.'
         - in: query
+          name: task_id
+          schema:
+            type: integer
+          description: 'The ID of the task which notes to fetch. If omitted, notes about all tasks will be returned.'
+        - in: query
           name: start
           description: Pagination start
           schema:
@@ -17499,6 +17891,15 @@ paths:
               - 0
               - 1
           description: 'If set, the results are filtered by note to project pinning state'
+        - in: query
+          name: pinned_to_task_flag
+          schema:
+            title: numberBoolean
+            type: number
+            enum:
+              - 0
+              - 1
+          description: 'If set, the results are filtered by note to task pinning state'
       responses:
         '200':
           description: Get all notes
@@ -17577,6 +17978,16 @@ paths:
                             title:
                               type: string
                               description: The title of the project the note is attached to
+                        task_id:
+                          type: integer
+                          description: The ID of the task the note is attached to
+                        task:
+                          type: object
+                          description: The task the note is attached to
+                          properties:
+                            title:
+                              type: string
+                              description: The title of the task the note is attached to
                         pinned_to_deal_flag:
                           type: boolean
                           description: 'If true, the results are filtered by note to deal pinning state'
@@ -17589,6 +18000,9 @@ paths:
                         pinned_to_project_flag:
                           type: boolean
                           description: 'If true, the results are filtered by note to project pinning state'
+                        pinned_to_task_flag:
+                          type: boolean
+                          description: 'If true, the results are filtered by note to task pinning state'
                         update_time:
                           type: string
                           description: The last updated date and time of the note
@@ -17698,19 +18112,22 @@ paths:
                     lead_id:
                       type: string
                       format: uuid
-                      description: The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id`) is specified.
+                      description: The ID of the lead the note will be attached to. This property is required unless one of (`deal_id/person_id/org_id/project_id/task_id`) is specified.
                     deal_id:
                       type: integer
-                      description: The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id`) is specified.
+                      description: The ID of the deal the note will be attached to. This property is required unless one of (`lead_id/person_id/org_id/project_id/task_id`) is specified.
                     person_id:
                       type: integer
-                      description: The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id`) is specified.
+                      description: The ID of the person this note will be attached to. This property is required unless one of (`deal_id/lead_id/org_id/project_id/task_id`) is specified.
                     org_id:
                       type: integer
-                      description: The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id`) is specified.
+                      description: The ID of the organization this note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/project_id/task_id`) is specified.
                     project_id:
                       type: integer
-                      description: The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id`) is specified.
+                      description: The ID of the project the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/task_id`) is specified.
+                    task_id:
+                      type: integer
+                      description: The ID of the task the note will be attached to. This property is required unless one of (`deal_id/lead_id/person_id/org_id/project_id`) is specified.
                 - type: object
                   properties:
                     user_id:
@@ -17759,6 +18176,14 @@ paths:
                             - 0
                             - 1
                       description: 'If set, the results are filtered by note to project pinning state (`project_id` is also required)'
+                    pinned_to_task_flag:
+                      allOf:
+                        - title: numberBoolean
+                          type: number
+                          enum:
+                            - 0
+                            - 1
+                      description: 'If set, the results are filtered by note to task pinning state (`task_id` is also required)'
       responses:
         '200':
           description: 'Add, update or get a note'
@@ -17834,6 +18259,16 @@ paths:
                           title:
                             type: string
                             description: The title of the project the note is attached to
+                      task_id:
+                        type: integer
+                        description: The ID of the task the note is attached to
+                      task:
+                        type: object
+                        description: The task the note is attached to
+                        properties:
+                          title:
+                            type: string
+                            description: The title of the task the note is attached to
                       pinned_to_deal_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to deal pinning state'
@@ -17846,6 +18281,9 @@ paths:
                       pinned_to_project_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to project pinning state'
+                      pinned_to_task_flag:
+                        type: boolean
+                        description: 'If true, the results are filtered by note to task pinning state'
                       update_time:
                         type: string
                         description: The last updated date and time of the note
@@ -18035,6 +18473,16 @@ paths:
                           title:
                             type: string
                             description: The title of the project the note is attached to
+                      task_id:
+                        type: integer
+                        description: The ID of the task the note is attached to
+                      task:
+                        type: object
+                        description: The task the note is attached to
+                        properties:
+                          title:
+                            type: string
+                            description: The title of the task the note is attached to
                       pinned_to_deal_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to deal pinning state'
@@ -18047,6 +18495,9 @@ paths:
                       pinned_to_project_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to project pinning state'
+                      pinned_to_task_flag:
+                        type: boolean
+                        description: 'If true, the results are filtered by note to task pinning state'
                       update_time:
                         type: string
                         description: The last updated date and time of the note
@@ -18151,6 +18602,9 @@ paths:
                     project_id:
                       type: integer
                       description: The ID of the project the note will be attached to
+                    task_id:
+                      type: integer
+                      description: The ID of the task the note will be attached to
                 - type: object
                   properties:
                     user_id:
@@ -18199,6 +18653,14 @@ paths:
                             - 0
                             - 1
                       description: 'If set, the results are filtered by note to project pinning state (`project_id` is also required)'
+                    pinned_to_task_flag:
+                      allOf:
+                        - title: numberBoolean
+                          type: number
+                          enum:
+                            - 0
+                            - 1
+                      description: 'If set, the results are filtered by note to task pinning state (`task_id` is also required)'
       responses:
         '200':
           description: 'Add, update or get a note'
@@ -18274,6 +18736,16 @@ paths:
                           title:
                             type: string
                             description: The title of the project the note is attached to
+                      task_id:
+                        type: integer
+                        description: The ID of the task the note is attached to
+                      task:
+                        type: object
+                        description: The task the note is attached to
+                        properties:
+                          title:
+                            type: string
+                            description: The title of the task the note is attached to
                       pinned_to_deal_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to deal pinning state'
@@ -18286,6 +18758,9 @@ paths:
                       pinned_to_project_flag:
                         type: boolean
                         description: 'If true, the results are filtered by note to project pinning state'
+                      pinned_to_task_flag:
+                        type: boolean
+                        description: 'If true, the results are filtered by note to task pinning state'
                       update_time:
                         type: string
                         description: The last updated date and time of the note
@@ -18992,7 +19467,7 @@ paths:
           content:
             text/html:
               example: |
-                As a result of the request, the customer will see a page with the confirmation dialog, which will present the details of your app (title, company name, icon) and explain the permission scopes that you have set for the app. Customers should confirm their wish to install the app by clicking "Allow and install" or deny authorization by clicking "Cancel".
+                As a result of the request, the customer will see a page with the confirmation dialog, which will present your app details (title, company name, icon) and explain the permission scopes that you have set for the app. Customers should confirm their wish to install the app by clicking "Allow and install" or deny authorization by clicking "Cancel".
   /oauth/token:
     post:
       summary: Getting the tokens
@@ -19411,6 +19886,7 @@ paths:
                     product_id: 1
                     activity_id: 1
                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                    project_id: 1
                     log_id: null
                     add_time: '2020-09-16 11:19:36'
                     update_time: '2020-09-16 11:19:36'
@@ -19431,6 +19907,7 @@ paths:
                     org_name: Pipedrive Inc.
                     product_name: ''
                     lead_name: nice lead
+                    project_name: My project
                     url: 'https://app.pipedrive.com/api/v1/files/304/download'
                     name: 95781006_794143070992462_4330873630616453120_n.jpg
                     description: ''
@@ -19694,6 +20171,7 @@ paths:
                       product_id: 1
                       activity_id: 1
                       lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                      project_id: 1
                       log_id: null
                       add_time: '2020-09-16 11:19:36'
                       update_time: '2020-09-16 11:19:36'
@@ -19714,6 +20192,7 @@ paths:
                       org_name: Pipedrive Inc.
                       product_name: ''
                       lead_name: nice lead
+                      project_name: My project
                       url: 'https://app.pipedrive.com/api/v1/files/304/download'
                       name: 95781006_794143070992462_4330873630616453120_n.jpg
                       description: ''
@@ -19973,6 +20452,16 @@ paths:
           description: Items shown per page
           schema:
             type: integer
+        - in: query
+          name: include_body
+          schema:
+            title: numberBooleanDefault0
+            type: number
+            default: 0
+            enum:
+              - 0
+              - 1
+          description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
       responses:
         '200':
           description: Success
@@ -20109,6 +20598,9 @@ paths:
                                     body_url:
                                       type: string
                                       description: The mail message body URL
+                                    body:
+                                      type: string
+                                      description: The mail message body content. Only present when `include_body=1` is passed.
                                     account_id:
                                       type: string
                                       description: The connection account ID
@@ -22939,6 +23431,7 @@ paths:
                     product_id: 1
                     activity_id: 1
                     lead_id: adf21080-0e10-11eb-879b-05d71fb426ec
+                    project_id: 1
                     log_id: null
                     add_time: '2020-09-16 11:19:36'
                     update_time: '2020-09-16 11:19:36'
@@ -22959,6 +23452,7 @@ paths:
                     org_name: Pipedrive Inc.
                     product_name: ''
                     lead_name: nice lead
+                    project_name: My project
                     url: 'https://app.pipedrive.com/api/v1/files/304/download'
                     name: 95781006_794143070992462_4330873630616453120_n.jpg
                     description: ''
@@ -23561,6 +24055,16 @@ paths:
           description: Items shown per page
           schema:
             type: integer
+        - in: query
+          name: include_body
+          schema:
+            title: numberBooleanDefault0
+            type: number
+            default: 0
+            enum:
+              - 0
+              - 1
+          description: 'Whether to include the mail message body content in the response. `0` = Don''t include, `1` = Include.'
       responses:
         '200':
           description: Success
@@ -23697,6 +24201,9 @@ paths:
                                     body_url:
                                       type: string
                                       description: The mail message body URL
+                                    body:
+                                      type: string
+                                      description: The mail message body content. Only present when `include_body=1` is passed.
                                     account_id:
                                       type: string
                                       description: The connection account ID
@@ -28845,6 +29352,10 @@ paths:
                                   type: array
                                   items:
                                     type: integer
+                                health_status:
+                                  description: The health status of the project
+                                  type: integer
+                                  nullable: true
                             - type: object
                               properties:
                                 add_time:
@@ -28882,6 +29393,7 @@ paths:
                     labels:
                       - 13
                       - 14
+                    health_status: 10
                     archive_time: '2023-09-15 11:12:18.110'
                     deal_ids:
                       - 1
@@ -28958,6 +29470,10 @@ paths:
                       type: array
                       items:
                         type: integer
+                    health_status:
+                      description: The health status of the project
+                      type: integer
+                      nullable: true
                 - type: object
                   properties:
                     template_id:
@@ -29032,6 +29548,10 @@ paths:
                                 type: array
                                 items:
                                   type: integer
+                              health_status:
+                                description: The health status of the project
+                                type: integer
+                                nullable: true
                           - type: object
                             properties:
                               add_time:
@@ -29066,6 +29586,7 @@ paths:
                   labels:
                     - 13
                     - 14
+                  health_status: 10
                   archive_time: '2023-09-15 11:12:18.110'
                   deal_ids:
                     - 1
@@ -29164,6 +29685,10 @@ paths:
                                 type: array
                                 items:
                                   type: integer
+                              health_status:
+                                description: The health status of the project
+                                type: integer
+                                nullable: true
                           - type: object
                             properties:
                               add_time:
@@ -29198,6 +29723,7 @@ paths:
                   labels:
                     - 13
                     - 14
+                  health_status: 10
                   archive_time: '2023-09-15 11:12:18.110'
                   deal_ids:
                     - 1
@@ -29277,6 +29803,10 @@ paths:
                       type: array
                       items:
                         type: integer
+                    health_status:
+                      description: The health status of the project
+                      type: integer
+                      nullable: true
       responses:
         '200':
           description: Updated project.
@@ -29346,6 +29876,10 @@ paths:
                                 type: array
                                 items:
                                   type: integer
+                              health_status:
+                                description: The health status of the project
+                                type: integer
+                                nullable: true
                           - type: object
                             properties:
                               add_time:
@@ -29380,6 +29914,7 @@ paths:
                   labels:
                     - 13
                     - 14
+                  health_status: 10
                   archive_time: '2023-09-15 11:12:18.110'
                   deal_ids:
                     - 1
@@ -29528,6 +30063,10 @@ paths:
                                 type: array
                                 items:
                                   type: integer
+                              health_status:
+                                description: The health status of the project
+                                type: integer
+                                nullable: true
                           - type: object
                             properties:
                               add_time:
@@ -29562,6 +30101,7 @@ paths:
                   labels:
                     - 13
                     - 14
+                  health_status: 10
                   archive_time: '2023-09-15 11:12:18.110'
                   deal_ids:
                     - 1
@@ -29906,7 +30446,14 @@ paths:
                                   type: number
                                 assignee_id:
                                   type: number
-                                  description: The ID of the user who will be the assignee of the task
+                                  description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                                assignee_ids:
+                                  type: array
+                                  items:
+                                    type: number
+                                  maxItems: 10
+                                  uniqueItems: true
+                                  description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                                 done:
                                   description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                   allOf:
@@ -29951,6 +30498,10 @@ paths:
                     due_date: '2023-10-11'
                     parent_task_id: 2
                     assignee_id: 2
+                    assignee_ids:
+                      - 2
+                      - 3
+                      - 4
                     add_time: '2023-09-14 08:14:40.288'
                     update_time: '2023-09-14 08:14:40.288'
                     marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -30164,7 +30715,7 @@ paths:
       x-token-cost: 20
       operationId: getProjectsBoards
       tags:
-        - Projects
+        - ProjectBoards
       security:
         - api_key: []
         - oauth2:
@@ -30221,7 +30772,7 @@ paths:
       x-token-cost: 2
       operationId: getProjectsBoard
       tags:
-        - ProjectTemplates
+        - ProjectBoards
       security:
         - api_key: []
         - oauth2:
@@ -30283,7 +30834,7 @@ paths:
       x-token-cost: 20
       operationId: getProjectsPhases
       tags:
-        - Projects
+        - ProjectPhases
       security:
         - api_key: []
         - oauth2:
@@ -30352,7 +30903,7 @@ paths:
       x-token-cost: 2
       operationId: getProjectsPhase
       tags:
-        - ProjectTemplates
+        - ProjectPhases
       security:
         - api_key: []
         - oauth2:
@@ -31312,12 +31863,30 @@ paths:
                                 name:
                                   type: string
                                   description: The name of the filter
+                                filter_code:
+                                  type: string
+                                  nullable: true
+                                  description: The system code of the filter
+                                is_editable:
+                                  type: boolean
+                                  description: Whether the filter can be edited by the requesting user
                                 active_flag:
                                   type: boolean
                                   description: The active flag of the filter
                                 type:
                                   type: string
-                                  description: The type of the item
+                                  enum:
+                                    - deals
+                                    - leads
+                                    - org
+                                    - people
+                                    - products
+                                    - activity
+                                    - projects
+                                temporary_flag:
+                                  type: boolean
+                                  nullable: true
+                                  description: Whether the filter is temporary
                                 user_id:
                                   type: integer
                                   description: The owner of the filter
@@ -31326,13 +31895,25 @@ paths:
                                   description: The date and time when the filter was added
                                 update_time:
                                   type: string
+                                  nullable: true
                                   description: The date and time when the filter was updated
                                 visible_to:
-                                  type: integer
-                                  description: The visibility group ID of who can see then filter
+                                  allOf:
+                                    - type: string
+                                      enum:
+                                        - '1'
+                                        - '3'
+                                        - '5'
+                                        - '7'
+                                  description: The visibility group ID of who can see the filter
+                                last_used_time:
+                                  type: string
+                                  nullable: true
+                                  description: The date and time when the filter was last used
                                 custom_view_id:
                                   type: integer
-                                  description: Used by Pipedrive webapp
+                                  nullable: true
+                                  description: The custom view ID linked to the filter
                         - type: object
                           properties:
                             item:
@@ -31404,6 +31985,16 @@ paths:
                                     title:
                                       type: string
                                       description: The title of the project the note is attached to
+                                task_id:
+                                  type: integer
+                                  description: The ID of the task the note is attached to
+                                task:
+                                  type: object
+                                  description: The task the note is attached to
+                                  properties:
+                                    title:
+                                      type: string
+                                      description: The title of the task the note is attached to
                                 pinned_to_deal_flag:
                                   type: boolean
                                   description: 'If true, the results are filtered by note to deal pinning state'
@@ -31416,6 +32007,9 @@ paths:
                                 pinned_to_project_flag:
                                   type: boolean
                                   description: 'If true, the results are filtered by note to project pinning state'
+                                pinned_to_task_flag:
+                                  type: boolean
+                                  description: 'If true, the results are filtered by note to task pinning state'
                                 update_time:
                                   type: string
                                   description: The last updated date and time of the note
@@ -32134,10 +32728,13 @@ paths:
                                           - projects
                                           - account_settings
                                           - partnership
+                                        description: The granular app access level
                                       admin:
                                         type: boolean
+                                        description: Whether the user has admin access or not
                                       permission_set_id:
                                         type: string
+                                        description: The ID of the permission set
                                 active_flag:
                                   type: boolean
                                   description: Boolean that indicates whether the user is activated
@@ -33754,7 +34351,14 @@ paths:
                                   type: number
                                 assignee_id:
                                   type: number
-                                  description: The ID of the user who will be the assignee of the task
+                                  description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                                assignee_ids:
+                                  type: array
+                                  items:
+                                    type: number
+                                  maxItems: 10
+                                  uniqueItems: true
+                                  description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                                 done:
                                   description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                   allOf:
@@ -33799,6 +34403,10 @@ paths:
                     due_date: '2023-10-11'
                     parent_task_id: 2
                     assignee_id: 2
+                    assignee_ids:
+                      - 2
+                      - 3
+                      - 4
                     add_time: '2023-09-14 08:14:40.288'
                     update_time: '2023-09-14 08:14:40.288'
                     marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -33844,7 +34452,14 @@ paths:
                       type: number
                     assignee_id:
                       type: number
-                      description: The ID of the user who will be the assignee of the task
+                      description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                    assignee_ids:
+                      type: array
+                      items:
+                        type: number
+                      maxItems: 10
+                      uniqueItems: true
+                      description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                     done:
                       description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                       allOf:
@@ -33898,7 +34513,14 @@ paths:
                                 type: number
                               assignee_id:
                                 type: number
-                                description: The ID of the user who will be the assignee of the task
+                                description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                              assignee_ids:
+                                type: array
+                                items:
+                                  type: number
+                                maxItems: 10
+                                uniqueItems: true
+                                description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                               done:
                                 description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                 allOf:
@@ -33940,6 +34562,10 @@ paths:
                   due_date: '2023-10-11'
                   parent_task_id: 2
                   assignee_id: 2
+                  assignee_ids:
+                    - 2
+                    - 3
+                    - 4
                   add_time: '2023-09-14 08:14:40.288'
                   update_time: '2023-09-14 08:14:40.288'
                   marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -34006,7 +34632,14 @@ paths:
                                 type: number
                               assignee_id:
                                 type: number
-                                description: The ID of the user who will be the assignee of the task
+                                description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                              assignee_ids:
+                                type: array
+                                items:
+                                  type: number
+                                maxItems: 10
+                                uniqueItems: true
+                                description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                               done:
                                 description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                 allOf:
@@ -34048,6 +34681,10 @@ paths:
                   due_date: '2023-10-11'
                   parent_task_id: 2
                   assignee_id: 2
+                  assignee_ids:
+                    - 2
+                    - 3
+                    - 4
                   add_time: '2023-09-14 08:14:40.288'
                   update_time: '2023-09-14 08:14:40.288'
                   marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -34096,7 +34733,14 @@ paths:
                       type: number
                     assignee_id:
                       type: number
-                      description: The ID of the user who will be the assignee of the task
+                      description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                    assignee_ids:
+                      type: array
+                      items:
+                        type: number
+                      maxItems: 10
+                      uniqueItems: true
+                      description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                     done:
                       description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                       allOf:
@@ -34150,7 +34794,14 @@ paths:
                                 type: number
                               assignee_id:
                                 type: number
-                                description: The ID of the user who will be the assignee of the task
+                                description: 'The ID of the user assigned to the task. When the `assignee_id` field is updated, the `assignee_ids` field value will be overwritten by the `assignee_id` field value.'
+                              assignee_ids:
+                                type: array
+                                items:
+                                  type: number
+                                maxItems: 10
+                                uniqueItems: true
+                                description: 'The IDs of users assigned to the task. When the `assignee_ids` field is updated, the `assignee_id` field value will be set to the first value of the `assignee_ids` field, or `null` if the list is empty.'
                               done:
                                 description: 'Whether the task is done or not. 0 = Not done, 1 = Done.'
                                 allOf:
@@ -34192,6 +34843,10 @@ paths:
                   due_date: '2023-10-11'
                   parent_task_id: 2
                   assignee_id: 2
+                  assignee_ids:
+                    - 2
+                    - 3
+                    - 4
                   add_time: '2023-09-14 08:14:40.288'
                   update_time: '2023-09-14 08:14:40.288'
                   marked_as_done_time: '2023-09-22 08:14:40.288'
@@ -34335,10 +34990,13 @@ paths:
                                       - projects
                                       - account_settings
                                       - partnership
+                                    description: The granular app access level
                                   admin:
                                     type: boolean
+                                    description: Whether the user has admin access or not
                                   permission_set_id:
                                     type: string
+                                    description: The ID of the permission set
                             active_flag:
                               type: boolean
                               description: Boolean that indicates whether the user is activated
@@ -34457,10 +35115,13 @@ paths:
                           - projects
                           - account_settings
                           - partnership
+                        description: The granular app access level
                       admin:
                         type: boolean
+                        description: Whether the user has admin access or not
                       permission_set_id:
                         type: string
+                        description: The ID of the permission set
                     required:
                       - app
                   description: |
@@ -34545,10 +35206,13 @@ paths:
                                     - projects
                                     - account_settings
                                     - partnership
+                                  description: The granular app access level
                                 admin:
                                   type: boolean
+                                  description: Whether the user has admin access or not
                                 permission_set_id:
                                   type: string
+                                  description: The ID of the permission set
                           active_flag:
                             type: boolean
                             description: Boolean that indicates whether the user is activated
@@ -34724,10 +35388,13 @@ paths:
                                       - projects
                                       - account_settings
                                       - partnership
+                                    description: The granular app access level
                                   admin:
                                     type: boolean
+                                    description: Whether the user has admin access or not
                                   permission_set_id:
                                     type: string
+                                    description: The ID of the permission set
                             active_flag:
                               type: boolean
                               description: Boolean that indicates whether the user is activated
@@ -34894,10 +35561,13 @@ paths:
                                         - projects
                                         - account_settings
                                         - partnership
+                                      description: The granular app access level
                                     admin:
                                       type: boolean
+                                      description: Whether the user has admin access or not
                                     permission_set_id:
                                       type: string
+                                      description: The ID of the permission set
                               active_flag:
                                 type: boolean
                                 description: Boolean that indicates whether the user is activated
@@ -35101,10 +35771,13 @@ paths:
                                     - projects
                                     - account_settings
                                     - partnership
+                                  description: The granular app access level
                                 admin:
                                   type: boolean
+                                  description: Whether the user has admin access or not
                                 permission_set_id:
                                   type: string
+                                  description: The ID of the permission set
                           active_flag:
                             type: boolean
                             description: Boolean that indicates whether the user is activated
@@ -35277,10 +35950,13 @@ paths:
                                     - projects
                                     - account_settings
                                     - partnership
+                                  description: The granular app access level
                                 admin:
                                   type: boolean
+                                  description: Whether the user has admin access or not
                                 permission_set_id:
                                   type: string
+                                  description: The ID of the permission set
                           active_flag:
                             type: boolean
                             description: Boolean that indicates whether the user is activated

--- a/openapi/upstream/v2.yaml
+++ b/openapi/upstream/v2.yaml
@@ -14,6 +14,12 @@ tags:
   - name: Deals
     description: |
       Deals represent ongoing, lost or won sales to an organization or to a person. Each deal has a monetary value and must be placed in a stage. Deals can be owned by a user, and followed by one or many users. Each deal consists of standard data fields but can also contain a number of custom fields. The custom fields can be recognized by long hashes as keys. These hashes can be mapped against `DealField.key`. The corresponding label for each such custom field can be obtained from `DealField.name`.
+  - name: DealProducts
+    description: |
+      Deal products are goods or services attached to a deal. Each deal product links a product to a deal with configurable quantity, pricing, and discounts, and contributes to the total value of the deal.
+  - name: DealInstallments
+    description: |
+      Deal installments are scheduled payment entries attached to a deal, enabling split payment arrangements.
   - name: DealFields
     description: |
       Deal fields represent the schema for a deal in the context of the company of the authorized user. Each company can have a different schema for their deals, with various custom fields.
@@ -50,9 +56,27 @@ tags:
   - name: Users
     description: |
       Users are individuals who have a Pipedrive account and can interact with its features.
+  - name: Projects
+    description: |
+      Projects are used to plan and manage work that spans across deals, activities, and tasks. Each project can have a board, phases, and associated activities and tasks.
+  - name: ProjectBoards
+    description: |
+      Project boards are the top-level containers for organizing projects into phases. Each board contains one or more phases that define the workflow stages for projects.
+  - name: ProjectPhases
+    description: |
+      Project phases are the stages within a project board that define the workflow for projects. Each phase belongs to a board and can contain multiple projects.
+  - name: ProjectTemplates
+    description: |
+      Project templates are reusable blueprints for creating projects with predefined structure and settings.
+  - name: ProjectFields
+    description: |
+      Project fields represent the schema for a project in the context of the company of the authorized user. Each company can have a different schema for their projects, with various custom fields.
+  - name: Tasks
+    description: |
+      Tasks are action items that can be associated with a project.
   - name: Beta
     description: |
-      Beta endpoints are endpoints that may have changes without a regular 60-90day notice period.
+      Beta endpoints are endpoints that may have changes without a regular 60-90 day notice period.
 paths:
   /activities:
     get:
@@ -1477,8 +1501,10 @@ paths:
                             type: object
                             properties:
                               id:
-                                type: integer
-                                description: The option ID
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
                               label:
                                 type: string
                                 description: The option display label
@@ -1706,8 +1732,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -1888,6 +1916,16 @@ paths:
           schema:
             type: string
         - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
+        - in: query
           name: limit
           description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
           schema:
@@ -2047,7 +2085,7 @@ paths:
                             custom_fields:
                               type: object
                               additionalProperties: true
-                              description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                       additional_data:
                         type: object
                         description: The additional data of the list
@@ -2189,7 +2227,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Add deal
@@ -2336,7 +2374,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -2656,7 +2694,7 @@ paths:
                             custom_fields:
                               type: object
                               additionalProperties: true
-                              description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                       additional_data:
                         type: object
                         description: The additional data of the list
@@ -2798,6 +2836,16 @@ paths:
           description: 'Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.'
           schema:
             type: string
+        - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
       responses:
         '200':
           description: Get deal
@@ -2944,7 +2992,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -3082,7 +3130,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Edit deal
@@ -3229,7 +3277,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -3551,7 +3599,7 @@ paths:
       x-token-cost: 10
       operationId: getDealsProducts
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -3563,6 +3611,8 @@ paths:
         - in: query
           name: deal_ids
           required: true
+          style: form
+          explode: false
           schema:
             type: array
             items:
@@ -3670,7 +3720,7 @@ paths:
                               default: percentage
                               description: The type of the discount's value
                             quantity:
-                              type: integer
+                              type: number
                               description: The quantity of the product
                             item_price:
                               type: number
@@ -3729,7 +3779,7 @@ paths:
                             billing_start_date:
                               default: null
                               type: string
-                              format: YYYY-MM-DD
+                              format: date
                               nullable: true
                               description: |
                                 Only available in Growth and above plans
@@ -3984,7 +4034,7 @@ paths:
       x-token-cost: 10
       operationId: getDealProducts
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4100,7 +4150,7 @@ paths:
                               default: percentage
                               description: The type of the discount's value
                             quantity:
-                              type: integer
+                              type: number
                               description: The quantity of the product
                             item_price:
                               type: number
@@ -4159,7 +4209,7 @@ paths:
                             billing_start_date:
                               default: null
                               type: string
-                              format: YYYY-MM-DD
+                              format: date
                               nullable: true
                               description: |
                                 Only available in Growth and above plans
@@ -4205,7 +4255,7 @@ paths:
       x-token-cost: 5
       operationId: addDealProduct
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4325,7 +4375,7 @@ paths:
                     billing_start_date:
                       default: null
                       type: string
-                      format: YYYY-MM-DD
+                      format: date
                       nullable: true
                       description: |
                         Only available in Growth and above plans
@@ -4397,7 +4447,7 @@ paths:
                             default: percentage
                             description: The type of the discount's value
                           quantity:
-                            type: integer
+                            type: number
                             description: The quantity of the product
                           item_price:
                             type: number
@@ -4456,7 +4506,7 @@ paths:
                           billing_start_date:
                             default: null
                             type: string
-                            format: YYYY-MM-DD
+                            format: date
                             nullable: true
                             description: |
                               Only available in Growth and above plans
@@ -4493,7 +4543,7 @@ paths:
       x-token-cost: 15
       operationId: deleteManyDealProducts
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4557,7 +4607,7 @@ paths:
       x-token-cost: 5
       operationId: updateDealProduct
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4672,7 +4722,7 @@ paths:
                   properties:
                     billing_start_date:
                       type: string
-                      format: YYYY-MM-DD
+                      format: date
                       nullable: true
                       description: |
                         Only available in Growth and above plans
@@ -4744,7 +4794,7 @@ paths:
                             default: percentage
                             description: The type of the discount's value
                           quantity:
-                            type: integer
+                            type: number
                             description: The quantity of the product
                           item_price:
                             type: number
@@ -4803,7 +4853,7 @@ paths:
                           billing_start_date:
                             default: null
                             type: string
-                            format: YYYY-MM-DD
+                            format: date
                             nullable: true
                             description: |
                               Only available in Growth and above plans
@@ -4840,7 +4890,7 @@ paths:
       x-token-cost: 3
       operationId: deleteDealProduct
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4889,7 +4939,7 @@ paths:
       x-token-cost: 25
       operationId: addManyDealProducts
       tags:
-        - Deals
+        - DealProducts
       security:
         - api_key: []
         - oauth2:
@@ -4913,7 +4963,7 @@ paths:
               properties:
                 data:
                   type: array
-                  description: 'Array of products to attach to the deal. See the single product endpoint (https://developers.pipedrive.com/docs/api/v1/Deals#addDealProduct) for the expected format of array items.'
+                  description: Array of products to attach to the deal. Each product object may have the following properties.
                   maxItems: 100
                   items:
                     title: addDealProductRequest
@@ -5019,7 +5069,7 @@ paths:
                           billing_start_date:
                             default: null
                             type: string
-                            format: YYYY-MM-DD
+                            format: date
                             nullable: true
                             description: |
                               Only available in Growth and above plans
@@ -5094,7 +5144,7 @@ paths:
                               default: percentage
                               description: The type of the discount's value
                             quantity:
-                              type: integer
+                              type: number
                               description: The quantity of the product
                             item_price:
                               type: number
@@ -5153,7 +5203,7 @@ paths:
                             billing_start_date:
                               default: null
                               type: string
-                              format: YYYY-MM-DD
+                              format: date
                               nullable: true
                               description: |
                                 Only available in Growth and above plans
@@ -5547,7 +5597,7 @@ paths:
       x-token-cost: 10
       operationId: getInstallments
       tags:
-        - Deals
+        - DealInstallments
       security:
         - api_key: []
         - oauth2:
@@ -5648,7 +5698,7 @@ paths:
       x-token-cost: 5
       operationId: postInstallment
       tags:
-        - Deals
+        - DealInstallments
       security:
         - api_key: []
         - oauth2:
@@ -5729,7 +5779,7 @@ paths:
       x-token-cost: 5
       operationId: updateInstallment
       tags:
-        - Deals
+        - DealInstallments
       security:
         - api_key: []
         - oauth2:
@@ -5811,7 +5861,7 @@ paths:
       x-token-cost: 3
       operationId: deleteInstallment
       tags:
-        - Deals
+        - DealInstallments
       security:
         - api_key: []
         - oauth2:
@@ -5991,7 +6041,6 @@ paths:
                       required:
                         - field_name
                         - field_code
-                        - description
                         - field_type
                         - is_custom_field
                         - is_optional_response_field
@@ -6050,8 +6099,10 @@ paths:
                             type: object
                             properties:
                               id:
-                                type: integer
-                                description: The option ID
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
                               label:
                                 type: string
                                 description: The option display label
@@ -6377,7 +6428,7 @@ paths:
                       default: []
                     statuses:
                       type: object
-                      description: 'Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings (''won'', ''lost''). Example - {"1":["won","lost"],"2":["won"]} means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.'
+                      description: 'Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings (''won'', ''lost''). Example - `{"1":["won","lost"],"2":["won"]}` means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.'
                       default: {}
                       additionalProperties:
                         type: array
@@ -6406,7 +6457,6 @@ paths:
                     required:
                       - field_name
                       - field_code
-                      - description
                       - field_type
                       - is_custom_field
                       - is_optional_response_field
@@ -6465,8 +6515,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -6655,7 +6707,6 @@ paths:
                     required:
                       - field_name
                       - field_code
-                      - description
                       - field_type
                       - is_custom_field
                       - is_optional_response_field
@@ -6714,8 +6765,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -6934,7 +6987,7 @@ paths:
                       default: []
                     statuses:
                       type: object
-                      description: 'Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings (''won'', ''lost''). Example - {"1":["won","lost"],"2":["won"]} means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.'
+                      description: 'Pipeline-specific status requirements for when deals are won or lost. Keys are pipeline IDs (as strings), values are arrays of status strings (''won'', ''lost''). Example - `{"1":["won","lost"],"2":["won"]}` means the field is required when marking deals as won or lost in pipeline 1, and only when won in pipeline 2. Must reference valid, active pipelines.'
                       default: {}
                       additionalProperties:
                         type: array
@@ -6963,7 +7016,6 @@ paths:
                     required:
                       - field_name
                       - field_code
-                      - description
                       - field_type
                       - is_custom_field
                       - is_optional_response_field
@@ -7022,8 +7074,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -7182,7 +7236,6 @@ paths:
                     required:
                       - field_name
                       - field_code
-                      - description
                       - field_type
                       - is_custom_field
                       - is_optional_response_field
@@ -7655,6 +7708,16 @@ paths:
           schema:
             type: string
         - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
+        - in: query
           name: limit
           description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
           schema:
@@ -7818,7 +7881,7 @@ paths:
                             custom_fields:
                               type: object
                               additionalProperties: true
-                              description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                       additional_data:
                         type: object
                         description: The additional data of the list
@@ -7897,8 +7960,6 @@ paths:
         content:
           application/json:
             schema:
-              required:
-                - title
               type: object
               properties:
                 name:
@@ -7965,7 +8026,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Add person
@@ -8116,7 +8177,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -8266,6 +8327,16 @@ paths:
           description: 'Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.'
           schema:
             type: string
+        - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
       responses:
         '200':
           description: Get person
@@ -8416,7 +8487,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -8559,7 +8630,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Edit person
@@ -8710,7 +8781,7 @@ paths:
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -9221,8 +9292,10 @@ paths:
                             type: object
                             properties:
                               id:
-                                type: integer
-                                description: The option ID
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
                               label:
                                 type: string
                                 description: The option display label
@@ -9486,10 +9559,6 @@ paths:
                       type: boolean
                       description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating persons. Default is false.'
                       default: false
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Create one person field
@@ -9561,8 +9630,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -9774,8 +9845,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -9960,10 +10033,6 @@ paths:
                       type: boolean
                       description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating persons. Default is false.'
                       default: false
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Get one person field
@@ -10035,8 +10104,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -10517,6 +10588,16 @@ paths:
           schema:
             type: string
         - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
+        - in: query
           name: limit
           description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
           schema:
@@ -10612,10 +10693,30 @@ paths:
                               description: The IDs of labels assigned to the organization
                               items:
                                 type: integer
+                            website:
+                              type: string
+                              nullable: true
+                              description: The website of the organization
+                            linkedin:
+                              type: string
+                              nullable: true
+                              description: The LinkedIn profile URL of the organization
+                            industry:
+                              type: integer
+                              nullable: true
+                              description: The industry the organization belongs to
+                            annual_revenue:
+                              type: integer
+                              nullable: true
+                              description: The annual revenue of the organization
+                            employee_count:
+                              type: integer
+                              nullable: true
+                              description: The number of employees in the organization
                             custom_fields:
                               type: object
                               additionalProperties: true
-                              description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                       additional_data:
                         type: object
                         description: The additional data of the list
@@ -10729,7 +10830,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Add organization
@@ -10812,10 +10913,30 @@ paths:
                             description: The IDs of labels assigned to the organization
                             items:
                               type: integer
+                          website:
+                            type: string
+                            nullable: true
+                            description: The website of the organization
+                          linkedin:
+                            type: string
+                            nullable: true
+                            description: The LinkedIn profile URL of the organization
+                          industry:
+                            type: integer
+                            nullable: true
+                            description: The industry the organization belongs to
+                          annual_revenue:
+                            type: integer
+                            nullable: true
+                            description: The annual revenue of the organization
+                          employee_count:
+                            type: integer
+                            nullable: true
+                            description: The number of employees in the organization
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -10933,6 +11054,16 @@ paths:
           description: 'Optional comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for faster results and smaller response.<br/>A maximum of 15 keys is allowed.'
           schema:
             type: string
+        - in: query
+          name: include_option_labels
+          description: 'When provided with a ''true'' value, single option and multiple option custom fields values contain objects in the form of ''{ id: number, label: string }'' instead of plain id'
+          schema:
+            type: boolean
+        - in: query
+          name: include_labels
+          description: 'When provided with ''true'' value, response will include an array of label objects in the form of ''{ id: number, label: string }'''
+          schema:
+            type: boolean
       responses:
         '200':
           description: Get organization
@@ -11015,10 +11146,30 @@ paths:
                             description: The IDs of labels assigned to the organization
                             items:
                               type: integer
+                          website:
+                            type: string
+                            nullable: true
+                            description: The website of the organization
+                          linkedin:
+                            type: string
+                            nullable: true
+                            description: The LinkedIn profile URL of the organization
+                          industry:
+                            type: integer
+                            nullable: true
+                            description: The industry the organization belongs to
+                          annual_revenue:
+                            type: integer
+                            nullable: true
+                            description: The annual revenue of the organization
+                          employee_count:
+                            type: integer
+                            nullable: true
+                            description: The number of employees in the organization
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -11128,7 +11279,7 @@ paths:
                 custom_fields:
                   type: object
                   additionalProperties: true
-                  description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
       responses:
         '200':
           description: Edit organization
@@ -11211,10 +11362,30 @@ paths:
                             description: The IDs of labels assigned to the organization
                             items:
                               type: integer
+                          website:
+                            type: string
+                            nullable: true
+                            description: The website of the organization
+                          linkedin:
+                            type: string
+                            nullable: true
+                            description: The LinkedIn profile URL of the organization
+                          industry:
+                            type: integer
+                            nullable: true
+                            description: The industry the organization belongs to
+                          annual_revenue:
+                            type: integer
+                            nullable: true
+                            description: The annual revenue of the organization
+                          employee_count:
+                            type: integer
+                            nullable: true
+                            description: The number of employees in the organization
                           custom_fields:
                             type: object
                             additionalProperties: true
-                            description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
               example:
                 success: true
                 data:
@@ -11622,8 +11793,10 @@ paths:
                             type: object
                             properties:
                               id:
-                                type: integer
-                                description: The option ID
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
                               label:
                                 type: string
                                 description: The option display label
@@ -11735,7 +11908,6 @@ paths:
                 data:
                   - field_name: Organization Name
                     field_code: name
-                    description: The name of the organization
                     field_type: varchar
                     options: null
                     subfields: null
@@ -11760,7 +11932,6 @@ paths:
                       enabled: true
                   - field_name: Address
                     field_code: address
-                    description: The physical address of the organization
                     field_type: address
                     options: null
                     subfields:
@@ -11817,7 +11988,6 @@ paths:
                       enabled: false
                   - field_name: Industry
                     field_code: 40characterhashforcustomfieldidentifier
-                    description: The industry sector of the organization
                     field_type: enum
                     options:
                       - id: 1
@@ -11969,10 +12139,6 @@ paths:
                       type: boolean
                       description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating organizations. Default is false.'
                       default: false
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Create one organization field
@@ -12044,8 +12210,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -12150,7 +12318,6 @@ paths:
                 data:
                   field_name: Industry
                   field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
-                  description: The industry sector of the organization
                   field_type: enum
                   options:
                     - id: 1
@@ -12285,8 +12452,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -12391,7 +12560,6 @@ paths:
                 data:
                   field_name: Organization Name
                   field_code: name
-                  description: The name of the organization
                   field_type: varchar
                   options: null
                   subfields: null
@@ -12510,10 +12678,6 @@ paths:
                       type: boolean
                       description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating organizations. Default is false.'
                       default: false
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Get one organization field
@@ -12585,8 +12749,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -12691,7 +12857,6 @@ paths:
                 data:
                   field_name: Organization Name
                   field_code: name
-                  description: The name of the organization
                   field_type: varchar
                   options: null
                   subfields: null
@@ -12785,7 +12950,6 @@ paths:
                 data:
                   field_name: Custom text field
                   field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
-                  description: A custom text field
                   field_type: varchar
                   options: null
                   subfields: null
@@ -13066,6 +13230,11 @@ paths:
               - asc
               - desc
         - in: query
+          name: updated_since
+          schema:
+            type: string
+          description: 'If set, only products with an `update_time` later than or equal to this time are returned. In RFC3339 format, e.g. 2025-01-01T10:20:00Z.'
+        - in: query
           name: custom_fields
           description: 'Comma separated string array of custom fields keys to include. If you are only interested in a particular set of custom fields, please use this parameter for a smaller response.<br/>A maximum of 15 keys is allowed.'
           schema:
@@ -13086,100 +13255,126 @@ paths:
                     type: array
                     description: Array containing data for all products
                     items:
-                      title: GetProductResponse
-                      type: object
-                      properties:
-                        success:
-                          type: boolean
-                          description: If the response is successful or not
-                        data:
+                      allOf:
+                        - title: BaseProduct
                           allOf:
-                            - title: BaseProduct
-                              allOf:
-                                - type: object
-                                  properties:
-                                    id:
-                                      type: number
-                                      description: The ID of the product
-                                    name:
-                                      type: string
-                                      description: The name of the product
-                                    code:
-                                      type: string
-                                      description: The product code
-                                    unit:
-                                      type: string
-                                      description: The unit in which this product is sold
-                                    tax:
-                                      type: number
-                                      description: The tax percentage
-                                      default: 0
-                                    is_deleted:
-                                      type: boolean
-                                      description: Whether this product will be marked as deleted or not
-                                      default: false
-                                    is_linkable:
-                                      type: boolean
-                                      description: Whether this product can be added to a deal or not
-                                      default: true
-                                    visible_to:
-                                      allOf:
-                                        - type: number
-                                          enum:
-                                            - 1
-                                            - 3
-                                            - 5
-                                            - 7
-                                      description: Visibility of the product
-                                    owner_id:
-                                      type: integer
-                                      description: Information about the Pipedrive user who owns the product
-                                    custom_fields:
-                                      type: object
-                                      additionalProperties: true
-                                      description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
-                                - type: object
-                                  properties:
-                                    billing_frequency:
-                                      default: one-time
-                                      type: string
-                                      enum:
-                                        - one-time
-                                        - annually
-                                        - semi-annually
-                                        - quarterly
-                                        - monthly
-                                        - weekly
-                                      description: |
-                                        Only available in Growth and above plans
-
-                                        How often a customer is billed for access to a service or product
-                                - type: object
-                                  properties:
-                                    billing_frequency_cycles:
-                                      default: null
-                                      type: integer
-                                      nullable: true
-                                      description: |
-                                        Only available in Growth and above plans
-
-                                        The number of times the billing frequency repeats for a product in a deal
-
-                                        When `billing_frequency` is set to `one-time`, this field must be `null`
-
-                                        When `billing_frequency` is set to `weekly`, this field cannot be `null`
-
-                                        For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
-
-                                        Must be a positive integer less or equal to 208
                             - type: object
-                              title: PricesArray
                               properties:
-                                prices:
-                                  type: array
-                                  items:
-                                    type: object
-                                  description: 'Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)'
+                                id:
+                                  type: integer
+                                  description: The ID of the product
+                                name:
+                                  type: string
+                                  description: The name of the product
+                                code:
+                                  type: string
+                                  description: The product code
+                                unit:
+                                  type: string
+                                  description: The unit in which this product is sold
+                                tax:
+                                  type: number
+                                  description: The tax percentage
+                                  default: 0
+                                is_deleted:
+                                  type: boolean
+                                  description: Whether this product will be marked as deleted or not
+                                  default: false
+                                is_linkable:
+                                  type: boolean
+                                  description: Whether this product can be added to a deal or not
+                                  default: true
+                                visible_to:
+                                  allOf:
+                                    - type: number
+                                      enum:
+                                        - 1
+                                        - 3
+                                        - 5
+                                        - 7
+                                  description: Visibility of the product
+                                owner_id:
+                                  type: integer
+                                  description: The ID of the Pipedrive user who owns the product
+                                add_time:
+                                  type: string
+                                  description: The date and time when the product was added
+                                update_time:
+                                  type: string
+                                  description: The date and time when the product was last updated
+                                description:
+                                  type: string
+                                  description: The description of the product
+                                category:
+                                  type: string
+                                  nullable: true
+                                  description: The category of the product
+                                custom_fields:
+                                  type: object
+                                  additionalProperties: true
+                                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+                            - type: object
+                              properties:
+                                billing_frequency:
+                                  default: one-time
+                                  type: string
+                                  enum:
+                                    - one-time
+                                    - annually
+                                    - semi-annually
+                                    - quarterly
+                                    - monthly
+                                    - weekly
+                                  description: |
+                                    Only available in Growth and above plans
+
+                                    How often a customer is billed for access to a service or product
+                            - type: object
+                              properties:
+                                billing_frequency_cycles:
+                                  default: null
+                                  type: integer
+                                  nullable: true
+                                  description: |
+                                    Only available in Growth and above plans
+
+                                    The number of times the billing frequency repeats for a product in a deal
+
+                                    When `billing_frequency` is set to `one-time`, this field must be `null`
+
+                                    When `billing_frequency` is set to `weekly`, this field cannot be `null`
+
+                                    For all the other values of `billing_frequency`, `null` represents a product billed indefinitely
+
+                                    Must be a positive integer less or equal to 208
+                        - type: object
+                          title: PricesArray
+                          properties:
+                            prices:
+                              type: array
+                              description: The prices of the product in different currencies
+                              items:
+                                type: object
+                                properties:
+                                  product_id:
+                                    type: integer
+                                    description: The ID of the product
+                                  price:
+                                    type: number
+                                    description: The price of the product
+                                  currency:
+                                    type: string
+                                    description: The currency of the price
+                                  cost:
+                                    type: number
+                                    description: The cost of the product
+                                  direct_cost:
+                                    type: number
+                                    nullable: true
+                                    description: The direct cost of the product
+                                  notes:
+                                    type: string
+                                    description: The notes about the price
                   additional_data:
                     type: object
                     description: Pagination related data
@@ -13291,7 +13486,7 @@ paths:
                     custom_fields:
                       type: object
                       additionalProperties: true
-                      description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                      description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                 - type: object
                   properties:
                     billing_frequency:
@@ -13345,7 +13540,7 @@ paths:
                           - type: object
                             properties:
                               id:
-                                type: number
+                                type: integer
                                 description: The ID of the product
                               name:
                                 type: string
@@ -13379,11 +13574,24 @@ paths:
                                 description: Visibility of the product
                               owner_id:
                                 type: integer
-                                description: Information about the Pipedrive user who owns the product
+                                description: The ID of the Pipedrive user who owns the product
+                              add_time:
+                                type: string
+                                description: The date and time when the product was added
+                              update_time:
+                                type: string
+                                description: The date and time when the product was last updated
+                              description:
+                                type: string
+                                description: The description of the product
+                              category:
+                                type: string
+                                nullable: true
+                                description: The category of the product
                               custom_fields:
                                 type: object
                                 additionalProperties: true
-                                description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                                description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                           - type: object
                             properties:
                               billing_frequency:
@@ -13423,9 +13631,29 @@ paths:
                         properties:
                           prices:
                             type: array
+                            description: The prices of the product in different currencies
                             items:
                               type: object
-                            description: 'Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)'
+                              properties:
+                                product_id:
+                                  type: integer
+                                  description: The ID of the product
+                                price:
+                                  type: number
+                                  description: The price of the product
+                                currency:
+                                  type: string
+                                  description: The currency of the price
+                                cost:
+                                  type: number
+                                  description: The cost of the product
+                                direct_cost:
+                                  type: number
+                                  nullable: true
+                                  description: The direct cost of the product
+                                notes:
+                                  type: string
+                                  description: The notes about the price
               example:
                 success: true
                 data:
@@ -13939,7 +14167,7 @@ paths:
                           - type: object
                             properties:
                               id:
-                                type: number
+                                type: integer
                                 description: The ID of the product
                               name:
                                 type: string
@@ -13973,11 +14201,24 @@ paths:
                                 description: Visibility of the product
                               owner_id:
                                 type: integer
-                                description: Information about the Pipedrive user who owns the product
+                                description: The ID of the Pipedrive user who owns the product
+                              add_time:
+                                type: string
+                                description: The date and time when the product was added
+                              update_time:
+                                type: string
+                                description: The date and time when the product was last updated
+                              description:
+                                type: string
+                                description: The description of the product
+                              category:
+                                type: string
+                                nullable: true
+                                description: The category of the product
                               custom_fields:
                                 type: object
                                 additionalProperties: true
-                                description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                                description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                           - type: object
                             properties:
                               billing_frequency:
@@ -14017,9 +14258,29 @@ paths:
                         properties:
                           prices:
                             type: array
+                            description: The prices of the product in different currencies
                             items:
                               type: object
-                            description: 'Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)'
+                              properties:
+                                product_id:
+                                  type: integer
+                                  description: The ID of the product
+                                price:
+                                  type: number
+                                  description: The price of the product
+                                currency:
+                                  type: string
+                                  description: The currency of the price
+                                cost:
+                                  type: number
+                                  description: The cost of the product
+                                direct_cost:
+                                  type: number
+                                  nullable: true
+                                  description: The direct cost of the product
+                                notes:
+                                  type: string
+                                  description: The notes about the price
               example:
                 success: true
                 data:
@@ -14127,7 +14388,7 @@ paths:
                     custom_fields:
                       type: object
                       additionalProperties: true
-                      description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                      description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                 - type: object
                   properties:
                     billing_frequency:
@@ -14179,7 +14440,7 @@ paths:
                           - type: object
                             properties:
                               id:
-                                type: number
+                                type: integer
                                 description: The ID of the product
                               name:
                                 type: string
@@ -14213,11 +14474,24 @@ paths:
                                 description: Visibility of the product
                               owner_id:
                                 type: integer
-                                description: Information about the Pipedrive user who owns the product
+                                description: The ID of the Pipedrive user who owns the product
+                              add_time:
+                                type: string
+                                description: The date and time when the product was added
+                              update_time:
+                                type: string
+                                description: The date and time when the product was last updated
+                              description:
+                                type: string
+                                description: The description of the product
+                              category:
+                                type: string
+                                nullable: true
+                                description: The category of the product
                               custom_fields:
                                 type: object
                                 additionalProperties: true
-                                description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                                description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                           - type: object
                             properties:
                               billing_frequency:
@@ -14257,9 +14531,29 @@ paths:
                         properties:
                           prices:
                             type: array
+                            description: The prices of the product in different currencies
                             items:
                               type: object
-                            description: 'Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)'
+                              properties:
+                                product_id:
+                                  type: integer
+                                  description: The ID of the product
+                                price:
+                                  type: number
+                                  description: The price of the product
+                                currency:
+                                  type: string
+                                  description: The currency of the price
+                                cost:
+                                  type: number
+                                  description: The cost of the product
+                                direct_cost:
+                                  type: number
+                                  nullable: true
+                                  description: The direct cost of the product
+                                notes:
+                                  type: string
+                                  description: The notes about the price
               example:
                 success: true
                 data:
@@ -14332,7 +14626,7 @@ paths:
                           - type: object
                             properties:
                               id:
-                                type: number
+                                type: integer
                                 description: The ID of the product
                               name:
                                 type: string
@@ -14366,11 +14660,24 @@ paths:
                                 description: Visibility of the product
                               owner_id:
                                 type: integer
-                                description: Information about the Pipedrive user who owns the product
+                                description: The ID of the Pipedrive user who owns the product
+                              add_time:
+                                type: string
+                                description: The date and time when the product was added
+                              update_time:
+                                type: string
+                                description: The date and time when the product was last updated
+                              description:
+                                type: string
+                                description: The description of the product
+                              category:
+                                type: string
+                                nullable: true
+                                description: The category of the product
                               custom_fields:
                                 type: object
                                 additionalProperties: true
-                                description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+                                description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
                           - type: object
                             properties:
                               billing_frequency:
@@ -14410,9 +14717,29 @@ paths:
                         properties:
                           prices:
                             type: array
+                            description: The prices of the product in different currencies
                             items:
                               type: object
-                            description: 'Array of objects, each containing: product_id (number), currency (string), price (number), cost (number), direct_cost (number | null), notes (string)'
+                              properties:
+                                product_id:
+                                  type: integer
+                                  description: The ID of the product
+                                price:
+                                  type: number
+                                  description: The price of the product
+                                currency:
+                                  type: string
+                                  description: The currency of the price
+                                cost:
+                                  type: number
+                                  description: The cost of the product
+                                direct_cost:
+                                  type: number
+                                  nullable: true
+                                  description: The direct cost of the product
+                                notes:
+                                  type: string
+                                  description: The notes about the price
               example:
                 success: true
                 data:
@@ -14498,7 +14825,7 @@ paths:
                       type: object
                       properties:
                         id:
-                          type: number
+                          type: integer
                           description: The ID of the product variation
                         name:
                           type: string
@@ -14584,7 +14911,7 @@ paths:
                     type: object
                     properties:
                       id:
-                        type: number
+                        type: integer
                         description: The ID of the product variation
                       name:
                         type: string
@@ -14666,7 +14993,7 @@ paths:
                     type: object
                     properties:
                       id:
-                        type: number
+                        type: integer
                         description: The ID of the product variation
                       name:
                         type: string
@@ -14855,7 +15182,7 @@ paths:
                         type: integer
                         description: The ID of the product image
                       product_id:
-                        type: number
+                        type: integer
                         description: The ID of the product associated
                       company_id:
                         type: string
@@ -14920,7 +15247,7 @@ paths:
                         type: integer
                         description: The ID of the product image
                       product_id:
-                        type: number
+                        type: integer
                         description: The ID of the product associated
                       company_id:
                         type: string
@@ -15082,8 +15409,10 @@ paths:
                             type: object
                             properties:
                               id:
-                                type: integer
-                                description: The option ID
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
                               label:
                                 type: string
                                 description: The option display label
@@ -15145,7 +15474,6 @@ paths:
                 data:
                   - field_name: Product Name
                     field_code: name
-                    description: The name of the product
                     field_type: varchar
                     options: null
                     subfields: null
@@ -15156,7 +15484,6 @@ paths:
                       details_visible_flag: true
                   - field_name: Price
                     field_code: 40characterhashforcustomfieldidentifier
-                    description: The price of the product
                     field_type: monetary
                     options: null
                     subfields:
@@ -15173,7 +15500,6 @@ paths:
                       details_visible_flag: true
                   - field_name: Categories
                     field_code: 40characterhashforcustomfieldcategories
-                    description: Product categories for classification
                     field_type: set
                     options:
                       - id: 1
@@ -15264,10 +15590,6 @@ paths:
                       type: boolean
                       description: Whether the field is shown in the product details view. Default is true.
                       default: true
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Create one product field
@@ -15339,8 +15661,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -15395,7 +15719,6 @@ paths:
                 data:
                   field_name: Categories
                   field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
-                  description: Product categories for classification
                   field_type: set
                   options:
                     - id: 1
@@ -15512,8 +15835,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -15568,7 +15893,6 @@ paths:
                 data:
                   field_name: Product Name
                   field_code: name
-                  description: The name of the product
                   field_type: varchar
                   options: null
                   subfields: null
@@ -15622,10 +15946,6 @@ paths:
                       type: boolean
                       description: Whether the field is shown in the product details view. Default is true.
                       default: true
-                description:
-                  type: string
-                  nullable: true
-                  description: Field description
       responses:
         '200':
           description: Get one product field
@@ -15697,8 +16017,10 @@ paths:
                           type: object
                           properties:
                             id:
-                              type: integer
-                              description: The option ID
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
                             label:
                               type: string
                               description: The option display label
@@ -15753,7 +16075,6 @@ paths:
                 data:
                   field_name: Product Name
                   field_code: name
-                  description: The name of the product
                   field_type: varchar
                   options: null
                   subfields: null
@@ -15833,7 +16154,6 @@ paths:
                 data:
                   field_name: Custom text field
                   field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
-                  description: A custom text field
                   field_type: varchar
                   options: null
                   subfields: null
@@ -17937,6 +18257,4071 @@ paths:
                   is_deal_probability_enabled: true
                   add_time: '2024-01-01T00:00:00Z'
                   update_time: '2024-01-01T00:00:00Z'
+  /projectFields:
+    get:
+      summary: Get all project fields
+      description: Returns metadata about all project fields in the company.
+      x-token-cost: 10
+      operationId: getProjectFields
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+            - 'project-fields:full'
+      parameters:
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+      responses:
+        '200':
+          description: Get all project fields
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request was successful
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - field_name
+                        - field_code
+                        - field_type
+                        - is_custom_field
+                        - is_optional_response_field
+                      properties:
+                        field_name:
+                          type: string
+                          description: The display name/label of the field
+                        field_code:
+                          type: string
+                          description: The unique identifier for the field (40-character hash for custom fields)
+                        field_type:
+                          type: string
+                          description: The type of the field
+                          enum:
+                            - int
+                            - double
+                            - boolean
+                            - varchar
+                            - text
+                            - phone
+                            - varchar_options
+                            - varchar_auto
+                            - date
+                            - daterange
+                            - time
+                            - timerange
+                            - enum
+                            - set
+                            - address
+                            - monetary
+                            - deal
+                            - deals
+                            - lead
+                            - org
+                            - people
+                            - project
+                            - stage
+                            - user
+                            - activity
+                            - json
+                            - picture
+                            - status
+                            - visible_to
+                            - price_list
+                            - billing_frequency
+                            - projects_board
+                            - projects_phase
+                        options:
+                          type: array
+                          nullable: true
+                          description: 'Array of available options for enum/set fields, null for other field types'
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                oneOf:
+                                  - type: integer
+                                  - type: string
+                                description: 'The option ID (integer for custom fields, string for built-in fields)'
+                              label:
+                                type: string
+                                description: The option display label
+                              color:
+                                type: string
+                                nullable: true
+                                description: Optional color code for the option
+                              update_time:
+                                type: string
+                                format: date-time
+                                nullable: true
+                                description: When the option was last updated
+                              add_time:
+                                type: string
+                                format: date-time
+                                nullable: true
+                                description: When the option was created
+                        subfields:
+                          type: array
+                          nullable: true
+                          description: 'Array of subfields for complex field types (address, monetary), null for simple field types'
+                          items:
+                            type: object
+                            properties:
+                              field_code:
+                                type: string
+                                description: The subfield identifier
+                              field_name:
+                                type: string
+                                description: The subfield display name
+                              field_type:
+                                type: string
+                                description: The subfield type
+                        is_custom_field:
+                          type: boolean
+                          description: Whether this is a user-created custom field
+                        is_optional_response_field:
+                          type: boolean
+                          description: Whether this field is not returned by default in entity responses
+                        ui_visibility:
+                          type: object
+                          description: UI visibility settings (only included when requested via include_fields parameter)
+                          properties:
+                            add_visible_flag:
+                              type: boolean
+                              description: Whether the field is shown in the add modal
+                            details_visible_flag:
+                              type: boolean
+                              description: Whether the field is shown in the details view
+                        important_fields:
+                          type: object
+                          description: Important fields configuration
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether the field is marked as important
+                            stage_ids:
+                              type: array
+                              items:
+                                type: integer
+                              description: Array of deal stage IDs where the field is important
+                        required_fields:
+                          type: object
+                          description: Required fields configuration
+                          properties:
+                            enabled:
+                              type: boolean
+                              description: Whether the field is required
+                  additional_data:
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        nullable: true
+                        description: 'Base64url-encoded cursor for fetching the next page of results, null if no more pages'
+              example:
+                success: true
+                data:
+                  - field_name: Project Name
+                    field_code: name
+                    field_type: varchar
+                    options: null
+                    subfields: null
+                    is_custom_field: false
+                    is_optional_response_field: false
+                    ui_visibility:
+                      add_visible_flag: true
+                      details_visible_flag: true
+                    important_fields:
+                      enabled: false
+                      stage_ids: []
+                    required_fields:
+                      enabled: true
+                  - field_name: Category
+                    field_code: 40characterhashforcustomfieldidentifier
+                    field_type: enum
+                    options:
+                      - id: 1
+                        label: Internal
+                      - id: 2
+                        label: External
+                      - id: 3
+                        label: Research
+                    subfields: null
+                    is_custom_field: true
+                    is_optional_response_field: false
+                    ui_visibility:
+                      add_visible_flag: true
+                      details_visible_flag: true
+                    important_fields:
+                      enabled: false
+                      stage_ids: []
+                    required_fields:
+                      enabled: false
+                additional_data:
+                  next_cursor: eyJmaWVsZCI6ImlkIiwiZmllbGRWYWx1ZSI6Nywic29ydERpcmVjdGlvbiI6ImFzYyIsImlkIjo3fQ
+    post:
+      summary: Create one project field
+      description: Creates a new project custom field.
+      x-token-cost: 5
+      operationId: addProjectField
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - field_name
+                - field_type
+              properties:
+                field_name:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: Field name
+                field_type:
+                  type: string
+                  description: 'The type of the field<table><tr><th>Value</th><th>Description</th></tr><tr><td>`varchar`</td><td>Text (up to 255 characters)</td><tr><td>`varchar_auto`</td><td>Autocomplete text (up to 255 characters)</td><tr><td>`text`</td><td>Long text (up to 65k characters)</td><tr><td>`double`</td><td>Numeric value</td><tr><td>`monetary`</td><td>Monetary field (has a numeric value and a currency value)</td><tr><td>`date`</td><td>Date (format YYYY-MM-DD)</td><tr><td>`set`</td><td>Options field with a possibility of having multiple chosen options</td><tr><td>`enum`</td><td>Options field with a single possible chosen option</td><tr><td>`user`</td><td>User field (contains a user ID of another Pipedrive user)</td><tr><td>`org`</td><td>Organization field (contains an organization ID which is stored on the same account)</td><tr><td>`people`</td><td>Person field (contains a person ID which is stored on the same account)</td><tr><td>`phone`</td><td>Phone field (up to 255 numbers and/or characters)</td><tr><td>`time`</td><td>Time field (format HH:MM:SS)</td><tr><td>`timerange`</td><td>Time-range field (has a start time and end time value, both HH:MM:SS)</td><tr><td>`daterange`</td><td>Date-range field (has a start date and end date value, both YYYY-MM-DD)</td><tr><td>`address`</td><td>Address field</dd></table>'
+                  enum:
+                    - varchar
+                    - text
+                    - double
+                    - phone
+                    - date
+                    - daterange
+                    - time
+                    - timerange
+                    - set
+                    - enum
+                    - varchar_auto
+                    - address
+                    - monetary
+                    - org
+                    - people
+                    - user
+                options:
+                  type: array
+                  description: Field options (required for enum and set field types)
+                  items:
+                    type: object
+                    required:
+                      - label
+                    properties:
+                      label:
+                        type: string
+                        description: The option label
+                ui_visibility:
+                  type: object
+                  description: UI visibility settings for the field. Controls where the field appears in the Pipedrive web UI.
+                  additionalProperties: true
+                  properties:
+                    add_visible_flag:
+                      type: boolean
+                      description: Whether the field is shown in the add project modal. Default is false.
+                      default: false
+                    details_visible_flag:
+                      type: boolean
+                      description: Whether the field is shown in the project details view. Default is true.
+                      default: true
+                important_fields:
+                  type: object
+                  description: Configuration for highlighting the field at specific stages.
+                  additionalProperties: true
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: 'Whether the field is marked as important. When false, the field is not highlighted. When true with empty stage_ids, the field is important everywhere. When true with specific stage_ids, the field is important only at those deal stages. Default is false.'
+                      default: false
+                    stage_ids:
+                      type: array
+                      items:
+                        type: integer
+                      description: 'Array of deal stage IDs where this project field should be highlighted as important. Must reference valid, active deal stages. Empty array when enabled is false.'
+                      default: []
+                required_fields:
+                  type: object
+                  description: Required fields configuration for marking the field as mandatory when interacted with in the Pipedrive web UI.
+                  additionalProperties: true
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating projects. Default is false.'
+                      default: false
+      responses:
+        '200':
+          description: Create one project field
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request was successful
+                  data:
+                    type: object
+                    required:
+                      - field_name
+                      - field_code
+                      - field_type
+                      - is_custom_field
+                      - is_optional_response_field
+                    properties:
+                      field_name:
+                        type: string
+                        description: The display name/label of the field
+                      field_code:
+                        type: string
+                        description: The unique identifier for the field (40-character hash for custom fields)
+                      field_type:
+                        type: string
+                        description: The type of the field
+                        enum:
+                          - int
+                          - double
+                          - boolean
+                          - varchar
+                          - text
+                          - phone
+                          - varchar_options
+                          - varchar_auto
+                          - date
+                          - daterange
+                          - time
+                          - timerange
+                          - enum
+                          - set
+                          - address
+                          - monetary
+                          - deal
+                          - deals
+                          - lead
+                          - org
+                          - people
+                          - project
+                          - stage
+                          - user
+                          - activity
+                          - json
+                          - picture
+                          - status
+                          - visible_to
+                          - price_list
+                          - billing_frequency
+                          - projects_board
+                          - projects_phase
+                      options:
+                        type: array
+                        nullable: true
+                        description: 'Array of available options for enum/set fields, null for other field types'
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
+                            label:
+                              type: string
+                              description: The option display label
+                            color:
+                              type: string
+                              nullable: true
+                              description: Optional color code for the option
+                            update_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was last updated
+                            add_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was created
+                      subfields:
+                        type: array
+                        nullable: true
+                        description: 'Array of subfields for complex field types (address, monetary), null for simple field types'
+                        items:
+                          type: object
+                          properties:
+                            field_code:
+                              type: string
+                              description: The subfield identifier
+                            field_name:
+                              type: string
+                              description: The subfield display name
+                            field_type:
+                              type: string
+                              description: The subfield type
+                      is_custom_field:
+                        type: boolean
+                        description: Whether this is a user-created custom field
+                      is_optional_response_field:
+                        type: boolean
+                        description: Whether this field is not returned by default in entity responses
+                      ui_visibility:
+                        type: object
+                        description: UI visibility settings (only included when requested via include_fields parameter)
+                        properties:
+                          add_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the add modal
+                          details_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the details view
+                      important_fields:
+                        type: object
+                        description: Important fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is marked as important
+                          stage_ids:
+                            type: array
+                            items:
+                              type: integer
+                            description: Array of deal stage IDs where the field is important
+                      required_fields:
+                        type: object
+                        description: Required fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is required
+              example:
+                success: true
+                data:
+                  field_name: Category
+                  field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
+                  field_type: enum
+                  options:
+                    - id: 1
+                      label: Internal
+                    - id: 2
+                      label: External
+                    - id: 3
+                      label: Research
+                  subfields: null
+                  is_custom_field: true
+                  is_optional_response_field: false
+                  ui_visibility:
+                    add_visible_flag: true
+                    details_visible_flag: true
+                  important_fields:
+                    enabled: false
+                    stage_ids: []
+                  required_fields:
+                    enabled: false
+  '/projectFields/{field_code}':
+    get:
+      summary: Get one project field
+      description: Returns metadata about a specific project field.
+      x-token-cost: 1
+      operationId: getProjectField
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Get one project field
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request was successful
+                  data:
+                    type: object
+                    required:
+                      - field_name
+                      - field_code
+                      - field_type
+                      - is_custom_field
+                      - is_optional_response_field
+                    properties:
+                      field_name:
+                        type: string
+                        description: The display name/label of the field
+                      field_code:
+                        type: string
+                        description: The unique identifier for the field (40-character hash for custom fields)
+                      field_type:
+                        type: string
+                        description: The type of the field
+                        enum:
+                          - int
+                          - double
+                          - boolean
+                          - varchar
+                          - text
+                          - phone
+                          - varchar_options
+                          - varchar_auto
+                          - date
+                          - daterange
+                          - time
+                          - timerange
+                          - enum
+                          - set
+                          - address
+                          - monetary
+                          - deal
+                          - deals
+                          - lead
+                          - org
+                          - people
+                          - project
+                          - stage
+                          - user
+                          - activity
+                          - json
+                          - picture
+                          - status
+                          - visible_to
+                          - price_list
+                          - billing_frequency
+                          - projects_board
+                          - projects_phase
+                      options:
+                        type: array
+                        nullable: true
+                        description: 'Array of available options for enum/set fields, null for other field types'
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
+                            label:
+                              type: string
+                              description: The option display label
+                            color:
+                              type: string
+                              nullable: true
+                              description: Optional color code for the option
+                            update_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was last updated
+                            add_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was created
+                      subfields:
+                        type: array
+                        nullable: true
+                        description: 'Array of subfields for complex field types (address, monetary), null for simple field types'
+                        items:
+                          type: object
+                          properties:
+                            field_code:
+                              type: string
+                              description: The subfield identifier
+                            field_name:
+                              type: string
+                              description: The subfield display name
+                            field_type:
+                              type: string
+                              description: The subfield type
+                      is_custom_field:
+                        type: boolean
+                        description: Whether this is a user-created custom field
+                      is_optional_response_field:
+                        type: boolean
+                        description: Whether this field is not returned by default in entity responses
+                      ui_visibility:
+                        type: object
+                        description: UI visibility settings (only included when requested via include_fields parameter)
+                        properties:
+                          add_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the add modal
+                          details_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the details view
+                      important_fields:
+                        type: object
+                        description: Important fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is marked as important
+                          stage_ids:
+                            type: array
+                            items:
+                              type: integer
+                            description: Array of deal stage IDs where the field is important
+                      required_fields:
+                        type: object
+                        description: Required fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is required
+              example:
+                success: true
+                data:
+                  field_name: Project Name
+                  field_code: name
+                  field_type: varchar
+                  options: null
+                  subfields: null
+                  is_custom_field: false
+                  is_optional_response_field: false
+                  ui_visibility:
+                    add_visible_flag: true
+                    details_visible_flag: true
+                  important_fields:
+                    enabled: false
+                    stage_ids: []
+                  required_fields:
+                    enabled: true
+    patch:
+      summary: Update one project field
+      description: Updates a project custom field. The field_code and field_type cannot be changed. At least one field must be provided in the request body.
+      x-token-cost: 5
+      operationId: updateProjectField
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                field_name:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: Field name
+                ui_visibility:
+                  type: object
+                  description: UI visibility settings for the field. Controls where the field appears in the Pipedrive web UI.
+                  additionalProperties: true
+                  properties:
+                    add_visible_flag:
+                      type: boolean
+                      description: Whether the field is shown in the add project modal. Default is false.
+                      default: false
+                    details_visible_flag:
+                      type: boolean
+                      description: Whether the field is shown in the project details view. Default is true.
+                      default: true
+                important_fields:
+                  type: object
+                  description: Configuration for highlighting the field at specific stages.
+                  additionalProperties: true
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: 'Whether the field is marked as important. When false, the field is not highlighted. When true with empty stage_ids, the field is important everywhere. When true with specific stage_ids, the field is important only at those deal stages. Default is false.'
+                      default: false
+                    stage_ids:
+                      type: array
+                      items:
+                        type: integer
+                      description: 'Array of deal stage IDs where this project field should be highlighted as important. Must reference valid, active deal stages. Empty array when enabled is false.'
+                      default: []
+                required_fields:
+                  type: object
+                  description: Required fields configuration for marking the field as mandatory when interacted with in the Pipedrive web UI.
+                  additionalProperties: true
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: 'Whether the field is required. When false, the field is optional. When true, the field is required when creating or updating projects. Default is false.'
+                      default: false
+      responses:
+        '200':
+          description: Get one project field
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request was successful
+                  data:
+                    type: object
+                    required:
+                      - field_name
+                      - field_code
+                      - field_type
+                      - is_custom_field
+                      - is_optional_response_field
+                    properties:
+                      field_name:
+                        type: string
+                        description: The display name/label of the field
+                      field_code:
+                        type: string
+                        description: The unique identifier for the field (40-character hash for custom fields)
+                      field_type:
+                        type: string
+                        description: The type of the field
+                        enum:
+                          - int
+                          - double
+                          - boolean
+                          - varchar
+                          - text
+                          - phone
+                          - varchar_options
+                          - varchar_auto
+                          - date
+                          - daterange
+                          - time
+                          - timerange
+                          - enum
+                          - set
+                          - address
+                          - monetary
+                          - deal
+                          - deals
+                          - lead
+                          - org
+                          - people
+                          - project
+                          - stage
+                          - user
+                          - activity
+                          - json
+                          - picture
+                          - status
+                          - visible_to
+                          - price_list
+                          - billing_frequency
+                          - projects_board
+                          - projects_phase
+                      options:
+                        type: array
+                        nullable: true
+                        description: 'Array of available options for enum/set fields, null for other field types'
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              oneOf:
+                                - type: integer
+                                - type: string
+                              description: 'The option ID (integer for custom fields, string for built-in fields)'
+                            label:
+                              type: string
+                              description: The option display label
+                            color:
+                              type: string
+                              nullable: true
+                              description: Optional color code for the option
+                            update_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was last updated
+                            add_time:
+                              type: string
+                              format: date-time
+                              nullable: true
+                              description: When the option was created
+                      subfields:
+                        type: array
+                        nullable: true
+                        description: 'Array of subfields for complex field types (address, monetary), null for simple field types'
+                        items:
+                          type: object
+                          properties:
+                            field_code:
+                              type: string
+                              description: The subfield identifier
+                            field_name:
+                              type: string
+                              description: The subfield display name
+                            field_type:
+                              type: string
+                              description: The subfield type
+                      is_custom_field:
+                        type: boolean
+                        description: Whether this is a user-created custom field
+                      is_optional_response_field:
+                        type: boolean
+                        description: Whether this field is not returned by default in entity responses
+                      ui_visibility:
+                        type: object
+                        description: UI visibility settings (only included when requested via include_fields parameter)
+                        properties:
+                          add_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the add modal
+                          details_visible_flag:
+                            type: boolean
+                            description: Whether the field is shown in the details view
+                      important_fields:
+                        type: object
+                        description: Important fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is marked as important
+                          stage_ids:
+                            type: array
+                            items:
+                              type: integer
+                            description: Array of deal stage IDs where the field is important
+                      required_fields:
+                        type: object
+                        description: Required fields configuration
+                        properties:
+                          enabled:
+                            type: boolean
+                            description: Whether the field is required
+              example:
+                success: true
+                data:
+                  field_name: Project Name
+                  field_code: name
+                  field_type: varchar
+                  options: null
+                  subfields: null
+                  is_custom_field: false
+                  is_optional_response_field: false
+                  ui_visibility:
+                    add_visible_flag: true
+                    details_visible_flag: true
+                  important_fields:
+                    enabled: false
+                    stage_ids: []
+                  required_fields:
+                    enabled: true
+    delete:
+      summary: Delete one project field
+      description: Marks a custom field as deleted.
+      x-token-cost: 3
+      operationId: deleteProjectField
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Delete one project field
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request was successful
+                  data:
+                    type: object
+                    required:
+                      - field_name
+                      - field_code
+                      - field_type
+                      - is_custom_field
+                      - is_optional_response_field
+                    properties:
+                      field_name:
+                        type: string
+                        description: The display name/label of the field
+                      field_code:
+                        type: string
+                        description: The unique identifier for the field (40-character hash for custom fields)
+                      field_type:
+                        type: string
+                        description: The type of the field
+                      options:
+                        type: array
+                        nullable: true
+                        description: 'Array of available options for enum/set fields, null for other field types'
+                        items:
+                          type: object
+                      subfields:
+                        type: array
+                        nullable: true
+                        description: 'Array of subfields for complex field types, null for simple field types'
+                        items:
+                          type: object
+                      is_custom_field:
+                        type: boolean
+                        description: Whether this is a user-created custom field
+                      is_optional_response_field:
+                        type: boolean
+                        description: Whether this field is not returned by default in entity responses
+              example:
+                success: true
+                data:
+                  field_name: Custom text field
+                  field_code: 946947d1b02fd3ef20798d6112ec5d895a686a21
+                  field_type: varchar
+                  options: null
+                  subfields: null
+                  is_custom_field: true
+                  is_optional_response_field: false
+  '/projectFields/{field_code}/options':
+    post:
+      summary: Add project field options in bulk
+      description: Adds new options to a project custom field that supports options (enum or set field types). This operation is atomic - all options are added or none are added. Returns only the newly added options.
+      x-token-cost: 5
+      operationId: addProjectFieldOptions
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: Array of options to add. Each item must contain a label. At least one option is required.
+              items:
+                type: object
+                required:
+                  - label
+                properties:
+                  label:
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    description: The display label for the new option
+      responses:
+        '200':
+          description: Field options operation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - label
+                      properties:
+                        id:
+                          type: integer
+                          description: The unique identifier of the option
+                        label:
+                          type: string
+                          description: The display label of the option
+                  additional_data:
+                    type: object
+                    nullable: true
+              example:
+                success: true
+                data:
+                  - id: 4
+                    label: Research & Development
+                additional_data: null
+    delete:
+      summary: Delete project field options in bulk
+      description: Removes existing options from a project custom field. This operation is atomic and fails if any of the specified option IDs do not exist. Returns only the deleted options.
+      x-token-cost: 3
+      operationId: deleteProjectFieldOptions
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: Array of option IDs to delete. Each item must contain an ID of the option to delete. At least one option ID is required. The entire request fails if any option does not exist.
+              items:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: integer
+                    description: The unique identifier of the option to delete
+      responses:
+        '200':
+          description: Field options operation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - label
+                      properties:
+                        id:
+                          type: integer
+                          description: The unique identifier of the option
+                        label:
+                          type: string
+                          description: The display label of the option
+                  additional_data:
+                    type: object
+                    nullable: true
+              example:
+                success: true
+                data:
+                  - id: 4
+                    label: Research & Development
+                additional_data: null
+    patch:
+      summary: Update project field options in bulk
+      description: Updates existing options for a project custom field. This operation is atomic and fails if any of the specified option IDs do not exist. Returns only the updated options.
+      x-token-cost: 5
+      operationId: updateProjectFieldOptions
+      tags:
+        - ProjectFields
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'project-fields:full'
+      parameters:
+        - in: path
+          name: field_code
+          description: The unique code identifying the field
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              description: Array of options to update. Each item must contain an ID and the updated label. At least one option is required. The entire request fails if any option does not exist.
+              items:
+                type: object
+                required:
+                  - id
+                  - label
+                properties:
+                  id:
+                    type: integer
+                    description: The unique identifier of the option to update
+                  label:
+                    type: string
+                    minLength: 1
+                    maxLength: 255
+                    description: The new display label for the option
+      responses:
+        '200':
+          description: Field options operation result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - id
+                        - label
+                      properties:
+                        id:
+                          type: integer
+                          description: The unique identifier of the option
+                        label:
+                          type: string
+                          description: The display label of the option
+                  additional_data:
+                    type: object
+                    nullable: true
+              example:
+                success: true
+                data:
+                  - id: 4
+                    label: Research & Development
+                additional_data: null
+  /projects:
+    get:
+      summary: Get all projects
+      description: Returns all non-archived projects.
+      x-token-cost: 10
+      operationId: getProjects
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: query
+          name: filter_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects matching the specified filter are returned'
+        - in: query
+          name: status
+          schema:
+            type: string
+            example: 'open,completed'
+          description: 'If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.'
+        - in: query
+          name: phase_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects in the specified phase are returned'
+        - in: query
+          name: deal_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects associated with the specified deal are returned'
+        - in: query
+          name: person_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects associated with the specified person are returned'
+        - in: query
+          name: org_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects associated with the specified organization are returned'
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+      responses:
+        '200':
+          description: Get all projects
+          content:
+            application/json:
+              schema:
+                type: object
+                title: GetProjectsResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        description: Projects array
+                        items:
+                          title: Project
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: The ID of the project
+                            title:
+                              type: string
+                              description: The title of the project
+                            description:
+                              type: string
+                              description: The description of the project
+                            status:
+                              type: string
+                              description: The status of the project
+                            board_id:
+                              type: integer
+                              description: The ID of the board this project is associated with
+                            phase_id:
+                              type: integer
+                              description: The ID of the phase this project is associated with
+                            owner_id:
+                              type: integer
+                              description: The ID of the user who owns the project
+                            start_date:
+                              type: string
+                              format: date
+                              description: 'The start date of the project. Format: YYYY-MM-DD'
+                            end_date:
+                              type: string
+                              format: date
+                              description: 'The end date of the project. Format: YYYY-MM-DD'
+                            deal_ids:
+                              type: array
+                              description: An array of IDs of the deals this project is associated with
+                              items:
+                                type: integer
+                            person_ids:
+                              type: array
+                              description: An array of IDs of the persons this project is associated with
+                              items:
+                                type: integer
+                            org_ids:
+                              type: array
+                              description: An array of IDs of the organizations this project is associated with
+                              items:
+                                type: integer
+                            label_ids:
+                              type: array
+                              description: An array of IDs of the labels this project has
+                              items:
+                                type: integer
+                            health_status:
+                              type: integer
+                              description: The health status of the project
+                              nullable: true
+                            add_time:
+                              type: string
+                              description: The creation date and time of the project in ISO 8601 format
+                            update_time:
+                              type: string
+                              description: The last updated date and time of the project in ISO 8601 format
+                            status_change_time:
+                              type: string
+                              description: The date and time of the last status change of the project in ISO 8601 format
+                            archive_time:
+                              type: string
+                              nullable: true
+                              description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                            custom_fields:
+                              type: object
+                              additionalProperties: true
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+                      additional_data:
+                        type: object
+                        description: The additional data of the list
+                        properties:
+                          next_cursor:
+                            type: string
+                            description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  - id: 3
+                    title: Project
+                    description: Description
+                    status: open
+                    board_id: 1
+                    phase_id: 1
+                    owner_id: 1
+                    start_date: '2026-04-15'
+                    end_date: '2026-04-23'
+                    deal_ids:
+                      - 1
+                    person_ids:
+                      - 1
+                    org_ids:
+                      - 1
+                    label_ids:
+                      - 1
+                    health_status: 10
+                    add_time: '2026-04-14T10:45:20.852Z'
+                    update_time: '2026-04-14T10:45:20.852Z'
+                    status_change_time: '2026-04-14T10:45:20.852Z'
+                    archive_time: null
+                    custom_fields: {}
+                additional_data:
+                  next_cursor: eyJmaWVsZCI6ImlkIiwiZmllbGRWYWx1ZSI6Nywic29ydERpcmVjdGlvbiI6ImFzYyIsImlkIjo3fQ
+    post:
+      summary: Add a project
+      description: Adds a new project. Custom fields should be wrapped in the `custom_fields` object.
+      x-token-cost: 5
+      operationId: addProject
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - title
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: The title of the project
+                description:
+                  type: string
+                  description: The description of the project
+                status:
+                  type: string
+                  description: The status of the project
+                board_id:
+                  type: integer
+                  description: The ID of the board this project is associated with
+                phase_id:
+                  type: integer
+                  description: The ID of the phase this project is associated with
+                owner_id:
+                  type: integer
+                  description: The ID of the user who owns the project
+                start_date:
+                  type: string
+                  format: date
+                  description: 'The start date of the project. Format: YYYY-MM-DD'
+                end_date:
+                  type: string
+                  format: date
+                  description: 'The end date of the project. Format: YYYY-MM-DD'
+                deal_ids:
+                  type: array
+                  description: An array of IDs of the deals this project is associated with
+                  items:
+                    type: integer
+                person_ids:
+                  type: array
+                  description: An array of IDs of the persons this project is associated with
+                  items:
+                    type: integer
+                org_ids:
+                  type: array
+                  description: An array of IDs of the organizations this project is associated with
+                  items:
+                    type: integer
+                label_ids:
+                  type: array
+                  description: An array of IDs of the labels this project has
+                  items:
+                    type: integer
+                health_status:
+                  type: integer
+                  description: The health status of the project
+                template_id:
+                  type: integer
+                  description: The ID of the template the project will be based on. Only used when creating a new project.
+                custom_fields:
+                  type: object
+                  additionalProperties: true
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+      responses:
+        '201':
+          description: Add project
+          content:
+            application/json:
+              schema:
+                type: object
+                title: UpsertProjectResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        title: Project
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: The ID of the project
+                          title:
+                            type: string
+                            description: The title of the project
+                          description:
+                            type: string
+                            description: The description of the project
+                          status:
+                            type: string
+                            description: The status of the project
+                          board_id:
+                            type: integer
+                            description: The ID of the board this project is associated with
+                          phase_id:
+                            type: integer
+                            description: The ID of the phase this project is associated with
+                          owner_id:
+                            type: integer
+                            description: The ID of the user who owns the project
+                          start_date:
+                            type: string
+                            format: date
+                            description: 'The start date of the project. Format: YYYY-MM-DD'
+                          end_date:
+                            type: string
+                            format: date
+                            description: 'The end date of the project. Format: YYYY-MM-DD'
+                          deal_ids:
+                            type: array
+                            description: An array of IDs of the deals this project is associated with
+                            items:
+                              type: integer
+                          person_ids:
+                            type: array
+                            description: An array of IDs of the persons this project is associated with
+                            items:
+                              type: integer
+                          org_ids:
+                            type: array
+                            description: An array of IDs of the organizations this project is associated with
+                            items:
+                              type: integer
+                          label_ids:
+                            type: array
+                            description: An array of IDs of the labels this project has
+                            items:
+                              type: integer
+                          health_status:
+                            type: integer
+                            description: The health status of the project
+                            nullable: true
+                          add_time:
+                            type: string
+                            description: The creation date and time of the project in ISO 8601 format
+                          update_time:
+                            type: string
+                            description: The last updated date and time of the project in ISO 8601 format
+                          status_change_time:
+                            type: string
+                            description: The date and time of the last status change of the project in ISO 8601 format
+                          archive_time:
+                            type: string
+                            nullable: true
+                            description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                          custom_fields:
+                            type: object
+                            additionalProperties: true
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+              example:
+                success: true
+                data:
+                  id: 3
+                  title: Project
+                  description: Description
+                  status: open
+                  board_id: 1
+                  phase_id: 1
+                  owner_id: 1
+                  start_date: '2026-04-15'
+                  end_date: '2026-04-23'
+                  deal_ids:
+                    - 1
+                  person_ids:
+                    - 1
+                  org_ids:
+                    - 1
+                  label_ids:
+                    - 1
+                  health_status: 10
+                  add_time: '2026-04-14T10:45:20.852Z'
+                  update_time: '2026-04-14T10:45:20.852Z'
+                  status_change_time: '2026-04-14T10:45:20.852Z'
+                  archive_time: null
+                  custom_fields: {}
+  /projects/archived:
+    get:
+      summary: Get all archived projects
+      description: Returns all archived projects.
+      x-token-cost: 10
+      operationId: getArchivedProjects
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: query
+          name: filter_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects matching the specified filter are returned'
+        - in: query
+          name: status
+          schema:
+            type: string
+            example: 'open,completed'
+          description: 'If supplied, includes only projects with the specified statuses. Possible values are `open`, `completed`, `canceled` and `deleted`. By default `deleted` projects are not returned.'
+        - in: query
+          name: phase_id
+          schema:
+            type: integer
+          description: 'If supplied, only projects in the specified phase are returned'
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+      responses:
+        '200':
+          description: Get all projects
+          content:
+            application/json:
+              schema:
+                type: object
+                title: GetProjectsResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        description: Projects array
+                        items:
+                          title: Project
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              description: The ID of the project
+                            title:
+                              type: string
+                              description: The title of the project
+                            description:
+                              type: string
+                              description: The description of the project
+                            status:
+                              type: string
+                              description: The status of the project
+                            board_id:
+                              type: integer
+                              description: The ID of the board this project is associated with
+                            phase_id:
+                              type: integer
+                              description: The ID of the phase this project is associated with
+                            owner_id:
+                              type: integer
+                              description: The ID of the user who owns the project
+                            start_date:
+                              type: string
+                              format: date
+                              description: 'The start date of the project. Format: YYYY-MM-DD'
+                            end_date:
+                              type: string
+                              format: date
+                              description: 'The end date of the project. Format: YYYY-MM-DD'
+                            deal_ids:
+                              type: array
+                              description: An array of IDs of the deals this project is associated with
+                              items:
+                                type: integer
+                            person_ids:
+                              type: array
+                              description: An array of IDs of the persons this project is associated with
+                              items:
+                                type: integer
+                            org_ids:
+                              type: array
+                              description: An array of IDs of the organizations this project is associated with
+                              items:
+                                type: integer
+                            label_ids:
+                              type: array
+                              description: An array of IDs of the labels this project has
+                              items:
+                                type: integer
+                            health_status:
+                              type: integer
+                              description: The health status of the project
+                              nullable: true
+                            add_time:
+                              type: string
+                              description: The creation date and time of the project in ISO 8601 format
+                            update_time:
+                              type: string
+                              description: The last updated date and time of the project in ISO 8601 format
+                            status_change_time:
+                              type: string
+                              description: The date and time of the last status change of the project in ISO 8601 format
+                            archive_time:
+                              type: string
+                              nullable: true
+                              description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                            custom_fields:
+                              type: object
+                              additionalProperties: true
+                              description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+                      additional_data:
+                        type: object
+                        description: The additional data of the list
+                        properties:
+                          next_cursor:
+                            type: string
+                            description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  - id: 3
+                    title: Project
+                    description: Description
+                    status: open
+                    board_id: 1
+                    phase_id: 1
+                    owner_id: 1
+                    start_date: '2026-04-15'
+                    end_date: '2026-04-23'
+                    deal_ids:
+                      - 1
+                    person_ids:
+                      - 1
+                    org_ids:
+                      - 1
+                    label_ids:
+                      - 1
+                    health_status: 10
+                    add_time: '2026-04-14T10:45:20.852Z'
+                    update_time: '2026-04-14T10:45:20.852Z'
+                    status_change_time: '2026-04-14T10:45:20.852Z'
+                    archive_time: null
+                    custom_fields: {}
+                additional_data:
+                  next_cursor: eyJmaWVsZCI6ImlkIiwiZmllbGRWYWx1ZSI6Nywic29ydERpcmVjdGlvbiI6ImFzYyIsImlkIjo3fQ
+  '/projects/{id}':
+    get:
+      summary: Get details of a project
+      description: Returns the details of a specific project. Custom fields appear as keys inside the `custom_fields` object.
+      x-token-cost: 1
+      operationId: getProject
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Get project
+          content:
+            application/json:
+              schema:
+                type: object
+                title: UpsertProjectResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        title: Project
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: The ID of the project
+                          title:
+                            type: string
+                            description: The title of the project
+                          description:
+                            type: string
+                            description: The description of the project
+                          status:
+                            type: string
+                            description: The status of the project
+                          board_id:
+                            type: integer
+                            description: The ID of the board this project is associated with
+                          phase_id:
+                            type: integer
+                            description: The ID of the phase this project is associated with
+                          owner_id:
+                            type: integer
+                            description: The ID of the user who owns the project
+                          start_date:
+                            type: string
+                            format: date
+                            description: 'The start date of the project. Format: YYYY-MM-DD'
+                          end_date:
+                            type: string
+                            format: date
+                            description: 'The end date of the project. Format: YYYY-MM-DD'
+                          deal_ids:
+                            type: array
+                            description: An array of IDs of the deals this project is associated with
+                            items:
+                              type: integer
+                          person_ids:
+                            type: array
+                            description: An array of IDs of the persons this project is associated with
+                            items:
+                              type: integer
+                          org_ids:
+                            type: array
+                            description: An array of IDs of the organizations this project is associated with
+                            items:
+                              type: integer
+                          label_ids:
+                            type: array
+                            description: An array of IDs of the labels this project has
+                            items:
+                              type: integer
+                          health_status:
+                            type: integer
+                            description: The health status of the project
+                            nullable: true
+                          add_time:
+                            type: string
+                            description: The creation date and time of the project in ISO 8601 format
+                          update_time:
+                            type: string
+                            description: The last updated date and time of the project in ISO 8601 format
+                          status_change_time:
+                            type: string
+                            description: The date and time of the last status change of the project in ISO 8601 format
+                          archive_time:
+                            type: string
+                            nullable: true
+                            description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                          custom_fields:
+                            type: object
+                            additionalProperties: true
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+              example:
+                success: true
+                data:
+                  id: 3
+                  title: Project
+                  description: Description
+                  status: open
+                  board_id: 1
+                  phase_id: 1
+                  owner_id: 1
+                  start_date: '2026-04-15'
+                  end_date: '2026-04-23'
+                  deal_ids:
+                    - 1
+                  person_ids:
+                    - 1
+                  org_ids:
+                    - 1
+                  label_ids:
+                    - 1
+                  health_status: 10
+                  add_time: '2026-04-14T10:45:20.852Z'
+                  update_time: '2026-04-14T10:45:20.852Z'
+                  status_change_time: '2026-04-14T10:45:20.852Z'
+                  archive_time: null
+                  custom_fields: {}
+    patch:
+      summary: Update a project
+      description: Updates the properties of a project.
+      x-token-cost: 5
+      operationId: updateProject
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: The title of the project
+                description:
+                  type: string
+                  description: The description of the project
+                status:
+                  type: string
+                  description: The status of the project
+                board_id:
+                  type: integer
+                  description: The ID of the board this project is associated with
+                phase_id:
+                  type: integer
+                  description: The ID of the phase this project is associated with
+                owner_id:
+                  type: integer
+                  description: The ID of the user who owns the project
+                start_date:
+                  type: string
+                  format: date
+                  description: 'The start date of the project. Format: YYYY-MM-DD'
+                end_date:
+                  type: string
+                  format: date
+                  description: 'The end date of the project. Format: YYYY-MM-DD'
+                deal_ids:
+                  type: array
+                  description: An array of IDs of the deals this project is associated with
+                  items:
+                    type: integer
+                person_ids:
+                  type: array
+                  description: An array of IDs of the persons this project is associated with
+                  items:
+                    type: integer
+                org_ids:
+                  type: array
+                  description: An array of IDs of the organizations this project is associated with
+                  items:
+                    type: integer
+                label_ids:
+                  type: array
+                  description: An array of IDs of the labels this project has
+                  items:
+                    type: integer
+                health_status:
+                  type: integer
+                  description: The health status of the project
+                template_id:
+                  type: integer
+                  description: The ID of the template the project will be based on. Only used when creating a new project.
+                custom_fields:
+                  type: object
+                  additionalProperties: true
+                  description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+      responses:
+        '200':
+          description: Update project
+          content:
+            application/json:
+              schema:
+                type: object
+                title: UpsertProjectResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        title: Project
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: The ID of the project
+                          title:
+                            type: string
+                            description: The title of the project
+                          description:
+                            type: string
+                            description: The description of the project
+                          status:
+                            type: string
+                            description: The status of the project
+                          board_id:
+                            type: integer
+                            description: The ID of the board this project is associated with
+                          phase_id:
+                            type: integer
+                            description: The ID of the phase this project is associated with
+                          owner_id:
+                            type: integer
+                            description: The ID of the user who owns the project
+                          start_date:
+                            type: string
+                            format: date
+                            description: 'The start date of the project. Format: YYYY-MM-DD'
+                          end_date:
+                            type: string
+                            format: date
+                            description: 'The end date of the project. Format: YYYY-MM-DD'
+                          deal_ids:
+                            type: array
+                            description: An array of IDs of the deals this project is associated with
+                            items:
+                              type: integer
+                          person_ids:
+                            type: array
+                            description: An array of IDs of the persons this project is associated with
+                            items:
+                              type: integer
+                          org_ids:
+                            type: array
+                            description: An array of IDs of the organizations this project is associated with
+                            items:
+                              type: integer
+                          label_ids:
+                            type: array
+                            description: An array of IDs of the labels this project has
+                            items:
+                              type: integer
+                          health_status:
+                            type: integer
+                            description: The health status of the project
+                            nullable: true
+                          add_time:
+                            type: string
+                            description: The creation date and time of the project in ISO 8601 format
+                          update_time:
+                            type: string
+                            description: The last updated date and time of the project in ISO 8601 format
+                          status_change_time:
+                            type: string
+                            description: The date and time of the last status change of the project in ISO 8601 format
+                          archive_time:
+                            type: string
+                            nullable: true
+                            description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                          custom_fields:
+                            type: object
+                            additionalProperties: true
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+              example:
+                success: true
+                data:
+                  id: 3
+                  title: Project
+                  description: Description
+                  status: open
+                  board_id: 1
+                  phase_id: 1
+                  owner_id: 1
+                  start_date: '2026-04-15'
+                  end_date: '2026-04-23'
+                  deal_ids:
+                    - 1
+                  person_ids:
+                    - 1
+                  org_ids:
+                    - 1
+                  label_ids:
+                    - 1
+                  health_status: 10
+                  add_time: '2026-04-14T10:45:20.852Z'
+                  update_time: '2026-04-14T10:45:20.852Z'
+                  status_change_time: '2026-04-14T10:45:20.852Z'
+                  archive_time: null
+                  custom_fields: {}
+    delete:
+      summary: Delete a project
+      description: Marks a project as deleted.
+      x-token-cost: 3
+      operationId: deleteProject
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Delete project
+          content:
+            application/json:
+              schema:
+                title: DeleteProjectResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the deleted project
+              example:
+                success: true
+                data:
+                  id: 3
+  /projectTemplates:
+    get:
+      summary: Get all project templates
+      description: Returns all not deleted project templates.
+      x-token-cost: 10
+      operationId: getProjectTemplates
+      tags:
+        - ProjectTemplates
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+      responses:
+        '200':
+          description: A list of project templates.
+          content:
+            application/json:
+              schema:
+                title: GetProjectTemplatesResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: array
+                    items:
+                      title: ProjectTemplate
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: The ID of the project template
+                        title:
+                          type: string
+                          description: The title of the project template
+                        description:
+                          type: string
+                          description: The description of the project template
+                        projects_board_id:
+                          type: integer
+                          description: The ID of the project board this template is associated with
+                        owner_id:
+                          type: integer
+                          description: The ID of the owner of the project template
+                        add_time:
+                          type: string
+                          description: The creation date and time of the project template in ISO 8601 format
+                        update_time:
+                          type: string
+                          description: The update date and time of the project template in ISO 8601 format
+                  additional_data:
+                    description: The additional data of the list
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  - id: 1
+                    title: Office Renovation
+                    description: Template for office renovation projects
+                    projects_board_id: 2
+                    owner_id: 3
+                    add_time: '2023-09-14T08:14:40.000Z'
+                    update_time: '2023-09-14T08:14:40.000Z'
+                additional_data:
+                  next_cursor: eyJhY3Rpdml0aWVzIjoyN30
+  '/projectTemplates/{id}':
+    get:
+      summary: Get details of a template
+      description: Returns the details of a specific project template.
+      x-token-cost: 1
+      operationId: getProjectTemplate
+      tags:
+        - ProjectTemplates
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project template
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Get a project template.
+          content:
+            application/json:
+              schema:
+                title: GetProjectTemplateResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    title: ProjectTemplate
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project template
+                      title:
+                        type: string
+                        description: The title of the project template
+                      description:
+                        type: string
+                        description: The description of the project template
+                      projects_board_id:
+                        type: integer
+                        description: The ID of the project board this template is associated with
+                      owner_id:
+                        type: integer
+                        description: The ID of the owner of the project template
+                      add_time:
+                        type: string
+                        description: The creation date and time of the project template in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the project template in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+                    example: null
+              example:
+                success: true
+                data:
+                  id: 1
+                  title: Office Renovation
+                  description: Template for office renovation projects
+                  projects_board_id: 2
+                  owner_id: 3
+                  add_time: '2023-09-14T08:14:40.000Z'
+                  update_time: '2023-09-14T08:14:40.000Z'
+                additional_data: null
+  /projects/search:
+    get:
+      summary: Search projects
+      description: 'Searches all projects by title, description, notes and/or custom fields. This endpoint is a wrapper of <a href="https://developers.pipedrive.com/docs/api/v1/ItemSearch#searchItem">/v1/itemSearch</a> with a narrower OAuth scope. Found projects can be filtered by person ID or organization ID.'
+      x-token-cost: 20
+      operationId: searchProjects
+      tags:
+        - Projects
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+            - 'search:read'
+      parameters:
+        - in: query
+          name: term
+          required: true
+          schema:
+            type: string
+          description: The search term to look for. Minimum 2 characters (or 1 if using `exact_match`). Please note that the search term has to be URL encoded.
+        - in: query
+          name: fields
+          schema:
+            type: string
+            enum:
+              - custom_fields
+              - notes
+              - title
+              - description
+          description: 'A comma-separated string array. The fields to perform the search from. Defaults to all of them. Only the following custom field types are searchable: `address`, `varchar`, `text`, `varchar_auto`, `double`, `monetary` and `phone`. Read more about searching by custom fields <a href="https://support.pipedrive.com/en/article/search-finding-what-you-need#searching-by-custom-fields" target="_blank" rel="noopener noreferrer">here</a>.'
+        - in: query
+          name: exact_match
+          schema:
+            type: boolean
+          description: 'When enabled, only full exact matches against the given term are returned. It is <b>not</b> case sensitive.'
+        - in: query
+          name: person_id
+          schema:
+            type: integer
+          description: Will filter projects by the provided person ID
+        - in: query
+          name: organization_id
+          schema:
+            type: integer
+          description: Will filter projects by the provided organization ID
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: GetProjectSearchResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            description: The array of found projects
+                            items:
+                              type: object
+                              properties:
+                                result_score:
+                                  type: number
+                                  description: Search result relevancy
+                                item:
+                                  type: object
+                                  properties:
+                                    id:
+                                      type: integer
+                                      description: The ID of the project
+                                    type:
+                                      type: string
+                                      description: The type of the item
+                                    title:
+                                      type: string
+                                      description: The title of the project
+                                    status:
+                                      type: string
+                                      nullable: true
+                                      description: The status of the project
+                                    owner:
+                                      type: object
+                                      properties:
+                                        id:
+                                          type: integer
+                                          nullable: true
+                                          description: The ID of the owner of the project
+                                    board_id:
+                                      type: integer
+                                      nullable: true
+                                      description: The ID of the board the project belongs to
+                                    phase:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        id:
+                                          type: integer
+                                          description: The ID of the phase
+                                        name:
+                                          type: string
+                                          description: The name of the phase
+                                    person:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        id:
+                                          type: integer
+                                          description: The ID of the person the project is associated with
+                                        name:
+                                          type: string
+                                          nullable: true
+                                          description: The name of the person the project is associated with
+                                    organization:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        id:
+                                          type: integer
+                                          description: The ID of the organization the project is associated with
+                                        name:
+                                          type: string
+                                          nullable: true
+                                          description: The name of the organization the project is associated with
+                                        address:
+                                          type: string
+                                          nullable: true
+                                          description: The address of the organization the project is associated with
+                                    deal:
+                                      type: object
+                                      nullable: true
+                                      properties:
+                                        id:
+                                          type: integer
+                                          description: The ID of the deal the project is associated with
+                                        title:
+                                          type: string
+                                          nullable: true
+                                          description: The title of the deal the project is associated with
+                                    deal_count:
+                                      type: integer
+                                      description: The number of deals associated with the project
+                                    description:
+                                      type: string
+                                      nullable: true
+                                      description: The description of the project
+                                    end_date:
+                                      type: string
+                                      nullable: true
+                                      description: The end date of the project
+                                    custom_fields:
+                                      type: array
+                                      items:
+                                        type: string
+                                      description: Custom fields
+                                    notes:
+                                      type: array
+                                      description: An array of notes
+                                      items:
+                                        type: string
+                      additional_data:
+                        description: The additional data of the list
+                        type: object
+                        properties:
+                          next_cursor:
+                            type: string
+                            description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  items:
+                    - result_score: 0.8412
+                      item:
+                        id: 1
+                        type: project
+                        title: Office renovation
+                        status: open
+                        owner:
+                          id: 1
+                        board_id: 2
+                        phase:
+                          id: 3
+                          name: In progress
+                        person:
+                          id: 10
+                          name: Jane Doe
+                        organization:
+                          id: 5
+                          name: Pipedrive
+                          address: null
+                        deal:
+                          id: 42
+                          title: Renovation deal
+                        deal_count: 1
+                        description: Full office renovation project
+                        end_date: '2025-12-31'
+                        custom_fields: []
+                        notes: []
+                additional_data:
+                  next_cursor: eyJmaWVsZCI6ImlkIiwiZmllbGRWYWx1ZSI6Nywic29ydERpcmVjdGlvbiI6ImFzYyIsImlkIjo3fQ
+  '/projects/{id}/archive':
+    post:
+      summary: Archive a project
+      description: Archives a project.
+      x-token-cost: 3
+      operationId: archiveProject
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Update project
+          content:
+            application/json:
+              schema:
+                type: object
+                title: UpsertProjectResponse
+                allOf:
+                  - title: baseResponse
+                    type: object
+                    properties:
+                      success:
+                        type: boolean
+                        description: If the response is successful or not
+                  - type: object
+                    properties:
+                      data:
+                        title: Project
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: The ID of the project
+                          title:
+                            type: string
+                            description: The title of the project
+                          description:
+                            type: string
+                            description: The description of the project
+                          status:
+                            type: string
+                            description: The status of the project
+                          board_id:
+                            type: integer
+                            description: The ID of the board this project is associated with
+                          phase_id:
+                            type: integer
+                            description: The ID of the phase this project is associated with
+                          owner_id:
+                            type: integer
+                            description: The ID of the user who owns the project
+                          start_date:
+                            type: string
+                            format: date
+                            description: 'The start date of the project. Format: YYYY-MM-DD'
+                          end_date:
+                            type: string
+                            format: date
+                            description: 'The end date of the project. Format: YYYY-MM-DD'
+                          deal_ids:
+                            type: array
+                            description: An array of IDs of the deals this project is associated with
+                            items:
+                              type: integer
+                          person_ids:
+                            type: array
+                            description: An array of IDs of the persons this project is associated with
+                            items:
+                              type: integer
+                          org_ids:
+                            type: array
+                            description: An array of IDs of the organizations this project is associated with
+                            items:
+                              type: integer
+                          label_ids:
+                            type: array
+                            description: An array of IDs of the labels this project has
+                            items:
+                              type: integer
+                          health_status:
+                            type: integer
+                            description: The health status of the project
+                            nullable: true
+                          add_time:
+                            type: string
+                            description: The creation date and time of the project in ISO 8601 format
+                          update_time:
+                            type: string
+                            description: The last updated date and time of the project in ISO 8601 format
+                          status_change_time:
+                            type: string
+                            description: The date and time of the last status change of the project in ISO 8601 format
+                          archive_time:
+                            type: string
+                            nullable: true
+                            description: 'The date and time the project was archived in ISO 8601 format. If not archived, this field is null.'
+                          custom_fields:
+                            type: object
+                            additionalProperties: true
+                            description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
+              example:
+                success: true
+                data:
+                  id: 3
+                  title: Project
+                  description: Description
+                  status: open
+                  board_id: 1
+                  phase_id: 1
+                  owner_id: 1
+                  start_date: '2026-04-15'
+                  end_date: '2026-04-23'
+                  deal_ids:
+                    - 1
+                  person_ids:
+                    - 1
+                  org_ids:
+                    - 1
+                  label_ids:
+                    - 1
+                  health_status: 10
+                  add_time: '2026-04-14T10:45:20.852Z'
+                  update_time: '2026-04-14T10:45:20.852Z'
+                  status_change_time: '2026-04-14T10:45:20.852Z'
+                  archive_time: null
+                  custom_fields: {}
+  '/projects/{id}/permittedUsers':
+    get:
+      summary: List permitted users
+      description: Lists the users permitted to access a project.
+      x-token-cost: 5
+      operationId: getProjectUsers
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                title: GetProjectPermittedUsersResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: array
+                    items:
+                      type: integer
+                    description: The list of permitted user IDs
+              example:
+                success: true
+                data:
+                  - 123
+                  - 456
+  '/projects/{id}/changelog':
+    get:
+      summary: List updates about project field values
+      description: Lists updates about field values of a project.
+      x-token-cost: 10
+      operationId: getProjectChangelog
+      tags:
+        - Projects
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project
+          required: true
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+      responses:
+        '200':
+          description: Get changelog of a project
+          content:
+            application/json:
+              schema:
+                title: GetProjectChangelogResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        change_source:
+                          type: string
+                          nullable: true
+                          description: 'The source of change, for example ''app'', ''mobile'', ''api'', etc.'
+                        change_source_user_agent:
+                          type: string
+                          nullable: true
+                          description: The user agent from which the change was made
+                        time:
+                          type: string
+                          description: The date and time of the change in ISO 8601 format
+                        new_values:
+                          type: object
+                          additionalProperties: true
+                          description: A map of field keys to their new values after the change
+                        old_values:
+                          type: object
+                          additionalProperties: true
+                          description: A map of field keys to their previous values before the change
+                        actor_user_id:
+                          type: integer
+                          description: The ID of the user who made the change
+                  additional_data:
+                    description: The additional data of the list
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  - change_source: app
+                    change_source_user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
+                    time: '2024-02-12T09:14:35.000Z'
+                    new_values:
+                      title: New Project Title
+                    old_values:
+                      title: Old Project Title
+                    actor_user_id: 26
+                  - change_source: api
+                    change_source_user_agent: null
+                    time: '2024-02-12T09:10:12.000Z'
+                    new_values:
+                      status: open
+                      board_id: 2
+                    old_values:
+                      status: closed
+                      board_id: 1
+                    actor_user_id: 42
+                additional_data:
+                  next_cursor: aWQ6NTQ0
+  /tasks:
+    get:
+      summary: Get all tasks
+      description: Returns all tasks.
+      x-token-cost: 10
+      operationId: getTasks
+      tags:
+        - Tasks
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: query
+          name: cursor
+          required: false
+          schema:
+            type: string
+          description: 'For pagination, the marker (an opaque string value) representing the first item on the next page'
+        - in: query
+          name: limit
+          description: 'For pagination, the limit of entries to be returned. If not provided, 100 items will be returned. Please note that a maximum value of 500 is allowed.'
+          schema:
+            type: integer
+            example: 100
+        - in: query
+          name: is_done
+          required: false
+          schema:
+            type: boolean
+          description: 'Whether the task is done or not. If omitted, both done and not done tasks are returned.'
+        - in: query
+          name: is_milestone
+          required: false
+          schema:
+            type: boolean
+          description: 'Whether the task is a milestone or not. If omitted, both milestone and non-milestone tasks are returned.'
+        - in: query
+          name: assignee_id
+          required: false
+          schema:
+            type: integer
+          description: 'If supplied, only tasks assigned to this user are returned'
+        - in: query
+          name: project_id
+          required: false
+          schema:
+            type: integer
+          description: 'If supplied, only tasks belonging to this project are returned'
+        - in: query
+          name: parent_task_id
+          required: false
+          schema:
+            type: string
+          description: 'If `null` is supplied, only root-level tasks (without a parent) are returned. If an integer is supplied, only subtasks of that specific task are returned. By default all tasks are returned.'
+      responses:
+        '200':
+          description: A list of tasks.
+          content:
+            application/json:
+              schema:
+                title: GetTasksResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: The ID of the task
+                        title:
+                          type: string
+                          minLength: 1
+                          maxLength: 255
+                          description: The title of the task
+                        creator_id:
+                          type: integer
+                          description: The ID of the user who created the task
+                        description:
+                          type: string
+                          nullable: true
+                          description: The description of the task
+                        project_id:
+                          type: integer
+                          description: The ID of the project this task is associated with
+                        is_done:
+                          type: boolean
+                          description: Whether the task is done or not.
+                        is_milestone:
+                          type: boolean
+                          description: Whether the task is a milestone or not.
+                        due_date:
+                          type: string
+                          format: date
+                          nullable: true
+                          description: 'The due date of the task. Format: YYYY-MM-DD.'
+                        start_date:
+                          type: string
+                          format: date
+                          nullable: true
+                          description: 'The start date of the task. Format: YYYY-MM-DD.'
+                        parent_task_id:
+                          type: integer
+                          nullable: true
+                          description: 'The ID of the parent task. If `null`, the task is a root-level task.'
+                        assignee_ids:
+                          type: array
+                          items:
+                            type: integer
+                          description: The IDs of users assigned to the task
+                        priority:
+                          type: integer
+                          minimum: 0
+                          nullable: true
+                          description: The priority of the task
+                        add_time:
+                          type: string
+                          description: The creation date and time of the task in ISO 8601 format
+                        update_time:
+                          type: string
+                          description: The update date and time of the task in ISO 8601 format
+                        marked_as_done_time:
+                          type: string
+                          nullable: true
+                          description: The date and time the task was marked as done in ISO 8601 format
+                  additional_data:
+                    description: The additional data of the list
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        description: The first item on the next page. The value of the `next_cursor` field will be `null` if you have reached the end of the dataset and there’s no more pages to be returned.
+              example:
+                success: true
+                data:
+                  - id: 1
+                    title: Task 1
+                    creator_id: 2
+                    description: Task description
+                    project_id: 1
+                    is_done: false
+                    is_milestone: false
+                    due_date: '2026-10-11'
+                    start_date: '2026-09-01'
+                    parent_task_id: null
+                    assignee_ids:
+                      - 2
+                      - 3
+                    priority: null
+                    add_time: '2026-09-14T08:14:40.000Z'
+                    update_time: '2026-09-14T08:14:40.000Z'
+                    marked_as_done_time: null
+                additional_data:
+                  next_cursor: eyJhY3Rpdml0aWVzIjoyN30
+    post:
+      summary: Add a task
+      description: Adds a new task.
+      x-token-cost: 5
+      operationId: addTask
+      tags:
+        - Tasks
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: addTaskRequest
+              type: object
+              required:
+                - title
+                - project_id
+              properties:
+                title:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: The title of the task
+                project_id:
+                  type: integer
+                  description: The ID of the project this task is associated with
+                parent_task_id:
+                  type: integer
+                  nullable: true
+                  description: The ID of the parent task. Cannot be the ID of a task that is already a subtask.
+                description:
+                  type: string
+                  nullable: true
+                  description: The description of the task
+                done:
+                  type: integer
+                  enum:
+                    - 0
+                    - 1
+                  description: 'Whether the task is done or not. `0` = Not done, `1` = Done.'
+                milestone:
+                  type: integer
+                  enum:
+                    - 0
+                    - 1
+                  description: 'Whether the task is a milestone or not. `0` = Not a milestone, `1` = Milestone.'
+                due_date:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: 'The due date of the task. Format: YYYY-MM-DD.'
+                start_date:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: 'The start date of the task. Format: YYYY-MM-DD.'
+                assignee_id:
+                  type: integer
+                  nullable: true
+                  description: 'The ID of the user assigned to the task. When set, the `assignee_ids` field will be overwritten with this value.'
+                assignee_ids:
+                  type: array
+                  items:
+                    type: integer
+                  maxItems: 10
+                  description: 'The IDs of users assigned to the task. When set, the `assignee_id` field will be set to the first value in this array, or `null` if empty.'
+                priority:
+                  type: integer
+                  minimum: 0
+                  nullable: true
+                  description: The priority of the task
+      responses:
+        '201':
+          description: Created task.
+          content:
+            application/json:
+              schema:
+                title: AddTaskResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the task
+                      title:
+                        type: string
+                        minLength: 1
+                        maxLength: 255
+                        description: The title of the task
+                      creator_id:
+                        type: integer
+                        description: The ID of the user who created the task
+                      description:
+                        type: string
+                        nullable: true
+                        description: The description of the task
+                      project_id:
+                        type: integer
+                        description: The ID of the project this task is associated with
+                      is_done:
+                        type: boolean
+                        description: Whether the task is done or not.
+                      is_milestone:
+                        type: boolean
+                        description: Whether the task is a milestone or not.
+                      due_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The due date of the task. Format: YYYY-MM-DD.'
+                      start_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The start date of the task. Format: YYYY-MM-DD.'
+                      parent_task_id:
+                        type: integer
+                        nullable: true
+                        description: 'The ID of the parent task. If `null`, the task is a root-level task.'
+                      assignee_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: The IDs of users assigned to the task
+                      priority:
+                        type: integer
+                        minimum: 0
+                        nullable: true
+                        description: The priority of the task
+                      add_time:
+                        type: string
+                        description: The creation date and time of the task in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the task in ISO 8601 format
+                      marked_as_done_time:
+                        type: string
+                        nullable: true
+                        description: The date and time the task was marked as done in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+                    example: null
+              example:
+                success: true
+                data:
+                  id: 1
+                  title: Task 1
+                  creator_id: 2
+                  description: Task description
+                  project_id: 1
+                  is_done: false
+                  is_milestone: false
+                  due_date: '2026-10-11'
+                  start_date: '2026-09-01'
+                  parent_task_id: null
+                  assignee_ids:
+                    - 2
+                    - 3
+                  priority: null
+                  add_time: '2026-09-14T08:14:40.000Z'
+                  update_time: '2026-09-14T08:14:40.000Z'
+                  marked_as_done_time: null
+                additional_data: null
+  '/tasks/{id}':
+    get:
+      summary: Get details of a task
+      description: Returns the details of a specific task.
+      x-token-cost: 1
+      operationId: getTask
+      tags:
+        - Tasks
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the task
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Get a task.
+          content:
+            application/json:
+              schema:
+                title: GetTaskResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the task
+                      title:
+                        type: string
+                        minLength: 1
+                        maxLength: 255
+                        description: The title of the task
+                      creator_id:
+                        type: integer
+                        description: The ID of the user who created the task
+                      description:
+                        type: string
+                        nullable: true
+                        description: The description of the task
+                      project_id:
+                        type: integer
+                        description: The ID of the project this task is associated with
+                      is_done:
+                        type: boolean
+                        description: Whether the task is done or not.
+                      is_milestone:
+                        type: boolean
+                        description: Whether the task is a milestone or not.
+                      due_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The due date of the task. Format: YYYY-MM-DD.'
+                      start_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The start date of the task. Format: YYYY-MM-DD.'
+                      parent_task_id:
+                        type: integer
+                        nullable: true
+                        description: 'The ID of the parent task. If `null`, the task is a root-level task.'
+                      assignee_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: The IDs of users assigned to the task
+                      priority:
+                        type: integer
+                        minimum: 0
+                        nullable: true
+                        description: The priority of the task
+                      add_time:
+                        type: string
+                        description: The creation date and time of the task in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the task in ISO 8601 format
+                      marked_as_done_time:
+                        type: string
+                        nullable: true
+                        description: The date and time the task was marked as done in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+                    example: null
+              example:
+                success: true
+                data:
+                  id: 1
+                  title: Task 1
+                  creator_id: 2
+                  description: Task description
+                  project_id: 1
+                  is_done: false
+                  is_milestone: false
+                  due_date: '2026-10-11'
+                  start_date: '2026-09-01'
+                  parent_task_id: null
+                  assignee_ids:
+                    - 2
+                    - 3
+                  priority: null
+                  add_time: '2026-09-14T08:14:40.000Z'
+                  update_time: '2026-09-14T08:14:40.000Z'
+                  marked_as_done_time: null
+                additional_data: null
+    patch:
+      summary: Update a task
+      description: Updates a task.
+      x-token-cost: 5
+      operationId: updateTask
+      tags:
+        - Tasks
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the task
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: updateTaskRequest
+              type: object
+              properties:
+                title:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: The title of the task
+                project_id:
+                  type: integer
+                  description: The ID of the project this task is associated with
+                parent_task_id:
+                  type: integer
+                  nullable: true
+                  description: The ID of the parent task. Cannot be the ID of a task that is already a subtask.
+                description:
+                  type: string
+                  nullable: true
+                  description: The description of the task
+                done:
+                  type: integer
+                  enum:
+                    - 0
+                    - 1
+                  description: 'Whether the task is done or not. `0` = Not done, `1` = Done.'
+                milestone:
+                  type: integer
+                  enum:
+                    - 0
+                    - 1
+                  description: 'Whether the task is a milestone or not. `0` = Not a milestone, `1` = Milestone.'
+                due_date:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: 'The due date of the task. Format: YYYY-MM-DD.'
+                start_date:
+                  type: string
+                  format: date
+                  nullable: true
+                  description: 'The start date of the task. Format: YYYY-MM-DD.'
+                assignee_id:
+                  type: integer
+                  nullable: true
+                  description: 'The ID of the user assigned to the task. When set, the `assignee_ids` field will be overwritten with this value.'
+                assignee_ids:
+                  type: array
+                  items:
+                    type: integer
+                  maxItems: 10
+                  description: 'The IDs of users assigned to the task. When set, the `assignee_id` field will be set to the first value in this array, or `null` if empty.'
+                priority:
+                  type: integer
+                  minimum: 0
+                  nullable: true
+                  description: The priority of the task
+      responses:
+        '200':
+          description: Updated task.
+          content:
+            application/json:
+              schema:
+                title: UpdateTaskResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the task
+                      title:
+                        type: string
+                        minLength: 1
+                        maxLength: 255
+                        description: The title of the task
+                      creator_id:
+                        type: integer
+                        description: The ID of the user who created the task
+                      description:
+                        type: string
+                        nullable: true
+                        description: The description of the task
+                      project_id:
+                        type: integer
+                        description: The ID of the project this task is associated with
+                      is_done:
+                        type: boolean
+                        description: Whether the task is done or not.
+                      is_milestone:
+                        type: boolean
+                        description: Whether the task is a milestone or not.
+                      due_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The due date of the task. Format: YYYY-MM-DD.'
+                      start_date:
+                        type: string
+                        format: date
+                        nullable: true
+                        description: 'The start date of the task. Format: YYYY-MM-DD.'
+                      parent_task_id:
+                        type: integer
+                        nullable: true
+                        description: 'The ID of the parent task. If `null`, the task is a root-level task.'
+                      assignee_ids:
+                        type: array
+                        items:
+                          type: integer
+                        description: The IDs of users assigned to the task
+                      priority:
+                        type: integer
+                        minimum: 0
+                        nullable: true
+                        description: The priority of the task
+                      add_time:
+                        type: string
+                        description: The creation date and time of the task in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the task in ISO 8601 format
+                      marked_as_done_time:
+                        type: string
+                        nullable: true
+                        description: The date and time the task was marked as done in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+                    example: null
+              example:
+                success: true
+                data:
+                  id: 1
+                  title: Task 1
+                  creator_id: 2
+                  description: Task description
+                  project_id: 1
+                  is_done: false
+                  is_milestone: false
+                  due_date: '2026-10-11'
+                  start_date: '2026-09-01'
+                  parent_task_id: null
+                  assignee_ids:
+                    - 2
+                    - 3
+                  priority: null
+                  add_time: '2026-09-14T08:14:40.000Z'
+                  update_time: '2026-09-14T08:14:40.000Z'
+                  marked_as_done_time: null
+                additional_data: null
+    delete:
+      summary: Delete a task
+      description: 'Marks a task as deleted. If the task has subtasks, those will also be deleted.'
+      x-token-cost: 3
+      operationId: deleteTask
+      tags:
+        - Tasks
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the task
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Deleted task.
+          content:
+            application/json:
+              schema:
+                title: DeleteTaskResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the deleted task
+                  additional_data:
+                    type: object
+                    nullable: true
+                    example: null
+              example:
+                success: true
+                data:
+                  id: 1
+                additional_data: null
+  /boards:
+    get:
+      summary: Get all project boards
+      description: Returns all active project boards.
+      x-token-cost: 10
+      operationId: getProjectsBoards
+      tags:
+        - ProjectBoards
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      responses:
+        '200':
+          description: Get all project boards
+          content:
+            application/json:
+              schema:
+                title: GetProjectBoardsResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: array
+                    description: The array of project boards
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: The ID of the project board
+                        name:
+                          type: string
+                          description: The name of the project board
+                        order_nr:
+                          type: integer
+                          description: The order of the board
+                        add_time:
+                          type: string
+                          description: The creation date and time of the board in ISO 8601 format
+                        update_time:
+                          type: string
+                          description: The update date and time of the board in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+              example:
+                success: true
+                data:
+                  - id: 1
+                    name: Project Board
+                    order_nr: 1
+                    add_time: '2024-01-01T00:00:00.000Z'
+                    update_time: '2024-01-01T00:00:00.000Z'
+                additional_data: null
+    post:
+      summary: Add a project board
+      description: Adds a new project board.
+      x-token-cost: 5
+      operationId: addProjectBoard
+      tags:
+        - ProjectBoards
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: addProjectBoardRequest
+              required:
+                - name
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the project board
+                order_nr:
+                  type: integer
+                  minimum: 1
+                  description: The order of the board. Must be between 1 and the total number of boards + 1.
+      responses:
+        '200':
+          description: Add a project board
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectBoardResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project board
+                      name:
+                        type: string
+                        description: The name of the project board
+                      order_nr:
+                        type: integer
+                        description: The order of the board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the board in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the board in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 1
+                  name: Project Board
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+  '/boards/{id}':
+    get:
+      summary: Get details of a project board
+      description: Returns the details of a specific project board.
+      x-token-cost: 10
+      operationId: getProjectsBoard
+      tags:
+        - ProjectBoards
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project board
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Get a project board
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectBoardResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project board
+                      name:
+                        type: string
+                        description: The name of the project board
+                      order_nr:
+                        type: integer
+                        description: The order of the board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the board in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the board in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 1
+                  name: Project Board
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+    patch:
+      summary: Update a project board
+      description: Updates the properties of a project board.
+      x-token-cost: 5
+      operationId: updateProjectBoard
+      tags:
+        - ProjectBoards
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project board
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: updateProjectBoardRequest
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the project board
+                order_nr:
+                  type: integer
+                  minimum: 1
+                  description: The order of the board. Must be between 1 and the total number of boards + 1.
+      responses:
+        '200':
+          description: Update a project board
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectBoardResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project board
+                      name:
+                        type: string
+                        description: The name of the project board
+                      order_nr:
+                        type: integer
+                        description: The order of the board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the board in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the board in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 1
+                  name: Project Board
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+    delete:
+      summary: Delete a project board
+      description: Marks a project board as deleted.
+      x-token-cost: 3
+      operationId: deleteProjectBoard
+      tags:
+        - ProjectBoards
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project board
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Delete a project board
+          content:
+            application/json:
+              schema:
+                title: DeleteProjectBoardResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the deleted project board
+              example:
+                success: true
+                data:
+                  id: 1
+  /phases:
+    get:
+      summary: Get project phases
+      description: Returns all active project phases under a specific board.
+      x-token-cost: 10
+      operationId: getProjectsPhases
+      tags:
+        - ProjectPhases
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: query
+          name: board_id
+          required: true
+          description: The ID of the board for which phases are requested
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '200':
+          description: Get all project phases for a board
+          content:
+            application/json:
+              schema:
+                title: GetProjectPhasesResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: array
+                    description: The array of project phases
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          description: The ID of the project phase
+                        name:
+                          type: string
+                          description: The name of the project phase
+                        board_id:
+                          type: integer
+                          description: The ID of the project board this phase belongs to
+                        order_nr:
+                          type: integer
+                          description: The order of the phase within its board
+                        add_time:
+                          type: string
+                          description: The creation date and time of the phase in ISO 8601 format
+                        update_time:
+                          type: string
+                          description: The update date and time of the phase in ISO 8601 format
+                  additional_data:
+                    type: object
+                    nullable: true
+              example:
+                success: true
+                data:
+                  - id: 2
+                    name: Project Phase
+                    board_id: 1
+                    order_nr: 1
+                    add_time: '2024-01-01T00:00:00.000Z'
+                    update_time: '2024-01-01T00:00:00.000Z'
+                additional_data: null
+    post:
+      summary: Add a project phase
+      description: Adds a new project phase to a board.
+      x-token-cost: 5
+      operationId: addProjectPhase
+      tags:
+        - ProjectPhases
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              title: addProjectPhaseRequest
+              required:
+                - name
+                - board_id
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the project phase
+                board_id:
+                  type: integer
+                  description: The ID of the project board to add the phase to
+                order_nr:
+                  type: integer
+                  minimum: 1
+                  description: The order of the phase within its board. Must be between 1 and the total number of phases on the board + 1.
+      responses:
+        '200':
+          description: Add a project phase
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectPhaseResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project phase
+                      name:
+                        type: string
+                        description: The name of the project phase
+                      board_id:
+                        type: integer
+                        description: The ID of the project board this phase belongs to
+                      order_nr:
+                        type: integer
+                        description: The order of the phase within its board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the phase in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the phase in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 2
+                  name: Project Phase
+                  board_id: 1
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+  '/phases/{id}':
+    get:
+      summary: Get details of a project phase
+      description: Returns the details of a specific project phase.
+      x-token-cost: 10
+      operationId: getProjectsPhase
+      tags:
+        - ProjectPhases
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:read'
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project phase
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Get a project phase
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectPhaseResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project phase
+                      name:
+                        type: string
+                        description: The name of the project phase
+                      board_id:
+                        type: integer
+                        description: The ID of the project board this phase belongs to
+                      order_nr:
+                        type: integer
+                        description: The order of the phase within its board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the phase in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the phase in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 2
+                  name: Project Phase
+                  board_id: 1
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+    patch:
+      summary: Update a project phase
+      description: Updates the properties of a project phase.
+      x-token-cost: 5
+      operationId: updateProjectPhase
+      tags:
+        - ProjectPhases
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project phase
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: updateProjectPhaseRequest
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the project phase
+                board_id:
+                  type: integer
+                  description: The ID of the project board to add the phase to
+                order_nr:
+                  type: integer
+                  minimum: 1
+                  description: The order of the phase within its board. Must be between 1 and the total number of phases on the board + 1.
+      responses:
+        '200':
+          description: Update a project phase
+          content:
+            application/json:
+              schema:
+                title: UpsertProjectPhaseResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the project phase
+                      name:
+                        type: string
+                        description: The name of the project phase
+                      board_id:
+                        type: integer
+                        description: The ID of the project board this phase belongs to
+                      order_nr:
+                        type: integer
+                        description: The order of the phase within its board
+                      add_time:
+                        type: string
+                        description: The creation date and time of the phase in ISO 8601 format
+                      update_time:
+                        type: string
+                        description: The update date and time of the phase in ISO 8601 format
+              example:
+                success: true
+                data:
+                  id: 2
+                  name: Project Phase
+                  board_id: 1
+                  order_nr: 1
+                  add_time: '2024-01-01T00:00:00.000Z'
+                  update_time: '2024-01-01T00:00:00.000Z'
+    delete:
+      summary: Delete a project phase
+      description: Marks a project phase as deleted.
+      x-token-cost: 3
+      operationId: deleteProjectPhase
+      tags:
+        - ProjectPhases
+        - Beta
+      security:
+        - api_key: []
+        - oauth2:
+            - 'projects:full'
+      parameters:
+        - in: path
+          name: id
+          description: The ID of the project phase
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Delete a project phase
+          content:
+            application/json:
+              schema:
+                title: DeleteProjectPhaseResponse
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: If the response is successful or not
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ID of the deleted project phase
+              example:
+                success: true
+                data:
+                  id: 2
   '/users/{id}/followers':
     get:
       summary: List followers of a user
@@ -18289,7 +22674,7 @@ components:
         custom_fields:
           type: object
           additionalProperties: true
-          description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+          description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
     FollowerItem:
       type: object
       properties:
@@ -18363,10 +22748,30 @@ components:
           description: The IDs of labels assigned to the organization
           items:
             type: integer
+        website:
+          type: string
+          nullable: true
+          description: The website of the organization
+        linkedin:
+          type: string
+          nullable: true
+          description: The LinkedIn profile URL of the organization
+        industry:
+          type: integer
+          nullable: true
+          description: The industry the organization belongs to
+        annual_revenue:
+          type: integer
+          nullable: true
+          description: The annual revenue of the organization
+        employee_count:
+          type: integer
+          nullable: true
+          description: The number of employees in the organization
         custom_fields:
           type: object
           additionalProperties: true
-          description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+          description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
     Person:
       type: object
       properties:
@@ -18499,7 +22904,7 @@ components:
         custom_fields:
           type: object
           additionalProperties: true
-          description: An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes
+          description: 'An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes. To clear a custom field value, set it to `null`. For multi-option fields (field type `set`), use `null` to clear the selection — sending an empty array `[]` is not supported and will result in a validation error.'
   securitySchemes:
     basic_authentication:
       type: http
@@ -18545,3 +22950,4 @@ components:
             'deal-fields:full': 'Create, read, update and delete deal fields'
             'product-fields:full': 'Create, read, update and delete product fields'
             'contact-fields:full': 'Create, read, update and delete person and organization fields'
+            'project-fields:full': 'Create, read, update and delete project fields'

--- a/pipedrive/v1/deals.go
+++ b/pipedrive/v1/deals.go
@@ -81,6 +81,16 @@ func WithDealsRequestOptions(opts ...pipedrive.RequestOption) DealsOption {
 	})
 }
 
+func WithDealsMailMessagesIncludeBody(enabled bool) DealsOption {
+	return dealsOptionFunc(func(cfg *dealsOptions) {
+		value := "0"
+		if enabled {
+			value = "1"
+		}
+		cfg.query = mergeQueryValues(cfg.query, url.Values{"include_body": {value}})
+	})
+}
+
 func newDealsOptions(opts []DealsOption) dealsOptions {
 	var cfg dealsOptions
 	for _, opt := range opts {

--- a/pipedrive/v1/deals_test.go
+++ b/pipedrive/v1/deals_test.go
@@ -170,12 +170,19 @@ func TestDealsService_ListMailMessages(t *testing.T) {
 		if r.URL.Path != "/deals/6/mailMessages" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("include_body"); got != "1" {
+			t.Fatalf("unexpected include_body: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":21,"subject":"Hello"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
 	})
 
-	messages, page, err := client.Deals.ListMailMessages(context.Background(), DealID(6))
+	messages, page, err := client.Deals.ListMailMessages(
+		context.Background(),
+		DealID(6),
+		WithDealsMailMessagesIncludeBody(true),
+	)
 	if err != nil {
 		t.Fatalf("ListMailMessages error: %v", err)
 	}

--- a/pipedrive/v1/filters.go
+++ b/pipedrive/v1/filters.go
@@ -94,21 +94,30 @@ type FilterOption interface {
 	UpdateFilterOption
 }
 
+type FilterIncludeFieldCodeOption interface {
+	GetFilterOption
+	CreateFilterOption
+	UpdateFilterOption
+}
+
 type listFiltersOptions struct {
 	params         genv1.GetFiltersParams
 	requestOptions []pipedrive.RequestOption
 }
 
 type getFilterOptions struct {
+	params         genv1.GetFilterParams
 	requestOptions []pipedrive.RequestOption
 }
 
 type createFilterOptions struct {
+	params         genv1.AddFilterParams
 	payload        filterPayload
 	requestOptions []pipedrive.RequestOption
 }
 
 type updateFilterOptions struct {
+	params         genv1.UpdateFilterParams
 	payload        filterPayload
 	requestOptions []pipedrive.RequestOption
 }
@@ -203,6 +212,23 @@ func (f listFilterHelpersOptionFunc) applyListFilterHelpers(cfg *listFilterHelpe
 	f(cfg)
 }
 
+type filterIncludeFieldCodeOption bool
+
+func (o filterIncludeFieldCodeOption) applyGetFilter(cfg *getFilterOptions) {
+	value := bool(o)
+	cfg.params.IncludeFieldCode = &value
+}
+
+func (o filterIncludeFieldCodeOption) applyCreateFilter(cfg *createFilterOptions) {
+	value := bool(o)
+	cfg.params.IncludeFieldCode = &value
+}
+
+func (o filterIncludeFieldCodeOption) applyUpdateFilter(cfg *updateFilterOptions) {
+	value := bool(o)
+	cfg.params.IncludeFieldCode = &value
+}
+
 func WithFiltersRequestOptions(opts ...pipedrive.RequestOption) FiltersRequestOption {
 	return filtersRequestOptions{requestOptions: opts}
 }
@@ -212,6 +238,10 @@ func WithFiltersType(filterType FilterType) ListFiltersOption {
 		value := genv1.GetFiltersParamsType(filterType)
 		cfg.params.Type = &value
 	})
+}
+
+func WithFilterIncludeFieldCode(enabled bool) FilterIncludeFieldCodeOption {
+	return filterIncludeFieldCodeOption(enabled)
 }
 
 func WithFilterName(name string) FilterOption {
@@ -347,7 +377,7 @@ func (s *FiltersService) Get(ctx context.Context, id FilterID, opts ...GetFilter
 	cfg := newGetFilterOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetFilter(ctx, int(id), toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetFilter(ctx, int(id), &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +421,7 @@ func (s *FiltersService) Create(ctx context.Context, opts ...CreateFilterOption)
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddFilterWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddFilterWithBody(ctx, &cfg.params, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +459,7 @@ func (s *FiltersService) Update(ctx context.Context, id FilterID, opts ...Update
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdateFilterWithBody(ctx, int(id), "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdateFilterWithBody(ctx, int(id), &cfg.params, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pipedrive/v1/filters_test.go
+++ b/pipedrive/v1/filters_test.go
@@ -59,6 +59,9 @@ func TestFiltersService_Get(t *testing.T) {
 		if r.URL.Path != "/filters/42" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("include_field_code"); got != "true" {
+			t.Fatalf("unexpected include_field_code: %q", got)
+		}
 		if got := r.Header.Get("X-Test"); got != "1" {
 			t.Fatalf("unexpected header X-Test: %q", got)
 		}
@@ -75,6 +78,7 @@ func TestFiltersService_Get(t *testing.T) {
 	filter, err := client.Filters.Get(
 		context.Background(),
 		FilterID(42),
+		WithFilterIncludeFieldCode(true),
 		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "1")),
 	)
 	if err != nil {
@@ -100,6 +104,9 @@ func TestFiltersService_Create(t *testing.T) {
 		}
 		if got := r.Header.Get("X-Test"); got != "create" {
 			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		if got := r.URL.Query().Get("include_field_code"); got != "true" {
+			t.Fatalf("unexpected include_field_code: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -133,6 +140,7 @@ func TestFiltersService_Create(t *testing.T) {
 		WithFilterName("New Filter"),
 		WithFilterType(FilterTypeDeals),
 		WithFilterConditions(conditions),
+		WithFilterIncludeFieldCode(true),
 		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "create")),
 	)
 	if err != nil {
@@ -155,6 +163,9 @@ func TestFiltersService_Update(t *testing.T) {
 		}
 		if got := r.Header.Get("X-Test"); got != "update" {
 			t.Fatalf("unexpected header X-Test: %q", got)
+		}
+		if got := r.URL.Query().Get("include_field_code"); got != "true" {
+			t.Fatalf("unexpected include_field_code: %q", got)
 		}
 		var payload map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
@@ -181,6 +192,7 @@ func TestFiltersService_Update(t *testing.T) {
 		FilterID(10),
 		WithFilterName("Updated Filter"),
 		WithFilterConditions(FilterConditions{"glue": "and"}),
+		WithFilterIncludeFieldCode(true),
 		WithFiltersRequestOptions(pipedrive.WithHeader("X-Test", "update")),
 	)
 	if err != nil {

--- a/pipedrive/v1/notes.go
+++ b/pipedrive/v1/notes.go
@@ -368,6 +368,13 @@ func WithNotesProjectID(id ProjectID) ListNotesOption {
 	})
 }
 
+func WithNotesTaskID(id TaskID) ListNotesOption {
+	return listNotesOptionFunc(func(cfg *listNotesOptions) {
+		value := int(id)
+		cfg.params.TaskId = &value
+	})
+}
+
 func WithNotesStart(start int) ListNotesOption {
 	return listNotesOptionFunc(func(cfg *listNotesOptions) {
 		cfg.params.Start = &start
@@ -430,6 +437,13 @@ func WithNotesPinnedToProject(flag bool) ListNotesOption {
 	return listNotesOptionFunc(func(cfg *listNotesOptions) {
 		value := genv1.GetNotesParamsPinnedToProjectFlag(boolToNumber(flag))
 		cfg.params.PinnedToProjectFlag = &value
+	})
+}
+
+func WithNotesPinnedToTask(flag bool) ListNotesOption {
+	return listNotesOptionFunc(func(cfg *listNotesOptions) {
+		value := genv1.GetNotesParamsPinnedToTaskFlag(boolToNumber(flag))
+		cfg.params.PinnedToTaskFlag = &value
 	})
 }
 

--- a/pipedrive/v1/notes_test.go
+++ b/pipedrive/v1/notes_test.go
@@ -42,6 +42,9 @@ func TestNotesService_List(t *testing.T) {
 		if got := q.Get("project_id"); got != "5" {
 			t.Fatalf("unexpected project_id: %q", got)
 		}
+		if got := q.Get("task_id"); got != "6" {
+			t.Fatalf("unexpected task_id: %q", got)
+		}
 		if got := q.Get("start"); got != "1" {
 			t.Fatalf("unexpected start: %q", got)
 		}
@@ -72,6 +75,9 @@ func TestNotesService_List(t *testing.T) {
 		if got := q.Get("pinned_to_project_flag"); got != "1" {
 			t.Fatalf("unexpected pinned_to_project_flag: %q", got)
 		}
+		if got := q.Get("pinned_to_task_flag"); got != "0" {
+			t.Fatalf("unexpected pinned_to_task_flag: %q", got)
+		}
 		if got := r.Header.Get("X-Test"); got != "1" {
 			t.Fatalf("unexpected header X-Test: %q", got)
 		}
@@ -97,6 +103,7 @@ func TestNotesService_List(t *testing.T) {
 		WithNotesPersonID(PersonID(3)),
 		WithNotesOrganizationID(OrganizationID(4)),
 		WithNotesProjectID(ProjectID(5)),
+		WithNotesTaskID(TaskID(6)),
 		WithNotesStart(1),
 		WithNotesLimit(2),
 		WithNotesSort("add_time DESC"),
@@ -107,6 +114,7 @@ func TestNotesService_List(t *testing.T) {
 		WithNotesPinnedToOrganization(true),
 		WithNotesPinnedToPerson(true),
 		WithNotesPinnedToProject(true),
+		WithNotesPinnedToTask(false),
 		WithNotesRequestOptions(pipedrive.WithHeader("X-Test", "1")),
 	)
 	if err != nil {

--- a/pipedrive/v1/organizations.go
+++ b/pipedrive/v1/organizations.go
@@ -48,6 +48,16 @@ func WithOrganizationsRequestOptions(opts ...pipedrive.RequestOption) Organizati
 	})
 }
 
+func WithOrganizationsMailMessagesIncludeBody(enabled bool) OrganizationsOption {
+	return organizationsOptionFunc(func(cfg *organizationsOptions) {
+		value := "0"
+		if enabled {
+			value = "1"
+		}
+		cfg.query = mergeQueryValues(cfg.query, url.Values{"include_body": {value}})
+	})
+}
+
 func newOrganizationsOptions(opts []OrganizationsOption) organizationsOptions {
 	var cfg organizationsOptions
 	for _, opt := range opts {

--- a/pipedrive/v1/organizations_test.go
+++ b/pipedrive/v1/organizations_test.go
@@ -103,12 +103,19 @@ func TestOrganizationsService_ListMailMessages(t *testing.T) {
 		if r.URL.Path != "/organizations/15/mailMessages" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("include_body"); got != "1" {
+			t.Fatalf("unexpected include_body: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":9,"subject":"Hello"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
 	})
 
-	messages, page, err := client.Organizations.ListMailMessages(context.Background(), OrganizationID(15))
+	messages, page, err := client.Organizations.ListMailMessages(
+		context.Background(),
+		OrganizationID(15),
+		WithOrganizationsMailMessagesIncludeBody(true),
+	)
 	if err != nil {
 		t.Fatalf("ListMailMessages error: %v", err)
 	}

--- a/pipedrive/v1/persons.go
+++ b/pipedrive/v1/persons.go
@@ -52,6 +52,16 @@ func WithPersonsRequestOptions(opts ...pipedrive.RequestOption) PersonsOption {
 	})
 }
 
+func WithPersonsMailMessagesIncludeBody(enabled bool) PersonsOption {
+	return personsOptionFunc(func(cfg *personsOptions) {
+		value := "0"
+		if enabled {
+			value = "1"
+		}
+		cfg.query = mergeQueryValues(cfg.query, url.Values{"include_body": {value}})
+	})
+}
+
 func newPersonsOptions(opts []PersonsOption) personsOptions {
 	var cfg personsOptions
 	for _, opt := range opts {

--- a/pipedrive/v1/persons_test.go
+++ b/pipedrive/v1/persons_test.go
@@ -104,12 +104,19 @@ func TestPersonsService_ListMailMessages(t *testing.T) {
 		if r.URL.Path != "/persons/15/mailMessages" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("include_body"); got != "1" {
+			t.Fatalf("unexpected include_body: %q", got)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true,"data":[{"id":9,"subject":"Hello"}],"additional_data":{"pagination":{"start":0,"limit":1,"more_items_in_collection":false}}}`))
 	})
 
-	messages, page, err := client.Persons.ListMailMessages(context.Background(), PersonID(15))
+	messages, page, err := client.Persons.ListMailMessages(
+		context.Background(),
+		PersonID(15),
+		WithPersonsMailMessagesIncludeBody(true),
+	)
 	if err != nil {
 		t.Fatalf("ListMailMessages error: %v", err)
 	}

--- a/pipedrive/v2/client.go
+++ b/pipedrive/v2/client.go
@@ -27,6 +27,12 @@ type Client struct {
 	Users              *UsersService
 	Pipelines          *PipelinesService
 	Stages             *StagesService
+	Projects           *ProjectsService
+	ProjectBoards      *ProjectBoardsService
+	ProjectPhases      *ProjectPhasesService
+	ProjectTemplates   *ProjectTemplatesService
+	ProjectFields      *ProjectFieldsService
+	Tasks              *TasksService
 }
 
 func NewClient(cfg pipedrive.Config) (*Client, error) {
@@ -66,5 +72,11 @@ func NewClient(cfg pipedrive.Config) (*Client, error) {
 	c.Users = &UsersService{client: c}
 	c.Pipelines = &PipelinesService{client: c}
 	c.Stages = &StagesService{client: c}
+	c.Projects = &ProjectsService{client: c}
+	c.ProjectBoards = &ProjectBoardsService{client: c}
+	c.ProjectPhases = &ProjectPhasesService{client: c}
+	c.ProjectTemplates = &ProjectTemplatesService{client: c}
+	c.ProjectFields = &ProjectFieldsService{client: c}
+	c.Tasks = &TasksService{client: c}
 	return c, nil
 }

--- a/pipedrive/v2/deals_test.go
+++ b/pipedrive/v2/deals_test.go
@@ -1308,7 +1308,7 @@ func TestDealsService_ListProductsAcrossDeals(t *testing.T) {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		q := r.URL.Query()
-		if got := q["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+		if got := q.Get("deal_ids"); got != "1,2" {
 			t.Fatalf("unexpected deal_ids: %#v", got)
 		}
 		if got := q.Get("limit"); got != "1" {
@@ -1367,7 +1367,7 @@ func TestDealsService_ListProductsAcrossDealsPager(t *testing.T) {
 		if r.URL.Path != "/deals/products" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+		if got := r.URL.Query().Get("deal_ids"); got != "1,2" {
 			t.Fatalf("unexpected deal_ids: %#v", got)
 		}
 		calls++
@@ -1413,7 +1413,7 @@ func TestDealsService_ForEachProductsAcrossDeals(t *testing.T) {
 		if r.URL.Path != "/deals/products" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		if got := r.URL.Query()["deal_ids"]; len(got) != 2 || got[0] != "1" || got[1] != "2" {
+		if got := r.URL.Query().Get("deal_ids"); got != "1,2" {
 			t.Fatalf("unexpected deal_ids: %#v", got)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/pipedrive/v2/fields.go
+++ b/pipedrive/v2/fields.go
@@ -1,6 +1,14 @@
 package v2
 
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
 
 type FieldType string
 
@@ -43,11 +51,95 @@ const (
 type FieldIncludeField string
 
 type FieldOption struct {
-	ID         int        `json:"id,omitempty"`
+	// ID contains numeric custom-field option identifiers. It remains an int for
+	// source compatibility with earlier releases.
+	ID int `json:"-"`
+	// StringID contains built-in field option identifiers when Pipedrive returns
+	// the documented string form. Exactly one of ID and StringID is normally set.
+	StringID   string     `json:"-"`
 	Label      string     `json:"label,omitempty"`
 	Color      *string    `json:"color,omitempty"`
 	UpdateTime *time.Time `json:"update_time,omitempty"`
 	AddTime    *time.Time `json:"add_time,omitempty"`
+}
+
+func (o *FieldOption) UnmarshalJSON(data []byte) error {
+	if o == nil {
+		return fmt.Errorf("v2.FieldOption: UnmarshalJSON on nil receiver")
+	}
+
+	var wire struct {
+		ID         json.RawMessage `json:"id"`
+		Label      string          `json:"label,omitempty"`
+		Color      *string         `json:"color,omitempty"`
+		UpdateTime *time.Time      `json:"update_time,omitempty"`
+		AddTime    *time.Time      `json:"add_time,omitempty"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return fmt.Errorf("v2.FieldOption: decode: %w", err)
+	}
+
+	decoded := FieldOption{
+		Label:      wire.Label,
+		Color:      wire.Color,
+		UpdateTime: wire.UpdateTime,
+		AddTime:    wire.AddTime,
+	}
+	id := bytes.TrimSpace(wire.ID)
+	if len(id) == 0 {
+		*o = decoded
+		return nil
+	}
+	if bytes.Equal(id, []byte("null")) {
+		return fmt.Errorf("v2.FieldOption: id must be an integer or string")
+	}
+
+	if id[0] == '"' {
+		if err := json.Unmarshal(id, &decoded.StringID); err != nil {
+			return fmt.Errorf("v2.FieldOption: decode string id: %w", err)
+		}
+		*o = decoded
+		return nil
+	}
+	if err := json.Unmarshal(id, &decoded.ID); err != nil {
+		return fmt.Errorf("v2.FieldOption: decode integer id: %w", err)
+	}
+	*o = decoded
+	return nil
+}
+
+func (o FieldOption) MarshalJSON() ([]byte, error) {
+	var id interface{}
+	switch {
+	case o.StringID != "":
+		id = o.StringID
+	case o.ID != 0:
+		id = o.ID
+	}
+
+	wire := struct {
+		ID         interface{} `json:"id,omitempty"`
+		Label      string      `json:"label,omitempty"`
+		Color      *string     `json:"color,omitempty"`
+		UpdateTime *time.Time  `json:"update_time,omitempty"`
+		AddTime    *time.Time  `json:"add_time,omitempty"`
+	}{
+		ID:         id,
+		Label:      o.Label,
+		Color:      o.Color,
+		UpdateTime: o.UpdateTime,
+		AddTime:    o.AddTime,
+	}
+	data, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("v2.FieldOption: encode: %w", err)
+	}
+	return data, nil
+}
+
+type EntityLabel struct {
+	ID    int    `json:"id"`
+	Label string `json:"label,omitempty"`
 }
 
 type FieldSubfield struct {
@@ -57,14 +149,45 @@ type FieldSubfield struct {
 }
 
 type Field struct {
-	FieldName               string          `json:"field_name,omitempty"`
-	FieldCode               string          `json:"field_code,omitempty"`
-	Description             string          `json:"description,omitempty"`
-	FieldType               FieldType       `json:"field_type,omitempty"`
-	Options                 []FieldOption   `json:"options,omitempty"`
-	Subfields               []FieldSubfield `json:"subfields,omitempty"`
-	IsCustomField           bool            `json:"is_custom_field,omitempty"`
-	IsOptionalResponseField bool            `json:"is_optional_response_field,omitempty"`
+	FieldName               string                 `json:"field_name,omitempty"`
+	FieldCode               string                 `json:"field_code,omitempty"`
+	Description             string                 `json:"description,omitempty"`
+	FieldType               FieldType              `json:"field_type,omitempty"`
+	Options                 []FieldOption          `json:"options,omitempty"`
+	Subfields               []FieldSubfield        `json:"subfields,omitempty"`
+	IsCustomField           bool                   `json:"is_custom_field,omitempty"`
+	IsOptionalResponseField bool                   `json:"is_optional_response_field,omitempty"`
+	UIVisibility            map[string]interface{} `json:"ui_visibility,omitempty"`
+	ImportantFields         map[string]interface{} `json:"important_fields,omitempty"`
+	RequiredFields          map[string]interface{} `json:"required_fields,omitempty"`
+}
+
+type optionalSlice[T any] struct {
+	value []T
+	set   bool
+}
+
+func (o *optionalSlice[T]) append(values ...T) {
+	if !o.set {
+		o.value = make([]T, 0, len(values))
+		o.set = true
+	}
+	o.value = append(o.value, values...)
+}
+
+type nullableValue[T any] struct {
+	value *T
+	set   bool
+}
+
+func (o *nullableValue[T]) assign(value T) {
+	o.value = &value
+	o.set = true
+}
+
+func (o *nullableValue[T]) clear() {
+	o.value = nil
+	o.set = true
 }
 
 type FieldOptionUpdate struct {
@@ -119,4 +242,26 @@ func (p fieldPayload) toMap() map[string]interface{} {
 		body["required_fields"] = p.requiredFields
 	}
 	return body
+}
+
+func readFieldResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("read field response: missing HTTP response body")
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	switch {
+	case readErr != nil && closeErr != nil:
+		return nil, errors.Join(
+			fmt.Errorf("read field response body: %w", readErr),
+			fmt.Errorf("close field response body: %w", closeErr),
+		)
+	case readErr != nil:
+		return nil, fmt.Errorf("read field response body: %w", readErr)
+	case closeErr != nil:
+		return nil, fmt.Errorf("close field response body: %w", closeErr)
+	default:
+		return body, nil
+	}
 }

--- a/pipedrive/v2/fields.go
+++ b/pipedrive/v2/fields.go
@@ -259,9 +259,8 @@ func readFieldResponseBody(resp *http.Response) ([]byte, error) {
 		)
 	case readErr != nil:
 		return nil, fmt.Errorf("read field response body: %w", readErr)
-	case closeErr != nil:
-		return nil, fmt.Errorf("close field response body: %w", closeErr)
 	default:
+		// A successful read preserves the payload needed for status-derived errors.
 		return body, nil
 	}
 }

--- a/pipedrive/v2/products.go
+++ b/pipedrive/v2/products.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
@@ -986,18 +988,22 @@ func (s *ProductsService) Get(ctx context.Context, id ProductID, opts ...GetProd
 	cfg := newGetProductOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetProductWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetProduct(ctx, int(id), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readProductResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Product `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -1040,18 +1046,22 @@ func (s *ProductsService) Create(ctx context.Context, opts ...CreateProductOptio
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddProductWithBodyWithResponse(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddProductWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readProductResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Product `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -1069,18 +1079,22 @@ func (s *ProductsService) Update(ctx context.Context, id ProductID, opts ...Upda
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdateProductWithBodyWithResponse(ctx, int(id), "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdateProductWithBody(ctx, int(id), "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readProductResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Product `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -1150,18 +1164,22 @@ func (s *ProductsService) Duplicate(ctx context.Context, id ProductID, opts ...D
 	cfg := newDuplicateProductOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.DuplicateProductWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	resp, err := s.client.gen.DuplicateProduct(ctx, int(id), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readProductResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Product `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -1491,12 +1509,16 @@ func (s *ProductsService) ForEachFollowersChangelog(ctx context.Context, id Prod
 func (s *ProductsService) list(ctx context.Context, params genv2.GetProductsParams, requestOptions []pipedrive.RequestOption) ([]Product, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetProductsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetProducts(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readProductResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -1505,7 +1527,7 @@ func (s *ProductsService) list(ctx context.Context, params genv2.GetProductsPara
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 
@@ -1514,6 +1536,28 @@ func (s *ProductsService) list(ctx context.Context, params genv2.GetProductsPara
 		next = payload.AdditionalData.NextCursor
 	}
 	return payload.Data, next, nil
+}
+
+func readProductResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("read product response: missing HTTP response body")
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	switch {
+	case readErr != nil && closeErr != nil:
+		return nil, errors.Join(
+			fmt.Errorf("read product response body: %w", readErr),
+			fmt.Errorf("close product response body: %w", closeErr),
+		)
+	case readErr != nil:
+		return nil, fmt.Errorf("read product response body: %w", readErr)
+	case closeErr != nil:
+		return nil, fmt.Errorf("close product response body: %w", closeErr)
+	default:
+		return body, nil
+	}
 }
 
 func (s *ProductsService) listVariations(ctx context.Context, id ProductID, params genv2.GetProductVariationsParams, requestOptions []pipedrive.RequestOption) ([]ProductVariation, *string, error) {

--- a/pipedrive/v2/products.go
+++ b/pipedrive/v2/products.go
@@ -1553,9 +1553,8 @@ func readProductResponseBody(resp *http.Response) ([]byte, error) {
 		)
 	case readErr != nil:
 		return nil, fmt.Errorf("read product response body: %w", readErr)
-	case closeErr != nil:
-		return nil, fmt.Errorf("close product response body: %w", closeErr)
 	default:
+		// A successful read preserves the payload needed for status-derived errors.
 		return body, nil
 	}
 }

--- a/pipedrive/v2/project_boards.go
+++ b/pipedrive/v2/project_boards.go
@@ -1,0 +1,184 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type ProjectBoard struct {
+	ID         ProjectBoardID `json:"id"`
+	Name       string         `json:"name,omitempty"`
+	Order      int            `json:"order_nr,omitempty"`
+	AddTime    *time.Time     `json:"add_time,omitempty"`
+	UpdateTime *time.Time     `json:"update_time,omitempty"`
+}
+
+type ProjectBoardDeleteResult struct {
+	ID ProjectBoardID `json:"id"`
+}
+
+type ProjectBoardsService struct{ client *Client }
+
+type CreateProjectBoardOption interface {
+	applyCreateProjectBoard(*createProjectBoardOptions)
+}
+type UpdateProjectBoardOption interface {
+	applyUpdateProjectBoard(*updateProjectBoardOptions)
+}
+
+type ProjectBoardOption interface {
+	CreateProjectBoardOption
+	UpdateProjectBoardOption
+}
+
+type ProjectBoardRequestOption interface {
+	CreateProjectBoardOption
+	UpdateProjectBoardOption
+	projectBoardRequestOptions() []pipedrive.RequestOption
+}
+
+type createProjectBoardOptions struct {
+	payload        projectBoardPayload
+	requestOptions []pipedrive.RequestOption
+}
+
+type updateProjectBoardOptions struct {
+	payload        projectBoardPayload
+	requestOptions []pipedrive.RequestOption
+}
+
+type projectBoardPayload struct {
+	name  *string
+	order *int
+}
+
+type projectBoardFieldOption func(*projectBoardPayload)
+
+func (f projectBoardFieldOption) applyCreateProjectBoard(cfg *createProjectBoardOptions) {
+	f(&cfg.payload)
+}
+func (f projectBoardFieldOption) applyUpdateProjectBoard(cfg *updateProjectBoardOptions) {
+	f(&cfg.payload)
+}
+
+type projectBoardRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o projectBoardRequestOption) projectBoardRequestOptions() []pipedrive.RequestOption {
+	return o.options
+}
+func (o projectBoardRequestOption) applyCreateProjectBoard(cfg *createProjectBoardOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectBoardRequestOption) applyUpdateProjectBoard(cfg *updateProjectBoardOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+func WithProjectBoardRequestOptions(opts ...pipedrive.RequestOption) ProjectBoardRequestOption {
+	return projectBoardRequestOption{options: opts}
+}
+
+func WithProjectBoardName(name string) ProjectBoardOption {
+	return projectBoardFieldOption(func(payload *projectBoardPayload) { payload.name = &name })
+}
+
+func WithProjectBoardOrder(order int) ProjectBoardOption {
+	return projectBoardFieldOption(func(payload *projectBoardPayload) { payload.order = &order })
+}
+
+func newCreateProjectBoardOptions(opts []CreateProjectBoardOption) createProjectBoardOptions {
+	var cfg createProjectBoardOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyCreateProjectBoard(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newUpdateProjectBoardOptions(opts []UpdateProjectBoardOption) updateProjectBoardOptions {
+	var cfg updateProjectBoardOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyUpdateProjectBoard(&cfg)
+		}
+	}
+	return cfg
+}
+
+func projectBoardRequestOptionValues(opts []ProjectBoardRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.projectBoardRequestOptions()...)
+		}
+	}
+	return out
+}
+
+func (p projectBoardPayload) body() map[string]interface{} {
+	body := map[string]interface{}{}
+	if p.name != nil {
+		body["name"] = *p.name
+	}
+	if p.order != nil {
+		body["order_nr"] = *p.order
+	}
+	return body
+}
+
+func (s *ProjectBoardsService) List(ctx context.Context, opts ...ProjectBoardRequestOption) ([]ProjectBoard, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectBoardRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectsBoardsWithResponse(ctx, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[ProjectBoard](resp.HTTPResponse, resp.Body)
+}
+
+func (s *ProjectBoardsService) Get(ctx context.Context, id ProjectBoardID, opts ...ProjectBoardRequestOption) (*ProjectBoard, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectBoardRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectsBoardWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectBoard](resp.HTTPResponse, resp.Body, "project board")
+}
+
+func (s *ProjectBoardsService) Create(ctx context.Context, opts ...CreateProjectBoardOption) (*ProjectBoard, error) {
+	cfg := newCreateProjectBoardOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.AddProjectBoardWithBodyWithResponse(ctx, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectBoard](resp.HTTPResponse, resp.Body, "project board")
+}
+
+func (s *ProjectBoardsService) Update(ctx context.Context, id ProjectBoardID, opts ...UpdateProjectBoardOption) (*ProjectBoard, error) {
+	cfg := newUpdateProjectBoardOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.UpdateProjectBoardWithBodyWithResponse(ctx, int(id), "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectBoard](resp.HTTPResponse, resp.Body, "project board")
+}
+
+func (s *ProjectBoardsService) Delete(ctx context.Context, id ProjectBoardID, opts ...ProjectBoardRequestOption) (*ProjectBoardDeleteResult, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectBoardRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteProjectBoardWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectBoardDeleteResult](resp.HTTPResponse, resp.Body, "project board delete")
+}

--- a/pipedrive/v2/project_boards_test.go
+++ b/pipedrive/v2/project_boards_test.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestProjectBoardsService_AllOperations(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "project-boards" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method + " " + r.URL.Path {
 		case "GET /boards":
@@ -34,23 +39,24 @@ func TestProjectBoardsService_AllOperations(t *testing.T) {
 		}
 	})
 	ctx := context.Background()
-	items, err := client.ProjectBoards.List(ctx)
+	requestOpt := WithProjectBoardRequestOptions(pipedrive.WithHeader("X-Test", "project-boards"))
+	items, err := client.ProjectBoards.List(ctx, requestOpt)
 	if err != nil || len(items) != 1 || items[0].ID != 2 {
 		t.Fatalf("List = %#v, %v", items, err)
 	}
-	created, err := client.ProjectBoards.Create(ctx, WithProjectBoardName("Delivery"), WithProjectBoardOrder(1))
+	created, err := client.ProjectBoards.Create(ctx, WithProjectBoardName("Delivery"), WithProjectBoardOrder(1), requestOpt)
 	if err != nil || created.ID != 2 {
 		t.Fatalf("Create = %#v, %v", created, err)
 	}
-	got, err := client.ProjectBoards.Get(ctx, 2)
+	got, err := client.ProjectBoards.Get(ctx, 2, requestOpt)
 	if err != nil || got.ID != 2 {
 		t.Fatalf("Get = %#v, %v", got, err)
 	}
-	updated, err := client.ProjectBoards.Update(ctx, 2, WithProjectBoardName("Updated"))
+	updated, err := client.ProjectBoards.Update(ctx, 2, WithProjectBoardName("Updated"), requestOpt)
 	if err != nil || updated.Name != "Updated" {
 		t.Fatalf("Update = %#v, %v", updated, err)
 	}
-	deleted, err := client.ProjectBoards.Delete(ctx, 2)
+	deleted, err := client.ProjectBoards.Delete(ctx, 2, requestOpt)
 	if err != nil || deleted.ID != 2 {
 		t.Fatalf("Delete = %#v, %v", deleted, err)
 	}

--- a/pipedrive/v2/project_boards_test.go
+++ b/pipedrive/v2/project_boards_test.go
@@ -1,0 +1,57 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestProjectBoardsService_AllOperations(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /boards":
+			_, _ = w.Write([]byte(`{"data":[{"id":2,"name":"Delivery","order_nr":1}]}`))
+		case "POST /boards":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["name"] != "Delivery" || body["order_nr"] != float64(1) {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":2,"name":"Delivery","order_nr":1}}`))
+		case "GET /boards/2":
+			_, _ = w.Write([]byte(`{"data":{"id":2,"name":"Delivery"}}`))
+		case "PATCH /boards/2":
+			_, _ = w.Write([]byte(`{"data":{"id":2,"name":"Updated"}}`))
+		case "DELETE /boards/2":
+			_, _ = w.Write([]byte(`{"data":{"id":2}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	ctx := context.Background()
+	items, err := client.ProjectBoards.List(ctx)
+	if err != nil || len(items) != 1 || items[0].ID != 2 {
+		t.Fatalf("List = %#v, %v", items, err)
+	}
+	created, err := client.ProjectBoards.Create(ctx, WithProjectBoardName("Delivery"), WithProjectBoardOrder(1))
+	if err != nil || created.ID != 2 {
+		t.Fatalf("Create = %#v, %v", created, err)
+	}
+	got, err := client.ProjectBoards.Get(ctx, 2)
+	if err != nil || got.ID != 2 {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+	updated, err := client.ProjectBoards.Update(ctx, 2, WithProjectBoardName("Updated"))
+	if err != nil || updated.Name != "Updated" {
+		t.Fatalf("Update = %#v, %v", updated, err)
+	}
+	deleted, err := client.ProjectBoards.Delete(ctx, 2)
+	if err != nil || deleted.ID != 2 {
+		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+}

--- a/pipedrive/v2/project_fields.go
+++ b/pipedrive/v2/project_fields.go
@@ -1,0 +1,343 @@
+package v2
+
+import (
+	"context"
+
+	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type ProjectFieldsService struct{ client *Client }
+
+type ListProjectFieldsOption interface {
+	applyListProjectFields(*listProjectFieldsOptions)
+}
+type CreateProjectFieldOption interface {
+	applyCreateProjectField(*createProjectFieldOptions)
+}
+type UpdateProjectFieldOption interface {
+	applyUpdateProjectField(*updateProjectFieldOptions)
+}
+
+type ProjectFieldOption interface {
+	CreateProjectFieldOption
+	UpdateProjectFieldOption
+}
+
+type ProjectFieldRequestOption interface {
+	ListProjectFieldsOption
+	CreateProjectFieldOption
+	UpdateProjectFieldOption
+	projectFieldRequestOptions() []pipedrive.RequestOption
+}
+
+type listProjectFieldsOptions struct {
+	params         genv2.GetProjectFieldsParams
+	requestOptions []pipedrive.RequestOption
+}
+type createProjectFieldOptions struct {
+	payload        projectCustomFieldPayload
+	requestOptions []pipedrive.RequestOption
+}
+type updateProjectFieldOptions struct {
+	payload        projectCustomFieldPayload
+	requestOptions []pipedrive.RequestOption
+}
+type projectCustomFieldPayload struct {
+	name            *string
+	fieldType       *FieldType
+	options         []fieldOptionInput
+	uiVisibility    map[string]interface{}
+	importantFields map[string]interface{}
+	requiredFields  map[string]interface{}
+}
+
+type listProjectFieldsOptionFunc func(*listProjectFieldsOptions)
+
+func (f listProjectFieldsOptionFunc) applyListProjectFields(cfg *listProjectFieldsOptions) { f(cfg) }
+
+type projectCustomFieldOption func(*projectCustomFieldPayload)
+
+func (f projectCustomFieldOption) applyCreateProjectField(cfg *createProjectFieldOptions) {
+	f(&cfg.payload)
+}
+func (f projectCustomFieldOption) applyUpdateProjectField(cfg *updateProjectFieldOptions) {
+	f(&cfg.payload)
+}
+
+type projectCustomFieldCreateOption func(*projectCustomFieldPayload)
+
+func (f projectCustomFieldCreateOption) applyCreateProjectField(cfg *createProjectFieldOptions) {
+	f(&cfg.payload)
+}
+
+type projectFieldRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o projectFieldRequestOption) projectFieldRequestOptions() []pipedrive.RequestOption {
+	return o.options
+}
+func (o projectFieldRequestOption) applyListProjectFields(cfg *listProjectFieldsOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectFieldRequestOption) applyCreateProjectField(cfg *createProjectFieldOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectFieldRequestOption) applyUpdateProjectField(cfg *updateProjectFieldOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+func WithProjectFieldRequestOptions(opts ...pipedrive.RequestOption) ProjectFieldRequestOption {
+	return projectFieldRequestOption{options: opts}
+}
+func WithProjectFieldsPageSize(limit int) ListProjectFieldsOption {
+	return listProjectFieldsOptionFunc(func(cfg *listProjectFieldsOptions) {
+		if limit > 0 {
+			cfg.params.Limit = &limit
+		}
+	})
+}
+func WithProjectFieldsCursor(cursor string) ListProjectFieldsOption {
+	return listProjectFieldsOptionFunc(func(cfg *listProjectFieldsOptions) {
+		if cursor != "" {
+			cfg.params.Cursor = &cursor
+		}
+	})
+}
+func WithProjectFieldName(name string) ProjectFieldOption {
+	return projectCustomFieldOption(func(p *projectCustomFieldPayload) { p.name = &name })
+}
+func WithProjectFieldType(fieldType FieldType) CreateProjectFieldOption {
+	return projectCustomFieldCreateOption(func(p *projectCustomFieldPayload) { p.fieldType = &fieldType })
+}
+func WithProjectFieldOptions(labels ...string) CreateProjectFieldOption {
+	return projectCustomFieldCreateOption(func(p *projectCustomFieldPayload) {
+		for _, label := range labels {
+			if label != "" {
+				p.options = append(p.options, fieldOptionInput{Label: label})
+			}
+		}
+	})
+}
+func WithProjectFieldUIVisibility(value map[string]interface{}) ProjectFieldOption {
+	return projectCustomFieldOption(func(p *projectCustomFieldPayload) { p.uiVisibility = value })
+}
+func WithProjectFieldImportantFields(value map[string]interface{}) ProjectFieldOption {
+	return projectCustomFieldOption(func(p *projectCustomFieldPayload) { p.importantFields = value })
+}
+func WithProjectFieldRequiredFields(value map[string]interface{}) ProjectFieldOption {
+	return projectCustomFieldOption(func(p *projectCustomFieldPayload) { p.requiredFields = value })
+}
+
+func newListProjectFieldsOptions(opts []ListProjectFieldsOption) listProjectFieldsOptions {
+	var cfg listProjectFieldsOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListProjectFields(&cfg)
+		}
+	}
+	return cfg
+}
+func newCreateProjectFieldOptions(opts []CreateProjectFieldOption) createProjectFieldOptions {
+	var cfg createProjectFieldOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyCreateProjectField(&cfg)
+		}
+	}
+	return cfg
+}
+func newUpdateProjectFieldOptions(opts []UpdateProjectFieldOption) updateProjectFieldOptions {
+	var cfg updateProjectFieldOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyUpdateProjectField(&cfg)
+		}
+	}
+	return cfg
+}
+func projectFieldRequestOptionValues(opts []ProjectFieldRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.projectFieldRequestOptions()...)
+		}
+	}
+	return out
+}
+func (p projectCustomFieldPayload) body() map[string]interface{} {
+	body := map[string]interface{}{}
+	if p.name != nil {
+		body["field_name"] = *p.name
+	}
+	if p.fieldType != nil {
+		body["field_type"] = string(*p.fieldType)
+	}
+	if len(p.options) > 0 {
+		body["options"] = p.options
+	}
+	if p.uiVisibility != nil {
+		body["ui_visibility"] = p.uiVisibility
+	}
+	if p.importantFields != nil {
+		body["important_fields"] = p.importantFields
+	}
+	if p.requiredFields != nil {
+		body["required_fields"] = p.requiredFields
+	}
+	return body
+}
+
+func (s *ProjectFieldsService) List(ctx context.Context, opts ...ListProjectFieldsOption) ([]Field, *string, error) {
+	cfg := newListProjectFieldsOptions(opts)
+	return s.list(ctx, cfg.params, cfg.requestOptions)
+}
+func (s *ProjectFieldsService) ListPager(opts ...ListProjectFieldsOption) *pipedrive.CursorPager[Field] {
+	cfg := newListProjectFieldsOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]Field, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.list(ctx, params, cfg.requestOptions)
+	})
+}
+func (s *ProjectFieldsService) ForEach(ctx context.Context, fn func(Field) error, opts ...ListProjectFieldsOption) error {
+	return s.ListPager(opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectFieldsService) Get(ctx context.Context, fieldCode string, opts ...ProjectFieldRequestOption) (*Field, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectFieldRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectField(ctx, fieldCode, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Field](resp, responseBody, "project field")
+}
+func (s *ProjectFieldsService) Create(ctx context.Context, opts ...CreateProjectFieldOption) (*Field, error) {
+	cfg := newCreateProjectFieldOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.AddProjectFieldWithBody(ctx, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Field](resp, responseBody, "project field")
+}
+func (s *ProjectFieldsService) Update(ctx context.Context, fieldCode string, opts ...UpdateProjectFieldOption) (*Field, error) {
+	cfg := newUpdateProjectFieldOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.UpdateProjectFieldWithBody(ctx, fieldCode, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Field](resp, responseBody, "project field")
+}
+func (s *ProjectFieldsService) Delete(ctx context.Context, fieldCode string, opts ...ProjectFieldRequestOption) (*Field, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectFieldRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteProjectField(ctx, fieldCode, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Field](resp, responseBody, "project field delete")
+}
+func (s *ProjectFieldsService) AddOptions(ctx context.Context, fieldCode string, labels []string, opts ...ProjectFieldRequestOption) ([]FieldOption, error) {
+	bodyItems := make([]map[string]interface{}, 0, len(labels))
+	for _, label := range labels {
+		if label != "" {
+			bodyItems = append(bodyItems, map[string]interface{}{"label": label})
+		}
+	}
+	body, err := encodeV2ArrayBody(bodyItems)
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectFieldRequestOptionValues(opts)...)
+	resp, err := s.client.gen.AddProjectFieldOptionsWithBody(ctx, fieldCode, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[FieldOption](resp, responseBody)
+}
+func (s *ProjectFieldsService) UpdateOptions(ctx context.Context, fieldCode string, updates []FieldOptionUpdate, opts ...ProjectFieldRequestOption) ([]FieldOption, error) {
+	bodyItems := make([]map[string]interface{}, 0, len(updates))
+	for _, update := range updates {
+		bodyItems = append(bodyItems, map[string]interface{}{"id": update.ID, "label": update.Label})
+	}
+	body, err := encodeV2ArrayBody(bodyItems)
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectFieldRequestOptionValues(opts)...)
+	resp, err := s.client.gen.UpdateProjectFieldOptionsWithBody(ctx, fieldCode, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[FieldOption](resp, responseBody)
+}
+func (s *ProjectFieldsService) DeleteOptions(ctx context.Context, fieldCode string, ids []int, opts ...ProjectFieldRequestOption) ([]FieldOption, error) {
+	bodyItems := make([]map[string]interface{}, 0, len(ids))
+	for _, id := range ids {
+		bodyItems = append(bodyItems, map[string]interface{}{"id": id})
+	}
+	body, err := encodeV2ArrayBody(bodyItems)
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectFieldRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteProjectFieldOptionsWithBody(ctx, fieldCode, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[FieldOption](resp, responseBody)
+}
+func (s *ProjectFieldsService) list(ctx context.Context, params genv2.GetProjectFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetProjectFields(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[Field](resp, responseBody)
+}

--- a/pipedrive/v2/project_fields_test.go
+++ b/pipedrive/v2/project_fields_test.go
@@ -5,71 +5,139 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestProjectFieldsService_AllOperations(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "project-fields" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method + " " + r.URL.Path {
 		case "GET /projectFields":
+			if query := r.URL.Query(); query.Get("limit") != "20" || query.Get("cursor") != "fields-start" {
+				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf","field_name":"Risk","field_type":"enum","options":[{"id":"system-high","label":"High"}]}],"additional_data":{"next_cursor":null}}`))
 		case "POST /projectFields":
 			var body map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if body["field_name"] != "Risk" || body["field_type"] != "enum" {
+			if body["field_name"] != "Risk" || body["field_type"] != "enum" ||
+				len(body["options"].([]any)) != 2 || body["ui_visibility"].(map[string]any)["enabled"] != true ||
+				body["important_fields"].(map[string]any)["pipeline_id"] != float64(1) ||
+				body["required_fields"].(map[string]any)["stage_id"] != float64(2) {
 				t.Fatalf("unexpected body: %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
 		case "GET /projectFields/cf":
 			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
 		case "PATCH /projectFields/cf":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["field_name"] != "Updated" || body["ui_visibility"].(map[string]any)["enabled"] != false ||
+				body["important_fields"].(map[string]any)["pipeline_id"] != float64(3) ||
+				body["required_fields"].(map[string]any)["stage_id"] != float64(4) {
+				t.Fatalf("unexpected update body: %#v", body)
+			}
 			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Updated","field_type":"enum"}}`))
 		case "DELETE /projectFields/cf":
 			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
 		case "POST /projectFields/cf/options":
+			var body []map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body) != 1 || body[0]["label"] != "High" {
+				t.Fatalf("unexpected add options body: %#v, %v", body, err)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"High"}]}`))
 		case "PATCH /projectFields/cf/options":
+			var body []map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body) != 1 ||
+				body[0]["id"] != float64(1) || body[0]["label"] != "Critical" {
+				t.Fatalf("unexpected update options body: %#v, %v", body, err)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
 		case "DELETE /projectFields/cf/options":
+			var body []map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body) != 1 || body[0]["id"] != float64(1) {
+				t.Fatalf("unexpected delete options body: %#v, %v", body, err)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
 	})
 	ctx := context.Background()
-	items, _, err := client.ProjectFields.List(ctx)
+	requestOpt := WithProjectFieldRequestOptions(pipedrive.WithHeader("X-Test", "project-fields"))
+	items, _, err := client.ProjectFields.List(ctx,
+		WithProjectFieldsPageSize(20),
+		WithProjectFieldsCursor("fields-start"),
+		requestOpt,
+	)
 	if err != nil || len(items) != 1 || items[0].FieldCode != "cf" || items[0].Options[0].StringID != "system-high" {
 		t.Fatalf("List = %#v, %v", items, err)
 	}
-	created, err := client.ProjectFields.Create(ctx, WithProjectFieldName("Risk"), WithProjectFieldType(FieldTypeEnum), WithProjectFieldOptions("High"))
+	created, err := client.ProjectFields.Create(ctx,
+		WithProjectFieldName("Risk"),
+		WithProjectFieldType(FieldTypeEnum),
+		WithProjectFieldOptions("High", "Low"),
+		WithProjectFieldUIVisibility(map[string]interface{}{"enabled": true}),
+		WithProjectFieldImportantFields(map[string]interface{}{"pipeline_id": 1}),
+		WithProjectFieldRequiredFields(map[string]interface{}{"stage_id": 2}),
+		requestOpt,
+	)
 	if err != nil || created.FieldCode != "cf" {
 		t.Fatalf("Create = %#v, %v", created, err)
 	}
-	got, err := client.ProjectFields.Get(ctx, "cf")
+	got, err := client.ProjectFields.Get(ctx, "cf", requestOpt)
 	if err != nil || got.FieldCode != "cf" {
 		t.Fatalf("Get = %#v, %v", got, err)
 	}
-	updated, err := client.ProjectFields.Update(ctx, "cf", WithProjectFieldName("Updated"))
+	updated, err := client.ProjectFields.Update(ctx, "cf",
+		WithProjectFieldName("Updated"),
+		WithProjectFieldUIVisibility(map[string]interface{}{"enabled": false}),
+		WithProjectFieldImportantFields(map[string]interface{}{"pipeline_id": 3}),
+		WithProjectFieldRequiredFields(map[string]interface{}{"stage_id": 4}),
+		requestOpt,
+	)
 	if err != nil || updated.FieldName != "Updated" {
 		t.Fatalf("Update = %#v, %v", updated, err)
 	}
-	deleted, err := client.ProjectFields.Delete(ctx, "cf")
+	deleted, err := client.ProjectFields.Delete(ctx, "cf", requestOpt)
 	if err != nil || deleted.FieldCode != "cf" {
 		t.Fatalf("Delete = %#v, %v", deleted, err)
 	}
-	added, err := client.ProjectFields.AddOptions(ctx, "cf", []string{"High"})
+	added, err := client.ProjectFields.AddOptions(ctx, "cf", []string{"", "High"}, requestOpt)
 	if err != nil || len(added) != 1 || added[0].Label != "High" {
 		t.Fatalf("AddOptions = %#v, %v", added, err)
 	}
-	changed, err := client.ProjectFields.UpdateOptions(ctx, "cf", []FieldOptionUpdate{{ID: 1, Label: "Critical"}})
+	changed, err := client.ProjectFields.UpdateOptions(ctx, "cf", []FieldOptionUpdate{{ID: 1, Label: "Critical"}}, requestOpt)
 	if err != nil || len(changed) != 1 || changed[0].Label != "Critical" {
 		t.Fatalf("UpdateOptions = %#v, %v", changed, err)
 	}
-	removed, err := client.ProjectFields.DeleteOptions(ctx, "cf", []int{1})
+	removed, err := client.ProjectFields.DeleteOptions(ctx, "cf", []int{1}, requestOpt)
 	if err != nil || len(removed) != 1 || removed[0].ID != 1 {
 		t.Fatalf("DeleteOptions = %#v, %v", removed, err)
 	}
+}
+
+func TestProjectFieldsService_ListPager(t *testing.T) {
+	t.Parallel()
+
+	runFieldListPagerTest(t, "/projectFields", func(client *Client) *pipedrive.CursorPager[Field] {
+		return client.ProjectFields.ListPager(WithProjectFieldsPageSize(2), WithProjectFieldsCursor("start"))
+	})
+}
+
+func TestProjectFieldsService_ForEach(t *testing.T) {
+	t.Parallel()
+
+	runFieldForEachTest(t, "/projectFields", func(ctx context.Context, client *Client, fn func(Field) error) error {
+		return client.ProjectFields.ForEach(ctx, fn)
+	})
 }

--- a/pipedrive/v2/project_fields_test.go
+++ b/pipedrive/v2/project_fields_test.go
@@ -1,0 +1,75 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestProjectFieldsService_AllOperations(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /projectFields":
+			_, _ = w.Write([]byte(`{"data":[{"field_code":"cf","field_name":"Risk","field_type":"enum","options":[{"id":"system-high","label":"High"}]}],"additional_data":{"next_cursor":null}}`))
+		case "POST /projectFields":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["field_name"] != "Risk" || body["field_type"] != "enum" {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
+		case "GET /projectFields/cf":
+			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
+		case "PATCH /projectFields/cf":
+			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Updated","field_type":"enum"}}`))
+		case "DELETE /projectFields/cf":
+			_, _ = w.Write([]byte(`{"data":{"field_code":"cf","field_name":"Risk","field_type":"enum"}}`))
+		case "POST /projectFields/cf/options":
+			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"High"}]}`))
+		case "PATCH /projectFields/cf/options":
+			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+		case "DELETE /projectFields/cf/options":
+			_, _ = w.Write([]byte(`{"data":[{"id":1,"label":"Critical"}]}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	ctx := context.Background()
+	items, _, err := client.ProjectFields.List(ctx)
+	if err != nil || len(items) != 1 || items[0].FieldCode != "cf" || items[0].Options[0].StringID != "system-high" {
+		t.Fatalf("List = %#v, %v", items, err)
+	}
+	created, err := client.ProjectFields.Create(ctx, WithProjectFieldName("Risk"), WithProjectFieldType(FieldTypeEnum), WithProjectFieldOptions("High"))
+	if err != nil || created.FieldCode != "cf" {
+		t.Fatalf("Create = %#v, %v", created, err)
+	}
+	got, err := client.ProjectFields.Get(ctx, "cf")
+	if err != nil || got.FieldCode != "cf" {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+	updated, err := client.ProjectFields.Update(ctx, "cf", WithProjectFieldName("Updated"))
+	if err != nil || updated.FieldName != "Updated" {
+		t.Fatalf("Update = %#v, %v", updated, err)
+	}
+	deleted, err := client.ProjectFields.Delete(ctx, "cf")
+	if err != nil || deleted.FieldCode != "cf" {
+		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+	added, err := client.ProjectFields.AddOptions(ctx, "cf", []string{"High"})
+	if err != nil || len(added) != 1 || added[0].Label != "High" {
+		t.Fatalf("AddOptions = %#v, %v", added, err)
+	}
+	changed, err := client.ProjectFields.UpdateOptions(ctx, "cf", []FieldOptionUpdate{{ID: 1, Label: "Critical"}})
+	if err != nil || len(changed) != 1 || changed[0].Label != "Critical" {
+		t.Fatalf("UpdateOptions = %#v, %v", changed, err)
+	}
+	removed, err := client.ProjectFields.DeleteOptions(ctx, "cf", []int{1})
+	if err != nil || len(removed) != 1 || removed[0].ID != 1 {
+		t.Fatalf("DeleteOptions = %#v, %v", removed, err)
+	}
+}

--- a/pipedrive/v2/project_phases.go
+++ b/pipedrive/v2/project_phases.go
@@ -1,0 +1,187 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type ProjectPhase struct {
+	ID         ProjectPhaseID `json:"id"`
+	Name       string         `json:"name,omitempty"`
+	BoardID    ProjectBoardID `json:"board_id,omitempty"`
+	Order      int            `json:"order_nr,omitempty"`
+	AddTime    *time.Time     `json:"add_time,omitempty"`
+	UpdateTime *time.Time     `json:"update_time,omitempty"`
+}
+
+type ProjectPhaseDeleteResult struct {
+	ID ProjectPhaseID `json:"id"`
+}
+
+type ProjectPhasesService struct{ client *Client }
+
+type CreateProjectPhaseOption interface {
+	applyCreateProjectPhase(*createProjectPhaseOptions)
+}
+type UpdateProjectPhaseOption interface {
+	applyUpdateProjectPhase(*updateProjectPhaseOptions)
+}
+
+type ProjectPhaseOption interface {
+	CreateProjectPhaseOption
+	UpdateProjectPhaseOption
+}
+
+type ProjectPhaseRequestOption interface {
+	CreateProjectPhaseOption
+	UpdateProjectPhaseOption
+	projectPhaseRequestOptions() []pipedrive.RequestOption
+}
+
+type createProjectPhaseOptions struct {
+	payload        projectPhasePayload
+	requestOptions []pipedrive.RequestOption
+}
+type updateProjectPhaseOptions struct {
+	payload        projectPhasePayload
+	requestOptions []pipedrive.RequestOption
+}
+type projectPhasePayload struct {
+	name    *string
+	boardID *ProjectBoardID
+	order   *int
+}
+
+type projectPhaseFieldOption func(*projectPhasePayload)
+
+func (f projectPhaseFieldOption) applyCreateProjectPhase(cfg *createProjectPhaseOptions) {
+	f(&cfg.payload)
+}
+func (f projectPhaseFieldOption) applyUpdateProjectPhase(cfg *updateProjectPhaseOptions) {
+	f(&cfg.payload)
+}
+
+type projectPhaseRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o projectPhaseRequestOption) projectPhaseRequestOptions() []pipedrive.RequestOption {
+	return o.options
+}
+func (o projectPhaseRequestOption) applyCreateProjectPhase(cfg *createProjectPhaseOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectPhaseRequestOption) applyUpdateProjectPhase(cfg *updateProjectPhaseOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+func WithProjectPhaseRequestOptions(opts ...pipedrive.RequestOption) ProjectPhaseRequestOption {
+	return projectPhaseRequestOption{options: opts}
+}
+func WithProjectPhaseName(name string) ProjectPhaseOption {
+	return projectPhaseFieldOption(func(p *projectPhasePayload) { p.name = &name })
+}
+func WithProjectPhaseBoardID(id ProjectBoardID) ProjectPhaseOption {
+	return projectPhaseFieldOption(func(p *projectPhasePayload) { p.boardID = &id })
+}
+func WithProjectPhaseOrder(order int) ProjectPhaseOption {
+	return projectPhaseFieldOption(func(p *projectPhasePayload) { p.order = &order })
+}
+
+func newCreateProjectPhaseOptions(opts []CreateProjectPhaseOption) createProjectPhaseOptions {
+	var cfg createProjectPhaseOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyCreateProjectPhase(&cfg)
+		}
+	}
+	return cfg
+}
+func newUpdateProjectPhaseOptions(opts []UpdateProjectPhaseOption) updateProjectPhaseOptions {
+	var cfg updateProjectPhaseOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyUpdateProjectPhase(&cfg)
+		}
+	}
+	return cfg
+}
+func projectPhaseRequestOptionValues(opts []ProjectPhaseRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.projectPhaseRequestOptions()...)
+		}
+	}
+	return out
+}
+func (p projectPhasePayload) body() map[string]interface{} {
+	body := map[string]interface{}{}
+	if p.name != nil {
+		body["name"] = *p.name
+	}
+	if p.boardID != nil {
+		body["board_id"] = int(*p.boardID)
+	}
+	if p.order != nil {
+		body["order_nr"] = *p.order
+	}
+	return body
+}
+
+func (s *ProjectPhasesService) List(ctx context.Context, boardID ProjectBoardID, opts ...ProjectPhaseRequestOption) ([]ProjectPhase, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectPhaseRequestOptionValues(opts)...)
+	params := genv2.GetProjectsPhasesParams{BoardId: int(boardID)}
+	resp, err := s.client.gen.GetProjectsPhasesWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[ProjectPhase](resp.HTTPResponse, resp.Body)
+}
+
+func (s *ProjectPhasesService) Get(ctx context.Context, id ProjectPhaseID, opts ...ProjectPhaseRequestOption) (*ProjectPhase, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectPhaseRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectsPhaseWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectPhase](resp.HTTPResponse, resp.Body, "project phase")
+}
+
+func (s *ProjectPhasesService) Create(ctx context.Context, opts ...CreateProjectPhaseOption) (*ProjectPhase, error) {
+	cfg := newCreateProjectPhaseOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.AddProjectPhaseWithBodyWithResponse(ctx, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectPhase](resp.HTTPResponse, resp.Body, "project phase")
+}
+
+func (s *ProjectPhasesService) Update(ctx context.Context, id ProjectPhaseID, opts ...UpdateProjectPhaseOption) (*ProjectPhase, error) {
+	cfg := newUpdateProjectPhaseOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.UpdateProjectPhaseWithBodyWithResponse(ctx, int(id), "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectPhase](resp.HTTPResponse, resp.Body, "project phase")
+}
+
+func (s *ProjectPhasesService) Delete(ctx context.Context, id ProjectPhaseID, opts ...ProjectPhaseRequestOption) (*ProjectPhaseDeleteResult, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectPhaseRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteProjectPhaseWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectPhaseDeleteResult](resp.HTTPResponse, resp.Body, "project phase delete")
+}

--- a/pipedrive/v2/project_phases_test.go
+++ b/pipedrive/v2/project_phases_test.go
@@ -1,0 +1,60 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestProjectPhasesService_AllOperations(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /phases":
+			if r.URL.Query().Get("board_id") != "2" {
+				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":3,"name":"Build","board_id":2,"order_nr":1}]}`))
+		case "POST /phases":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["name"] != "Build" || body["board_id"] != float64(2) {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":3,"name":"Build","board_id":2}}`))
+		case "GET /phases/3":
+			_, _ = w.Write([]byte(`{"data":{"id":3,"name":"Build","board_id":2}}`))
+		case "PATCH /phases/3":
+			_, _ = w.Write([]byte(`{"data":{"id":3,"name":"Test","board_id":2}}`))
+		case "DELETE /phases/3":
+			_, _ = w.Write([]byte(`{"data":{"id":3}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	ctx := context.Background()
+	items, err := client.ProjectPhases.List(ctx, 2)
+	if err != nil || len(items) != 1 || items[0].ID != 3 {
+		t.Fatalf("List = %#v, %v", items, err)
+	}
+	created, err := client.ProjectPhases.Create(ctx, WithProjectPhaseName("Build"), WithProjectPhaseBoardID(2), WithProjectPhaseOrder(1))
+	if err != nil || created.ID != 3 {
+		t.Fatalf("Create = %#v, %v", created, err)
+	}
+	got, err := client.ProjectPhases.Get(ctx, 3)
+	if err != nil || got.ID != 3 {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+	updated, err := client.ProjectPhases.Update(ctx, 3, WithProjectPhaseName("Test"))
+	if err != nil || updated.Name != "Test" {
+		t.Fatalf("Update = %#v, %v", updated, err)
+	}
+	deleted, err := client.ProjectPhases.Delete(ctx, 3)
+	if err != nil || deleted.ID != 3 {
+		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+}

--- a/pipedrive/v2/project_phases_test.go
+++ b/pipedrive/v2/project_phases_test.go
@@ -5,11 +5,16 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestProjectPhasesService_AllOperations(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "project-phases" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method + " " + r.URL.Path {
 		case "GET /phases":
@@ -37,23 +42,24 @@ func TestProjectPhasesService_AllOperations(t *testing.T) {
 		}
 	})
 	ctx := context.Background()
-	items, err := client.ProjectPhases.List(ctx, 2)
+	requestOpt := WithProjectPhaseRequestOptions(pipedrive.WithHeader("X-Test", "project-phases"))
+	items, err := client.ProjectPhases.List(ctx, 2, requestOpt)
 	if err != nil || len(items) != 1 || items[0].ID != 3 {
 		t.Fatalf("List = %#v, %v", items, err)
 	}
-	created, err := client.ProjectPhases.Create(ctx, WithProjectPhaseName("Build"), WithProjectPhaseBoardID(2), WithProjectPhaseOrder(1))
+	created, err := client.ProjectPhases.Create(ctx, WithProjectPhaseName("Build"), WithProjectPhaseBoardID(2), WithProjectPhaseOrder(1), requestOpt)
 	if err != nil || created.ID != 3 {
 		t.Fatalf("Create = %#v, %v", created, err)
 	}
-	got, err := client.ProjectPhases.Get(ctx, 3)
+	got, err := client.ProjectPhases.Get(ctx, 3, requestOpt)
 	if err != nil || got.ID != 3 {
 		t.Fatalf("Get = %#v, %v", got, err)
 	}
-	updated, err := client.ProjectPhases.Update(ctx, 3, WithProjectPhaseName("Test"))
+	updated, err := client.ProjectPhases.Update(ctx, 3, WithProjectPhaseName("Test"), requestOpt)
 	if err != nil || updated.Name != "Test" {
 		t.Fatalf("Update = %#v, %v", updated, err)
 	}
-	deleted, err := client.ProjectPhases.Delete(ctx, 3)
+	deleted, err := client.ProjectPhases.Delete(ctx, 3, requestOpt)
 	if err != nil || deleted.ID != 3 {
 		t.Fatalf("Delete = %#v, %v", deleted, err)
 	}

--- a/pipedrive/v2/project_templates.go
+++ b/pipedrive/v2/project_templates.go
@@ -1,0 +1,128 @@
+package v2
+
+import (
+	"context"
+	"time"
+
+	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type ProjectTemplate struct {
+	ID          ProjectTemplateID `json:"id"`
+	Title       string            `json:"title,omitempty"`
+	Description string            `json:"description,omitempty"`
+	BoardID     ProjectBoardID    `json:"projects_board_id,omitempty"`
+	OwnerID     UserID            `json:"owner_id,omitempty"`
+	AddTime     *time.Time        `json:"add_time,omitempty"`
+	UpdateTime  *time.Time        `json:"update_time,omitempty"`
+}
+
+type ProjectTemplatesService struct{ client *Client }
+
+type ListProjectTemplatesOption interface {
+	applyListProjectTemplates(*listProjectTemplatesOptions)
+}
+type ProjectTemplateRequestOption interface {
+	ListProjectTemplatesOption
+	projectTemplateRequestOptions() []pipedrive.RequestOption
+}
+
+type listProjectTemplatesOptions struct {
+	params         genv2.GetProjectTemplatesParams
+	requestOptions []pipedrive.RequestOption
+}
+
+type listProjectTemplatesOptionFunc func(*listProjectTemplatesOptions)
+
+func (f listProjectTemplatesOptionFunc) applyListProjectTemplates(cfg *listProjectTemplatesOptions) {
+	f(cfg)
+}
+
+type projectTemplateRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o projectTemplateRequestOption) projectTemplateRequestOptions() []pipedrive.RequestOption {
+	return o.options
+}
+func (o projectTemplateRequestOption) applyListProjectTemplates(cfg *listProjectTemplatesOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+func WithProjectTemplateRequestOptions(opts ...pipedrive.RequestOption) ProjectTemplateRequestOption {
+	return projectTemplateRequestOption{options: opts}
+}
+func WithProjectTemplatesPageSize(limit int) ListProjectTemplatesOption {
+	return listProjectTemplatesOptionFunc(func(cfg *listProjectTemplatesOptions) {
+		if limit > 0 {
+			cfg.params.Limit = &limit
+		}
+	})
+}
+func WithProjectTemplatesCursor(cursor string) ListProjectTemplatesOption {
+	return listProjectTemplatesOptionFunc(func(cfg *listProjectTemplatesOptions) {
+		if cursor != "" {
+			cfg.params.Cursor = &cursor
+		}
+	})
+}
+
+func newListProjectTemplatesOptions(opts []ListProjectTemplatesOption) listProjectTemplatesOptions {
+	var cfg listProjectTemplatesOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListProjectTemplates(&cfg)
+		}
+	}
+	return cfg
+}
+func projectTemplateRequestOptionValues(opts []ProjectTemplateRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.projectTemplateRequestOptions()...)
+		}
+	}
+	return out
+}
+
+func (s *ProjectTemplatesService) List(ctx context.Context, opts ...ListProjectTemplatesOption) ([]ProjectTemplate, *string, error) {
+	cfg := newListProjectTemplatesOptions(opts)
+	return s.list(ctx, cfg.params, cfg.requestOptions)
+}
+
+func (s *ProjectTemplatesService) ListPager(opts ...ListProjectTemplatesOption) *pipedrive.CursorPager[ProjectTemplate] {
+	cfg := newListProjectTemplatesOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]ProjectTemplate, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.list(ctx, params, cfg.requestOptions)
+	})
+}
+
+func (s *ProjectTemplatesService) ForEach(ctx context.Context, fn func(ProjectTemplate) error, opts ...ListProjectTemplatesOption) error {
+	return s.ListPager(opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectTemplatesService) Get(ctx context.Context, id ProjectTemplateID, opts ...ProjectTemplateRequestOption) (*ProjectTemplate, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectTemplateRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectTemplateWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectTemplate](resp.HTTPResponse, resp.Body, "project template")
+}
+
+func (s *ProjectTemplatesService) list(ctx context.Context, params genv2.GetProjectTemplatesParams, requestOptions []pipedrive.RequestOption) ([]ProjectTemplate, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetProjectTemplatesWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[ProjectTemplate](resp.HTTPResponse, resp.Body)
+}

--- a/pipedrive/v2/project_templates_test.go
+++ b/pipedrive/v2/project_templates_test.go
@@ -4,15 +4,20 @@ import (
 	"context"
 	"net/http"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestProjectTemplatesService_AllOperations(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "project-templates" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/projectTemplates":
-			if r.URL.Query().Get("limit") != "10" {
+			if r.URL.Query().Get("limit") != "10" || r.URL.Query().Get("cursor") != "templates-start" {
 				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`{"data":[{"id":6,"title":"Launch","projects_board_id":2}],"additional_data":{"next_cursor":null}}`))
@@ -23,12 +28,59 @@ func TestProjectTemplatesService_AllOperations(t *testing.T) {
 		}
 	})
 	ctx := context.Background()
-	items, _, err := client.ProjectTemplates.List(ctx, WithProjectTemplatesPageSize(10))
+	requestOpt := WithProjectTemplateRequestOptions(pipedrive.WithHeader("X-Test", "project-templates"))
+	items, _, err := client.ProjectTemplates.List(ctx,
+		WithProjectTemplatesPageSize(10),
+		WithProjectTemplatesCursor("templates-start"),
+		requestOpt,
+	)
 	if err != nil || len(items) != 1 || items[0].ID != 6 {
 		t.Fatalf("List = %#v, %v", items, err)
 	}
-	got, err := client.ProjectTemplates.Get(ctx, 6)
+	got, err := client.ProjectTemplates.Get(ctx, 6, requestOpt)
 	if err != nil || got.ID != 6 {
 		t.Fatalf("Get = %#v, %v", got, err)
+	}
+}
+
+func TestProjectTemplatesService_PagerAndIterator(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/projectTemplates" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("cursor") {
+		case "start":
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case "next":
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			_, _ = w.Write([]byte(`{"data":[{"id":3}],"additional_data":{"next_cursor":null}}`))
+		}
+	})
+
+	ctx := context.Background()
+	pager := client.ProjectTemplates.ListPager(WithProjectTemplatesPageSize(2), WithProjectTemplatesCursor("start"))
+	var ids []ProjectTemplateID
+	for pager.Next(ctx) {
+		for _, template := range pager.Items() {
+			ids = append(ids, template.ID)
+		}
+	}
+	if err := pager.Err(); err != nil || len(ids) != 2 || ids[1] != 2 {
+		t.Fatalf("pager = %v, %v", ids, err)
+	}
+
+	var iterated []ProjectTemplateID
+	if err := client.ProjectTemplates.ForEach(ctx, func(template ProjectTemplate) error {
+		iterated = append(iterated, template.ID)
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(iterated) != 1 || iterated[0] != 3 {
+		t.Fatalf("unexpected iterated templates: %v", iterated)
 	}
 }

--- a/pipedrive/v2/project_templates_test.go
+++ b/pipedrive/v2/project_templates_test.go
@@ -1,0 +1,34 @@
+package v2
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestProjectTemplatesService_AllOperations(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/projectTemplates":
+			if r.URL.Query().Get("limit") != "10" {
+				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":6,"title":"Launch","projects_board_id":2}],"additional_data":{"next_cursor":null}}`))
+		case "/projectTemplates/6":
+			_, _ = w.Write([]byte(`{"data":{"id":6,"title":"Launch","projects_board_id":2}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	})
+	ctx := context.Background()
+	items, _, err := client.ProjectTemplates.List(ctx, WithProjectTemplatesPageSize(10))
+	if err != nil || len(items) != 1 || items[0].ID != 6 {
+		t.Fatalf("List = %#v, %v", items, err)
+	}
+	got, err := client.ProjectTemplates.Get(ctx, 6)
+	if err != nil || got.ID != 6 {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+}

--- a/pipedrive/v2/projects.go
+++ b/pipedrive/v2/projects.go
@@ -1,0 +1,833 @@
+package v2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type ProjectStatus string
+
+const (
+	ProjectStatusOpen      ProjectStatus = "open"
+	ProjectStatusCompleted ProjectStatus = "completed"
+	ProjectStatusCanceled  ProjectStatus = "canceled"
+	ProjectStatusDeleted   ProjectStatus = "deleted"
+)
+
+type ProjectSearchField string
+
+const (
+	ProjectSearchFieldCustomFields ProjectSearchField = "custom_fields"
+	ProjectSearchFieldNotes        ProjectSearchField = "notes"
+	ProjectSearchFieldTitle        ProjectSearchField = "title"
+	ProjectSearchFieldDescription  ProjectSearchField = "description"
+)
+
+type Project struct {
+	ID               ProjectID              `json:"id"`
+	Title            string                 `json:"title,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	Status           ProjectStatus          `json:"status,omitempty"`
+	BoardID          ProjectBoardID         `json:"board_id,omitempty"`
+	PhaseID          ProjectPhaseID         `json:"phase_id,omitempty"`
+	OwnerID          UserID                 `json:"owner_id,omitempty"`
+	StartDate        string                 `json:"start_date,omitempty"`
+	EndDate          string                 `json:"end_date,omitempty"`
+	DealIDs          []DealID               `json:"deal_ids,omitempty"`
+	PersonIDs        []PersonID             `json:"person_ids,omitempty"`
+	OrganizationIDs  []OrganizationID       `json:"org_ids,omitempty"`
+	LabelIDs         []int                  `json:"label_ids,omitempty"`
+	HealthStatus     *int                   `json:"health_status,omitempty"`
+	AddTime          *time.Time             `json:"add_time,omitempty"`
+	UpdateTime       *time.Time             `json:"update_time,omitempty"`
+	StatusChangeTime *time.Time             `json:"status_change_time,omitempty"`
+	ArchiveTime      *time.Time             `json:"archive_time,omitempty"`
+	CustomFields     map[string]interface{} `json:"custom_fields,omitempty"`
+}
+
+type ProjectSearchResult struct {
+	ResultScore float64           `json:"result_score,omitempty"`
+	Item        ProjectSearchItem `json:"item"`
+}
+
+type ProjectSearchItem struct {
+	ID           ProjectID                  `json:"id"`
+	Type         string                     `json:"type,omitempty"`
+	Title        string                     `json:"title,omitempty"`
+	Status       *ProjectStatus             `json:"status,omitempty"`
+	Owner        *ProjectSearchOwner        `json:"owner,omitempty"`
+	BoardID      *ProjectBoardID            `json:"board_id,omitempty"`
+	Phase        *ProjectSearchPhase        `json:"phase,omitempty"`
+	Person       *ProjectSearchPerson       `json:"person,omitempty"`
+	Organization *ProjectSearchOrganization `json:"organization,omitempty"`
+	Deal         *ProjectSearchDeal         `json:"deal,omitempty"`
+	DealCount    int                        `json:"deal_count,omitempty"`
+	Description  *string                    `json:"description,omitempty"`
+	EndDate      *string                    `json:"end_date,omitempty"`
+	CustomFields []string                   `json:"custom_fields,omitempty"`
+	Notes        []string                   `json:"notes,omitempty"`
+}
+
+type ProjectSearchOwner struct {
+	ID *UserID `json:"id,omitempty"`
+}
+
+type ProjectSearchPhase struct {
+	ID   ProjectPhaseID `json:"id"`
+	Name string         `json:"name,omitempty"`
+}
+
+type ProjectSearchPerson struct {
+	ID   PersonID `json:"id"`
+	Name *string  `json:"name,omitempty"`
+}
+
+type ProjectSearchOrganization struct {
+	ID      OrganizationID `json:"id"`
+	Name    *string        `json:"name,omitempty"`
+	Address *string        `json:"address,omitempty"`
+}
+
+type ProjectSearchDeal struct {
+	ID    DealID  `json:"id"`
+	Title *string `json:"title,omitempty"`
+}
+
+type ProjectChangelogEntry struct {
+	ChangeSource          *string                `json:"change_source,omitempty"`
+	ChangeSourceUserAgent *string                `json:"change_source_user_agent,omitempty"`
+	Time                  *time.Time             `json:"time,omitempty"`
+	NewValues             map[string]interface{} `json:"new_values,omitempty"`
+	OldValues             map[string]interface{} `json:"old_values,omitempty"`
+	ActorUserID           UserID                 `json:"actor_user_id,omitempty"`
+}
+
+type ProjectDeleteResult struct {
+	ID ProjectID `json:"id"`
+}
+
+type ProjectsService struct {
+	client *Client
+}
+
+type ListProjectsOption interface{ applyListProjects(*listProjectsOptions) }
+type ListArchivedProjectsOption interface {
+	applyListArchivedProjects(*listArchivedProjectsOptions)
+}
+
+type ProjectListOption interface {
+	ListProjectsOption
+	ListArchivedProjectsOption
+}
+
+type SearchProjectsOption interface{ applySearchProjects(*searchProjectsOptions) }
+type CreateProjectOption interface{ applyCreateProject(*createProjectOptions) }
+type UpdateProjectOption interface{ applyUpdateProject(*updateProjectOptions) }
+type ListProjectChangelogOption interface {
+	applyListProjectChangelog(*listProjectChangelogOptions)
+}
+
+type ProjectRequestOption interface {
+	ListProjectsOption
+	ListArchivedProjectsOption
+	SearchProjectsOption
+	CreateProjectOption
+	UpdateProjectOption
+	ListProjectChangelogOption
+	projectRequestOptions() []pipedrive.RequestOption
+}
+
+type ProjectOption interface {
+	CreateProjectOption
+	UpdateProjectOption
+}
+
+type listProjectsOptions struct {
+	params         genv2.GetProjectsParams
+	requestOptions []pipedrive.RequestOption
+}
+
+type listArchivedProjectsOptions struct {
+	params         genv2.GetArchivedProjectsParams
+	requestOptions []pipedrive.RequestOption
+}
+
+type searchProjectsOptions struct {
+	params         genv2.SearchProjectsParams
+	requestOptions []pipedrive.RequestOption
+}
+
+type listProjectChangelogOptions struct {
+	params         genv2.GetProjectChangelogParams
+	requestOptions []pipedrive.RequestOption
+}
+
+type createProjectOptions struct {
+	payload        projectPayload
+	requestOptions []pipedrive.RequestOption
+}
+
+type updateProjectOptions struct {
+	payload        projectPayload
+	requestOptions []pipedrive.RequestOption
+}
+
+type projectPayload struct {
+	title           *string
+	description     *string
+	status          *ProjectStatus
+	boardID         *ProjectBoardID
+	phaseID         *ProjectPhaseID
+	ownerID         *UserID
+	startDate       *string
+	endDate         *string
+	healthStatus    *int
+	templateID      *ProjectTemplateID
+	dealIDs         []DealID
+	dealIDsSet      bool
+	personIDs       []PersonID
+	personIDsSet    bool
+	organizationIDs []OrganizationID
+	orgIDsSet       bool
+	labelIDs        []int
+	labelIDsSet     bool
+	customFields    map[string]interface{}
+}
+
+type projectRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o projectRequestOption) projectRequestOptions() []pipedrive.RequestOption { return o.options }
+func (o projectRequestOption) applyListProjects(cfg *listProjectsOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectRequestOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectRequestOption) applySearchProjects(cfg *searchProjectsOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectRequestOption) applyCreateProject(cfg *createProjectOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectRequestOption) applyUpdateProject(cfg *updateProjectOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o projectRequestOption) applyListProjectChangelog(cfg *listProjectChangelogOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+type listProjectsOptionFunc func(*listProjectsOptions)
+
+func (f listProjectsOptionFunc) applyListProjects(cfg *listProjectsOptions) { f(cfg) }
+
+type listArchivedProjectsOptionFunc func(*listArchivedProjectsOptions)
+
+func (f listArchivedProjectsOptionFunc) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	f(cfg)
+}
+
+type searchProjectsOptionFunc func(*searchProjectsOptions)
+
+func (f searchProjectsOptionFunc) applySearchProjects(cfg *searchProjectsOptions) { f(cfg) }
+
+type listProjectChangelogOptionFunc func(*listProjectChangelogOptions)
+
+func (f listProjectChangelogOptionFunc) applyListProjectChangelog(cfg *listProjectChangelogOptions) {
+	f(cfg)
+}
+
+type projectFieldOption func(*projectPayload)
+
+func (f projectFieldOption) applyCreateProject(cfg *createProjectOptions) { f(&cfg.payload) }
+func (f projectFieldOption) applyUpdateProject(cfg *updateProjectOptions) { f(&cfg.payload) }
+
+func WithProjectRequestOptions(opts ...pipedrive.RequestOption) ProjectRequestOption {
+	return projectRequestOption{options: opts}
+}
+
+func WithProjectFilterID(id int) ProjectListOption {
+	return projectListFilterOption{id: id}
+}
+
+type projectListFilterOption struct{ id int }
+
+func (o projectListFilterOption) applyListProjects(cfg *listProjectsOptions) {
+	cfg.params.FilterId = &o.id
+}
+func (o projectListFilterOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	cfg.params.FilterId = &o.id
+}
+
+func WithProjectsStatus(statuses ...ProjectStatus) ProjectListOption {
+	return projectListStatusOption{status: joinCSV(statuses)}
+}
+
+type projectListStatusOption struct{ status string }
+
+func (o projectListStatusOption) applyListProjects(cfg *listProjectsOptions) {
+	if o.status != "" {
+		cfg.params.Status = &o.status
+	}
+}
+func (o projectListStatusOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	if o.status != "" {
+		cfg.params.Status = &o.status
+	}
+}
+
+func WithProjectsPhaseID(id ProjectPhaseID) ProjectListOption {
+	return projectListPhaseOption{id: int(id)}
+}
+
+type projectListPhaseOption struct{ id int }
+
+func (o projectListPhaseOption) applyListProjects(cfg *listProjectsOptions) {
+	cfg.params.PhaseId = &o.id
+}
+func (o projectListPhaseOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	cfg.params.PhaseId = &o.id
+}
+
+func WithProjectsDealID(id DealID) ListProjectsOption {
+	return listProjectsOptionFunc(func(cfg *listProjectsOptions) { value := int(id); cfg.params.DealId = &value })
+}
+
+func WithProjectsPersonID(id PersonID) ListProjectsOption {
+	return listProjectsOptionFunc(func(cfg *listProjectsOptions) { value := int(id); cfg.params.PersonId = &value })
+}
+
+func WithProjectsOrganizationID(id OrganizationID) ListProjectsOption {
+	return listProjectsOptionFunc(func(cfg *listProjectsOptions) { value := int(id); cfg.params.OrgId = &value })
+}
+
+func WithProjectsPageSize(limit int) ProjectListOption {
+	return projectListPageSizeOption{limit: limit}
+}
+
+type projectListPageSizeOption struct{ limit int }
+
+func (o projectListPageSizeOption) applyListProjects(cfg *listProjectsOptions) {
+	if o.limit > 0 {
+		cfg.params.Limit = &o.limit
+	}
+}
+func (o projectListPageSizeOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	if o.limit > 0 {
+		cfg.params.Limit = &o.limit
+	}
+}
+
+func WithProjectsCursor(cursor string) ProjectListOption {
+	return projectListCursorOption{cursor: cursor}
+}
+
+type projectListCursorOption struct{ cursor string }
+
+func (o projectListCursorOption) applyListProjects(cfg *listProjectsOptions) {
+	if o.cursor != "" {
+		cfg.params.Cursor = &o.cursor
+	}
+}
+func (o projectListCursorOption) applyListArchivedProjects(cfg *listArchivedProjectsOptions) {
+	if o.cursor != "" {
+		cfg.params.Cursor = &o.cursor
+	}
+}
+
+func WithProjectSearchFields(fields ...ProjectSearchField) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) {
+		value := joinCSV(fields)
+		if value != "" {
+			typed := genv2.SearchProjectsParamsFields(value)
+			cfg.params.Fields = &typed
+		}
+	})
+}
+
+func WithProjectSearchExactMatch(exact bool) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) { cfg.params.ExactMatch = &exact })
+}
+
+func WithProjectSearchPersonID(id PersonID) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) { value := int(id); cfg.params.PersonId = &value })
+}
+
+func WithProjectSearchOrganizationID(id OrganizationID) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) { value := int(id); cfg.params.OrganizationId = &value })
+}
+
+func WithProjectSearchPageSize(limit int) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) {
+		if limit > 0 {
+			cfg.params.Limit = &limit
+		}
+	})
+}
+
+func WithProjectSearchCursor(cursor string) SearchProjectsOption {
+	return searchProjectsOptionFunc(func(cfg *searchProjectsOptions) {
+		if cursor != "" {
+			cfg.params.Cursor = &cursor
+		}
+	})
+}
+
+func WithProjectChangelogPageSize(limit int) ListProjectChangelogOption {
+	return listProjectChangelogOptionFunc(func(cfg *listProjectChangelogOptions) {
+		if limit > 0 {
+			cfg.params.Limit = &limit
+		}
+	})
+}
+
+func WithProjectChangelogCursor(cursor string) ListProjectChangelogOption {
+	return listProjectChangelogOptionFunc(func(cfg *listProjectChangelogOptions) {
+		if cursor != "" {
+			cfg.params.Cursor = &cursor
+		}
+	})
+}
+
+func WithProjectTitle(title string) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.title = &title })
+}
+func WithProjectDescription(description string) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.description = &description })
+}
+func WithProjectStatus(status ProjectStatus) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.status = &status })
+}
+func WithProjectBoardID(id ProjectBoardID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.boardID = &id })
+}
+func WithProjectPhaseID(id ProjectPhaseID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.phaseID = &id })
+}
+func WithProjectOwnerID(id UserID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.ownerID = &id })
+}
+func WithProjectStartDate(date string) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.startDate = &date })
+}
+func WithProjectEndDate(date string) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.endDate = &date })
+}
+func WithProjectHealthStatus(status int) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.healthStatus = &status })
+}
+func WithProjectTemplateID(id ProjectTemplateID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.templateID = &id })
+}
+func WithProjectDealIDs(ids ...DealID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.dealIDsSet = true; p.dealIDs = append([]DealID{}, ids...) })
+}
+func WithProjectPersonIDs(ids ...PersonID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.personIDsSet = true; p.personIDs = append([]PersonID{}, ids...) })
+}
+func WithProjectOrganizationIDs(ids ...OrganizationID) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.orgIDsSet = true; p.organizationIDs = append([]OrganizationID{}, ids...) })
+}
+func WithProjectLabelIDs(ids ...int) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.labelIDsSet = true; p.labelIDs = append([]int{}, ids...) })
+}
+func WithProjectCustomFields(fields map[string]interface{}) ProjectOption {
+	return projectFieldOption(func(p *projectPayload) { p.customFields = fields })
+}
+
+func newListProjectsOptions(opts []ListProjectsOption) listProjectsOptions {
+	var cfg listProjectsOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListProjects(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newListArchivedProjectsOptions(opts []ListArchivedProjectsOption) listArchivedProjectsOptions {
+	var cfg listArchivedProjectsOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListArchivedProjects(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newSearchProjectsOptions(term string, opts []SearchProjectsOption) searchProjectsOptions {
+	cfg := searchProjectsOptions{params: genv2.SearchProjectsParams{Term: term}}
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applySearchProjects(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newCreateProjectOptions(opts []CreateProjectOption) createProjectOptions {
+	var cfg createProjectOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyCreateProject(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newUpdateProjectOptions(opts []UpdateProjectOption) updateProjectOptions {
+	var cfg updateProjectOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyUpdateProject(&cfg)
+		}
+	}
+	return cfg
+}
+
+func newProjectChangelogOptions(opts []ListProjectChangelogOption) listProjectChangelogOptions {
+	var cfg listProjectChangelogOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListProjectChangelog(&cfg)
+		}
+	}
+	return cfg
+}
+
+func projectRequestOptionValues(opts []ProjectRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.projectRequestOptions()...)
+		}
+	}
+	return out
+}
+
+func (p projectPayload) body() map[string]interface{} {
+	body := map[string]interface{}{}
+	if p.title != nil {
+		body["title"] = *p.title
+	}
+	if p.description != nil {
+		body["description"] = *p.description
+	}
+	if p.status != nil {
+		body["status"] = string(*p.status)
+	}
+	if p.boardID != nil {
+		body["board_id"] = int(*p.boardID)
+	}
+	if p.phaseID != nil {
+		body["phase_id"] = int(*p.phaseID)
+	}
+	if p.ownerID != nil {
+		body["owner_id"] = int(*p.ownerID)
+	}
+	if p.startDate != nil {
+		body["start_date"] = *p.startDate
+	}
+	if p.endDate != nil {
+		body["end_date"] = *p.endDate
+	}
+	if p.healthStatus != nil {
+		body["health_status"] = *p.healthStatus
+	}
+	if p.templateID != nil {
+		body["template_id"] = int(*p.templateID)
+	}
+	if p.dealIDsSet {
+		body["deal_ids"] = p.dealIDs
+	}
+	if p.personIDsSet {
+		body["person_ids"] = p.personIDs
+	}
+	if p.orgIDsSet {
+		body["org_ids"] = p.organizationIDs
+	}
+	if p.labelIDsSet {
+		body["label_ids"] = p.labelIDs
+	}
+	if p.customFields != nil {
+		body["custom_fields"] = p.customFields
+	}
+	return body
+}
+
+func (s *ProjectsService) List(ctx context.Context, opts ...ListProjectsOption) ([]Project, *string, error) {
+	cfg := newListProjectsOptions(opts)
+	return s.list(ctx, cfg.params, cfg.requestOptions)
+}
+
+func (s *ProjectsService) ListPager(opts ...ListProjectsOption) *pipedrive.CursorPager[Project] {
+	cfg := newListProjectsOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]Project, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.list(ctx, params, cfg.requestOptions)
+	})
+}
+
+func (s *ProjectsService) ForEach(ctx context.Context, fn func(Project) error, opts ...ListProjectsOption) error {
+	return s.ListPager(opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectsService) ListArchived(ctx context.Context, opts ...ListArchivedProjectsOption) ([]Project, *string, error) {
+	cfg := newListArchivedProjectsOptions(opts)
+	return s.listArchived(ctx, cfg.params, cfg.requestOptions)
+}
+
+func (s *ProjectsService) ListArchivedPager(opts ...ListArchivedProjectsOption) *pipedrive.CursorPager[Project] {
+	cfg := newListArchivedProjectsOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]Project, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.listArchived(ctx, params, cfg.requestOptions)
+	})
+}
+
+func (s *ProjectsService) ForEachArchived(ctx context.Context, fn func(Project) error, opts ...ListArchivedProjectsOption) error {
+	return s.ListArchivedPager(opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectsService) Search(ctx context.Context, term string, opts ...SearchProjectsOption) ([]ProjectSearchResult, *string, error) {
+	cfg := newSearchProjectsOptions(term, opts)
+	return s.search(ctx, cfg.params, cfg.requestOptions)
+}
+
+func (s *ProjectsService) SearchPager(term string, opts ...SearchProjectsOption) *pipedrive.CursorPager[ProjectSearchResult] {
+	cfg := newSearchProjectsOptions(term, opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]ProjectSearchResult, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.search(ctx, params, cfg.requestOptions)
+	})
+}
+
+func (s *ProjectsService) ForEachSearch(ctx context.Context, term string, fn func(ProjectSearchResult) error, opts ...SearchProjectsOption) error {
+	return s.SearchPager(term, opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectsService) Get(ctx context.Context, id ProjectID, opts ...ProjectRequestOption) (*Project, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Project](resp.HTTPResponse, resp.Body, "project")
+}
+
+func (s *ProjectsService) Create(ctx context.Context, opts ...CreateProjectOption) (*Project, error) {
+	cfg := newCreateProjectOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.AddProjectWithBodyWithResponse(ctx, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Project](resp.HTTPResponse, resp.Body, "project")
+}
+
+func (s *ProjectsService) Update(ctx context.Context, id ProjectID, opts ...UpdateProjectOption) (*Project, error) {
+	cfg := newUpdateProjectOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.UpdateProjectWithBodyWithResponse(ctx, int(id), "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Project](resp.HTTPResponse, resp.Body, "project")
+}
+
+func (s *ProjectsService) Delete(ctx context.Context, id ProjectID, opts ...ProjectRequestOption) (*ProjectDeleteResult, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteProjectWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[ProjectDeleteResult](resp.HTTPResponse, resp.Body, "project delete")
+}
+
+func (s *ProjectsService) Archive(ctx context.Context, id ProjectID, opts ...ProjectRequestOption) (*Project, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectRequestOptionValues(opts)...)
+	resp, err := s.client.gen.ArchiveProjectWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Project](resp.HTTPResponse, resp.Body, "archived project")
+}
+
+func (s *ProjectsService) ListChangelog(ctx context.Context, id ProjectID, opts ...ListProjectChangelogOption) ([]ProjectChangelogEntry, *string, error) {
+	cfg := newProjectChangelogOptions(opts)
+	return s.listChangelog(ctx, id, cfg.params, cfg.requestOptions)
+}
+
+func (s *ProjectsService) ChangelogPager(id ProjectID, opts ...ListProjectChangelogOption) *pipedrive.CursorPager[ProjectChangelogEntry] {
+	cfg := newProjectChangelogOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]ProjectChangelogEntry, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.listChangelog(ctx, id, params, cfg.requestOptions)
+	})
+}
+
+func (s *ProjectsService) ForEachChangelog(ctx context.Context, id ProjectID, fn func(ProjectChangelogEntry) error, opts ...ListProjectChangelogOption) error {
+	return s.ChangelogPager(id, opts...).ForEach(ctx, fn)
+}
+
+func (s *ProjectsService) ListPermittedUsers(ctx context.Context, id ProjectID, opts ...ProjectRequestOption) ([]UserID, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, projectRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetProjectUsersWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2ListNoCursor[UserID](resp.HTTPResponse, resp.Body)
+}
+
+func (s *ProjectsService) list(ctx context.Context, params genv2.GetProjectsParams, requestOptions []pipedrive.RequestOption) ([]Project, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetProjectsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[Project](resp.HTTPResponse, resp.Body)
+}
+
+func (s *ProjectsService) listArchived(ctx context.Context, params genv2.GetArchivedProjectsParams, requestOptions []pipedrive.RequestOption) ([]Project, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetArchivedProjectsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[Project](resp.HTTPResponse, resp.Body)
+}
+
+func (s *ProjectsService) search(ctx context.Context, params genv2.SearchProjectsParams, requestOptions []pipedrive.RequestOption) ([]ProjectSearchResult, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.SearchProjectsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	}
+	var payload struct {
+		Data struct {
+			Items []ProjectSearchResult `json:"items"`
+		} `json:"data"`
+		AdditionalData *struct {
+			NextCursor *string `json:"next_cursor"`
+		} `json:"additional_data"`
+	}
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return nil, nil, fmt.Errorf("decode response: %w", err)
+	}
+	var next *string
+	if payload.AdditionalData != nil {
+		next = payload.AdditionalData.NextCursor
+	}
+	return payload.Data.Items, next, nil
+}
+
+func (s *ProjectsService) listChangelog(ctx context.Context, id ProjectID, params genv2.GetProjectChangelogParams, requestOptions []pipedrive.RequestOption) ([]ProjectChangelogEntry, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetProjectChangelogWithResponse(ctx, int(id), &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[ProjectChangelogEntry](resp.HTTPResponse, resp.Body)
+}
+
+func encodeV2Body(body map[string]interface{}) (*bytes.Reader, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+	return bytes.NewReader(encoded), nil
+}
+
+func encodeV2ArrayBody(body []map[string]interface{}) (*bytes.Reader, error) {
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+	return bytes.NewReader(encoded), nil
+}
+
+func decodeV2Data[T any](httpResp *http.Response, body []byte, label string) (*T, error) {
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		return nil, errorFromResponse(httpResp, body)
+	}
+	var payload struct {
+		Data *T `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if payload.Data == nil {
+		return nil, fmt.Errorf("missing %s data in response", label)
+	}
+	return payload.Data, nil
+}
+
+func decodeV2List[T any](httpResp *http.Response, body []byte) ([]T, *string, error) {
+	if httpResp.StatusCode < 200 || httpResp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(httpResp, body)
+	}
+	var payload struct {
+		Data           []T `json:"data"`
+		AdditionalData *struct {
+			NextCursor *string `json:"next_cursor"`
+		} `json:"additional_data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, nil, fmt.Errorf("decode response: %w", err)
+	}
+	var next *string
+	if payload.AdditionalData != nil {
+		next = payload.AdditionalData.NextCursor
+	}
+	return payload.Data, next, nil
+}
+
+func decodeV2ListNoCursor[T any](httpResp *http.Response, body []byte) ([]T, error) {
+	items, _, err := decodeV2List[T](httpResp, body)
+	return items, err
+}

--- a/pipedrive/v2/projects_test.go
+++ b/pipedrive/v2/projects_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/juhokoskela/pipedrive-go/pipedrive"
@@ -13,18 +14,35 @@ func TestProjectsService_AllOperations(t *testing.T) {
 	t.Parallel()
 
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "projects" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method + " " + r.URL.Path {
 		case "GET /projects":
-			if got := r.URL.Query().Get("status"); got != "open,completed" {
-				t.Fatalf("unexpected status: %q", got)
+			query := r.URL.Query()
+			if query.Get("filter_id") != "5" || query.Get("status") != "open,completed" ||
+				query.Get("phase_id") != "3" || query.Get("deal_id") != "4" ||
+				query.Get("person_id") != "5" || query.Get("org_id") != "6" ||
+				query.Get("limit") != "25" || query.Get("cursor") != "projects-start" {
+				t.Fatalf("unexpected projects query: %s", r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`{"data":[{"id":1,"title":"Migration"}],"additional_data":{"next_cursor":"next"}}`))
 		case "GET /projects/archived":
+			query := r.URL.Query()
+			if query.Get("filter_id") != "7" || query.Get("status") != "canceled" ||
+				query.Get("phase_id") != "8" || query.Get("limit") != "10" ||
+				query.Get("cursor") != "archived-start" {
+				t.Fatalf("unexpected archived projects query: %s", r.URL.RawQuery)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"id":2,"title":"Archived"}],"additional_data":{"next_cursor":null}}`))
 		case "GET /projects/search":
-			if got := r.URL.Query().Get("term"); got != "migration" {
-				t.Fatalf("unexpected term: %q", got)
+			query := r.URL.Query()
+			if query.Get("term") != "migration" || query.Get("fields") != "title,description" ||
+				query.Get("exact_match") != "true" || query.Get("person_id") != "5" ||
+				query.Get("organization_id") != "6" || query.Get("limit") != "15" ||
+				query.Get("cursor") != "search-start" {
+				t.Fatalf("unexpected search query: %s", r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`{"data":{"items":[{"result_score":0.9,"item":{"id":1,"title":"Migration"}}]},"additional_data":{"next_cursor":null}}`))
 		case "POST /projects":
@@ -32,19 +50,40 @@ func TestProjectsService_AllOperations(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if body["title"] != "Migration" || body["board_id"] != float64(3) {
+			if body["title"] != "Migration" || body["description"] != "Move systems" ||
+				body["status"] != "open" || body["board_id"] != float64(3) ||
+				body["phase_id"] != float64(4) || body["owner_id"] != float64(7) ||
+				body["start_date"] != "2026-08-01" || body["end_date"] != "2026-08-31" ||
+				body["health_status"] != float64(2) || body["template_id"] != float64(9) {
 				t.Fatalf("unexpected body: %#v", body)
+			}
+			if len(body["deal_ids"].([]any)) != 2 || len(body["person_ids"].([]any)) != 1 ||
+				len(body["org_ids"].([]any)) != 1 || len(body["label_ids"].([]any)) != 2 ||
+				body["custom_fields"].(map[string]any)["risk"] != "high" {
+				t.Fatalf("unexpected collection fields: %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Migration"}}`))
 		case "GET /projects/1":
 			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Migration"}}`))
 		case "PATCH /projects/1":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["title"] != "Updated" || len(body["deal_ids"].([]any)) != 0 ||
+				len(body["person_ids"].([]any)) != 0 || len(body["org_ids"].([]any)) != 0 ||
+				len(body["label_ids"].([]any)) != 0 {
+				t.Fatalf("unexpected update body: %#v", body)
+			}
 			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Updated"}}`))
 		case "DELETE /projects/1":
 			_, _ = w.Write([]byte(`{"data":{"id":1}}`))
 		case "POST /projects/1/archive":
 			_, _ = w.Write([]byte(`{"data":{"id":1,"archive_time":"2026-08-06T10:00:00Z"}}`))
 		case "GET /projects/1/changelog":
+			if query := r.URL.Query(); query.Get("limit") != "20" || query.Get("cursor") != "changes-start" {
+				t.Fatalf("unexpected changelog query: %s", r.URL.RawQuery)
+			}
 			_, _ = w.Write([]byte(`{"data":[{"time":"2026-08-06T10:00:00Z","actor_user_id":7,"new_values":{"title":"Updated"},"old_values":{"title":"Migration"}}],"additional_data":{"next_cursor":null}}`))
 		case "GET /projects/1/permittedUsers":
 			_, _ = w.Write([]byte(`{"data":[7,8]}`))
@@ -54,45 +93,187 @@ func TestProjectsService_AllOperations(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	projects, next, err := client.Projects.List(ctx, WithProjectsStatus(ProjectStatusOpen, ProjectStatusCompleted))
+	requestOpt := WithProjectRequestOptions(pipedrive.WithHeader("X-Test", "projects"))
+	projects, next, err := client.Projects.List(ctx,
+		WithProjectFilterID(5),
+		WithProjectsStatus(ProjectStatusOpen, ProjectStatusCompleted),
+		WithProjectsPhaseID(3),
+		WithProjectsDealID(4),
+		WithProjectsPersonID(5),
+		WithProjectsOrganizationID(6),
+		WithProjectsPageSize(25),
+		WithProjectsCursor("projects-start"),
+		requestOpt,
+	)
 	if err != nil || len(projects) != 1 || projects[0].ID != 1 || next == nil || *next != "next" {
 		t.Fatalf("List = %#v, %v, %v", projects, next, err)
 	}
-	archived, _, err := client.Projects.ListArchived(ctx)
+	archived, _, err := client.Projects.ListArchived(ctx,
+		WithProjectFilterID(7),
+		WithProjectsStatus(ProjectStatusCanceled),
+		WithProjectsPhaseID(8),
+		WithProjectsPageSize(10),
+		WithProjectsCursor("archived-start"),
+		requestOpt,
+	)
 	if err != nil || len(archived) != 1 || archived[0].ID != 2 {
 		t.Fatalf("ListArchived = %#v, %v", archived, err)
 	}
-	results, _, err := client.Projects.Search(ctx, "migration", WithProjectSearchFields(ProjectSearchFieldTitle))
+	results, _, err := client.Projects.Search(ctx, "migration",
+		WithProjectSearchFields(ProjectSearchFieldTitle, ProjectSearchFieldDescription),
+		WithProjectSearchExactMatch(true),
+		WithProjectSearchPersonID(5),
+		WithProjectSearchOrganizationID(6),
+		WithProjectSearchPageSize(15),
+		WithProjectSearchCursor("search-start"),
+		requestOpt,
+	)
 	if err != nil || len(results) != 1 || results[0].Item.ID != 1 {
 		t.Fatalf("Search = %#v, %v", results, err)
 	}
-	created, err := client.Projects.Create(ctx, WithProjectTitle("Migration"), WithProjectBoardID(3))
+	created, err := client.Projects.Create(ctx,
+		WithProjectTitle("Migration"),
+		WithProjectDescription("Move systems"),
+		WithProjectStatus(ProjectStatusOpen),
+		WithProjectBoardID(3),
+		WithProjectPhaseID(4),
+		WithProjectOwnerID(7),
+		WithProjectStartDate("2026-08-01"),
+		WithProjectEndDate("2026-08-31"),
+		WithProjectHealthStatus(2),
+		WithProjectTemplateID(9),
+		WithProjectDealIDs(10, 11),
+		WithProjectPersonIDs(12),
+		WithProjectOrganizationIDs(13),
+		WithProjectLabelIDs(14, 15),
+		WithProjectCustomFields(map[string]interface{}{"risk": "high"}),
+		requestOpt,
+	)
 	if err != nil || created.ID != 1 {
 		t.Fatalf("Create = %#v, %v", created, err)
 	}
-	got, err := client.Projects.Get(ctx, 1)
+	got, err := client.Projects.Get(ctx, 1, requestOpt)
 	if err != nil || got.ID != 1 {
 		t.Fatalf("Get = %#v, %v", got, err)
 	}
-	updated, err := client.Projects.Update(ctx, 1, WithProjectTitle("Updated"))
+	updated, err := client.Projects.Update(ctx, 1,
+		WithProjectTitle("Updated"),
+		WithProjectDealIDs(),
+		WithProjectPersonIDs(),
+		WithProjectOrganizationIDs(),
+		WithProjectLabelIDs(),
+		requestOpt,
+	)
 	if err != nil || updated.Title != "Updated" {
 		t.Fatalf("Update = %#v, %v", updated, err)
 	}
-	deleted, err := client.Projects.Delete(ctx, 1)
+	deleted, err := client.Projects.Delete(ctx, 1, requestOpt)
 	if err != nil || deleted.ID != 1 {
 		t.Fatalf("Delete = %#v, %v", deleted, err)
 	}
-	archivedProject, err := client.Projects.Archive(ctx, 1)
+	archivedProject, err := client.Projects.Archive(ctx, 1, requestOpt)
 	if err != nil || archivedProject.ArchiveTime == nil {
 		t.Fatalf("Archive = %#v, %v", archivedProject, err)
 	}
-	changes, _, err := client.Projects.ListChangelog(ctx, 1)
+	changes, _, err := client.Projects.ListChangelog(ctx, 1,
+		WithProjectChangelogPageSize(20),
+		WithProjectChangelogCursor("changes-start"),
+		requestOpt,
+	)
 	if err != nil || len(changes) != 1 || changes[0].ActorUserID != 7 {
 		t.Fatalf("ListChangelog = %#v, %v", changes, err)
 	}
-	users, err := client.Projects.ListPermittedUsers(ctx, 1, WithProjectRequestOptions(pipedrive.WithHeader("X-Test", "users")))
+	users, err := client.Projects.ListPermittedUsers(ctx, 1, requestOpt)
 	if err != nil || len(users) != 2 || users[1] != 8 {
 		t.Fatalf("ListPermittedUsers = %#v, %v", users, err)
+	}
+}
+
+func TestProjectsService_PagersAndIterators(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		cursor := r.URL.Query().Get("cursor")
+		id := 1
+		next := `null`
+		if cursor == "start" {
+			next = `"next"`
+		} else if cursor == "next" {
+			id = 2
+		}
+		switch r.URL.Path {
+		case "/projects", "/projects/archived":
+			_, _ = w.Write([]byte(`{"data":[{"id":` + strconv.Itoa(id) + `}],"additional_data":{"next_cursor":` + next + `}}`))
+		case "/projects/search":
+			_, _ = w.Write([]byte(`{"data":{"items":[{"item":{"id":` + strconv.Itoa(id) + `}}]},"additional_data":{"next_cursor":` + next + `}}`))
+		case "/projects/1/changelog":
+			_, _ = w.Write([]byte(`{"data":[{"actor_user_id":` + strconv.Itoa(id) + `}],"additional_data":{"next_cursor":` + next + `}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	})
+
+	ctx := context.Background()
+	projectPager := client.Projects.ListPager(WithProjectsPageSize(2), WithProjectsCursor("start"))
+	var projectIDs []ProjectID
+	for projectPager.Next(ctx) {
+		for _, project := range projectPager.Items() {
+			projectIDs = append(projectIDs, project.ID)
+		}
+	}
+	if err := projectPager.Err(); err != nil || len(projectIDs) != 2 || projectIDs[1] != 2 {
+		t.Fatalf("project pager = %v, %v", projectIDs, err)
+	}
+
+	archivedPager := client.Projects.ListArchivedPager(WithProjectsCursor("start"))
+	var archivedIDs []ProjectID
+	for archivedPager.Next(ctx) {
+		for _, project := range archivedPager.Items() {
+			archivedIDs = append(archivedIDs, project.ID)
+		}
+	}
+	if err := archivedPager.Err(); err != nil || len(archivedIDs) != 2 {
+		t.Fatalf("archived pager = %v, %v", archivedIDs, err)
+	}
+
+	searchPager := client.Projects.SearchPager("migration", WithProjectSearchCursor("start"))
+	var searchIDs []ProjectID
+	for searchPager.Next(ctx) {
+		for _, result := range searchPager.Items() {
+			searchIDs = append(searchIDs, result.Item.ID)
+		}
+	}
+	if err := searchPager.Err(); err != nil || len(searchIDs) != 2 {
+		t.Fatalf("search pager = %v, %v", searchIDs, err)
+	}
+
+	changelogPager := client.Projects.ChangelogPager(1, WithProjectChangelogCursor("start"))
+	var actors []UserID
+	for changelogPager.Next(ctx) {
+		for _, change := range changelogPager.Items() {
+			actors = append(actors, change.ActorUserID)
+		}
+	}
+	if err := changelogPager.Err(); err != nil || len(actors) != 2 {
+		t.Fatalf("changelog pager = %v, %v", actors, err)
+	}
+
+	var iterated int
+	if err := client.Projects.ForEach(ctx, func(Project) error { iterated++; return nil }); err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if err := client.Projects.ForEachArchived(ctx, func(Project) error { iterated++; return nil }); err != nil {
+		t.Fatalf("ForEachArchived error: %v", err)
+	}
+	if err := client.Projects.ForEachSearch(ctx, "migration", func(ProjectSearchResult) error { iterated++; return nil }); err != nil {
+		t.Fatalf("ForEachSearch error: %v", err)
+	}
+	if err := client.Projects.ForEachChangelog(ctx, 1, func(ProjectChangelogEntry) error { iterated++; return nil }); err != nil {
+		t.Fatalf("ForEachChangelog error: %v", err)
+	}
+	if iterated != 4 {
+		t.Fatalf("unexpected iteration count: %d", iterated)
 	}
 }
 

--- a/pipedrive/v2/projects_test.go
+++ b/pipedrive/v2/projects_test.go
@@ -1,0 +1,108 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func TestProjectsService_AllOperations(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /projects":
+			if got := r.URL.Query().Get("status"); got != "open,completed" {
+				t.Fatalf("unexpected status: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":1,"title":"Migration"}],"additional_data":{"next_cursor":"next"}}`))
+		case "GET /projects/archived":
+			_, _ = w.Write([]byte(`{"data":[{"id":2,"title":"Archived"}],"additional_data":{"next_cursor":null}}`))
+		case "GET /projects/search":
+			if got := r.URL.Query().Get("term"); got != "migration" {
+				t.Fatalf("unexpected term: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":{"items":[{"result_score":0.9,"item":{"id":1,"title":"Migration"}}]},"additional_data":{"next_cursor":null}}`))
+		case "POST /projects":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["title"] != "Migration" || body["board_id"] != float64(3) {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Migration"}}`))
+		case "GET /projects/1":
+			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Migration"}}`))
+		case "PATCH /projects/1":
+			_, _ = w.Write([]byte(`{"data":{"id":1,"title":"Updated"}}`))
+		case "DELETE /projects/1":
+			_, _ = w.Write([]byte(`{"data":{"id":1}}`))
+		case "POST /projects/1/archive":
+			_, _ = w.Write([]byte(`{"data":{"id":1,"archive_time":"2026-08-06T10:00:00Z"}}`))
+		case "GET /projects/1/changelog":
+			_, _ = w.Write([]byte(`{"data":[{"time":"2026-08-06T10:00:00Z","actor_user_id":7,"new_values":{"title":"Updated"},"old_values":{"title":"Migration"}}],"additional_data":{"next_cursor":null}}`))
+		case "GET /projects/1/permittedUsers":
+			_, _ = w.Write([]byte(`{"data":[7,8]}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
+		}
+	})
+
+	ctx := context.Background()
+	projects, next, err := client.Projects.List(ctx, WithProjectsStatus(ProjectStatusOpen, ProjectStatusCompleted))
+	if err != nil || len(projects) != 1 || projects[0].ID != 1 || next == nil || *next != "next" {
+		t.Fatalf("List = %#v, %v, %v", projects, next, err)
+	}
+	archived, _, err := client.Projects.ListArchived(ctx)
+	if err != nil || len(archived) != 1 || archived[0].ID != 2 {
+		t.Fatalf("ListArchived = %#v, %v", archived, err)
+	}
+	results, _, err := client.Projects.Search(ctx, "migration", WithProjectSearchFields(ProjectSearchFieldTitle))
+	if err != nil || len(results) != 1 || results[0].Item.ID != 1 {
+		t.Fatalf("Search = %#v, %v", results, err)
+	}
+	created, err := client.Projects.Create(ctx, WithProjectTitle("Migration"), WithProjectBoardID(3))
+	if err != nil || created.ID != 1 {
+		t.Fatalf("Create = %#v, %v", created, err)
+	}
+	got, err := client.Projects.Get(ctx, 1)
+	if err != nil || got.ID != 1 {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+	updated, err := client.Projects.Update(ctx, 1, WithProjectTitle("Updated"))
+	if err != nil || updated.Title != "Updated" {
+		t.Fatalf("Update = %#v, %v", updated, err)
+	}
+	deleted, err := client.Projects.Delete(ctx, 1)
+	if err != nil || deleted.ID != 1 {
+		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+	archivedProject, err := client.Projects.Archive(ctx, 1)
+	if err != nil || archivedProject.ArchiveTime == nil {
+		t.Fatalf("Archive = %#v, %v", archivedProject, err)
+	}
+	changes, _, err := client.Projects.ListChangelog(ctx, 1)
+	if err != nil || len(changes) != 1 || changes[0].ActorUserID != 7 {
+		t.Fatalf("ListChangelog = %#v, %v", changes, err)
+	}
+	users, err := client.Projects.ListPermittedUsers(ctx, 1, WithProjectRequestOptions(pipedrive.WithHeader("X-Test", "users")))
+	if err != nil || len(users) != 2 || users[1] != 8 {
+		t.Fatalf("ListPermittedUsers = %#v, %v", users, err)
+	}
+}
+
+func TestProjectsService_MissingData(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+	if _, err := client.Projects.Get(context.Background(), 1); err == nil {
+		t.Fatal("expected missing data error")
+	}
+}

--- a/pipedrive/v2/projects_test.go
+++ b/pipedrive/v2/projects_test.go
@@ -197,9 +197,10 @@ func TestProjectsService_PagersAndIterators(t *testing.T) {
 		cursor := r.URL.Query().Get("cursor")
 		id := 1
 		next := `null`
-		if cursor == "start" {
+		switch cursor {
+		case "start":
 			next = `"next"`
-		} else if cursor == "next" {
+		case "next":
 			id = 2
 		}
 		switch r.URL.Path {

--- a/pipedrive/v2/response_body_test.go
+++ b/pipedrive/v2/response_body_test.go
@@ -1,0 +1,86 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+func TestResponseBodyCloseError_PreservesAPIError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(context.Context, *Client) error
+	}{
+		{
+			name: "product",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.Products.Get(ctx, 42)
+				return err
+			},
+		},
+		{
+			name: "field",
+			call: func(ctx context.Context, client *Client) error {
+				_, err := client.ProjectFields.Get(ctx, "custom_field")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			const payload = `{"code":"invalid_request","message":"bad request"}`
+			client, err := NewClient(pipedrive.Config{
+				BaseURL: "https://example.test",
+				HTTPClient: &http.Client{Transport: responseRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Header: http.Header{
+							"Content-Type": []string{"application/json"},
+							"X-Request-Id": []string{"request-123"},
+						},
+						Body:    &closeErrorReadCloser{Reader: strings.NewReader(payload)},
+						Request: req,
+					}, nil
+				})},
+			})
+			if err != nil {
+				t.Fatalf("NewClient error: %v", err)
+			}
+
+			err = tt.call(context.Background(), client)
+			var apiErr *pipedrive.APIError
+			if !errors.As(err, &apiErr) {
+				t.Fatalf("expected APIError, got %T: %v", err, err)
+			}
+			if apiErr.Status != http.StatusBadRequest || apiErr.RequestID != "request-123" ||
+				apiErr.Code != "invalid_request" || apiErr.Message != "bad request" ||
+				string(apiErr.Body) != payload {
+				t.Fatalf("unexpected APIError: %#v", apiErr)
+			}
+		})
+	}
+}
+
+type responseRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f responseRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type closeErrorReadCloser struct {
+	io.Reader
+}
+
+func (c *closeErrorReadCloser) Close() error {
+	return errors.New("close failed")
+}

--- a/pipedrive/v2/tasks.go
+++ b/pipedrive/v2/tasks.go
@@ -1,0 +1,356 @@
+package v2
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	genv2 "github.com/juhokoskela/pipedrive-go/internal/gen/v2"
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
+)
+
+type Task struct {
+	ID               TaskID     `json:"id"`
+	Title            string     `json:"title,omitempty"`
+	CreatorID        UserID     `json:"creator_id,omitempty"`
+	Description      *string    `json:"description,omitempty"`
+	ProjectID        ProjectID  `json:"project_id,omitempty"`
+	IsDone           bool       `json:"is_done,omitempty"`
+	IsMilestone      bool       `json:"is_milestone,omitempty"`
+	DueDate          *string    `json:"due_date,omitempty"`
+	StartDate        *string    `json:"start_date,omitempty"`
+	ParentTaskID     *TaskID    `json:"parent_task_id,omitempty"`
+	AssigneeIDs      []UserID   `json:"assignee_ids,omitempty"`
+	Priority         *int       `json:"priority,omitempty"`
+	AddTime          *time.Time `json:"add_time,omitempty"`
+	UpdateTime       *time.Time `json:"update_time,omitempty"`
+	MarkedAsDoneTime *time.Time `json:"marked_as_done_time,omitempty"`
+}
+
+type TaskDeleteResult struct {
+	ID TaskID `json:"id"`
+}
+
+type TasksService struct{ client *Client }
+
+type ListTasksOption interface{ applyListTasks(*listTasksOptions) }
+type CreateTaskOption interface{ applyCreateTask(*createTaskOptions) }
+type UpdateTaskOption interface{ applyUpdateTask(*updateTaskOptions) }
+
+type TaskOption interface {
+	CreateTaskOption
+	UpdateTaskOption
+}
+
+type TaskRequestOption interface {
+	ListTasksOption
+	CreateTaskOption
+	UpdateTaskOption
+	taskRequestOptions() []pipedrive.RequestOption
+}
+
+type listTasksOptions struct {
+	params         genv2.GetTasksParams
+	requestOptions []pipedrive.RequestOption
+}
+type createTaskOptions struct {
+	payload        taskPayload
+	requestOptions []pipedrive.RequestOption
+}
+type updateTaskOptions struct {
+	payload        taskPayload
+	requestOptions []pipedrive.RequestOption
+}
+
+type nullableTaskValue[T any] struct {
+	set   bool
+	value *T
+}
+
+type taskPayload struct {
+	title          *string
+	projectID      *ProjectID
+	parentTaskID   nullableTaskValue[TaskID]
+	description    nullableTaskValue[string]
+	done           *bool
+	milestone      *bool
+	dueDate        nullableTaskValue[string]
+	startDate      nullableTaskValue[string]
+	assigneeID     nullableTaskValue[UserID]
+	assigneeIDs    []UserID
+	assigneeIDsSet bool
+	priority       nullableTaskValue[int]
+}
+
+type listTasksOptionFunc func(*listTasksOptions)
+
+func (f listTasksOptionFunc) applyListTasks(cfg *listTasksOptions) { f(cfg) }
+
+type taskFieldOption func(*taskPayload)
+
+func (f taskFieldOption) applyCreateTask(cfg *createTaskOptions) { f(&cfg.payload) }
+func (f taskFieldOption) applyUpdateTask(cfg *updateTaskOptions) { f(&cfg.payload) }
+
+type taskRequestOption struct{ options []pipedrive.RequestOption }
+
+func (o taskRequestOption) taskRequestOptions() []pipedrive.RequestOption { return o.options }
+func (o taskRequestOption) applyListTasks(cfg *listTasksOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o taskRequestOption) applyCreateTask(cfg *createTaskOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+func (o taskRequestOption) applyUpdateTask(cfg *updateTaskOptions) {
+	cfg.requestOptions = append(cfg.requestOptions, o.options...)
+}
+
+func WithTaskRequestOptions(opts ...pipedrive.RequestOption) TaskRequestOption {
+	return taskRequestOption{options: opts}
+}
+func WithTasksPageSize(limit int) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) {
+		if limit > 0 {
+			cfg.params.Limit = &limit
+		}
+	})
+}
+func WithTasksCursor(cursor string) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) {
+		if cursor != "" {
+			cfg.params.Cursor = &cursor
+		}
+	})
+}
+func WithTasksDone(done bool) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) { cfg.params.IsDone = &done })
+}
+func WithTasksMilestone(milestone bool) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) { cfg.params.IsMilestone = &milestone })
+}
+func WithTasksAssigneeID(id UserID) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) { value := int(id); cfg.params.AssigneeId = &value })
+}
+func WithTasksProjectID(id ProjectID) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) { value := int(id); cfg.params.ProjectId = &value })
+}
+func WithTasksParentTaskID(id TaskID) ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) {
+		value := strconv.FormatInt(int64(id), 10)
+		cfg.params.ParentTaskId = &value
+	})
+}
+func WithTasksRootOnly() ListTasksOption {
+	return listTasksOptionFunc(func(cfg *listTasksOptions) { value := "null"; cfg.params.ParentTaskId = &value })
+}
+
+func WithTaskTitle(title string) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.title = &title })
+}
+func WithTaskProjectID(id ProjectID) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.projectID = &id })
+}
+func WithTaskParentTaskID(id TaskID) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.parentTaskID = nullableTaskValue[TaskID]{set: true, value: &id} })
+}
+func ClearTaskParentTaskID() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.parentTaskID = nullableTaskValue[TaskID]{set: true} })
+}
+func WithTaskDescription(description string) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.description = nullableTaskValue[string]{set: true, value: &description} })
+}
+func ClearTaskDescription() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.description = nullableTaskValue[string]{set: true} })
+}
+func WithTaskDone(done bool) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.done = &done })
+}
+func WithTaskMilestone(milestone bool) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.milestone = &milestone })
+}
+func WithTaskDueDate(date string) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.dueDate = nullableTaskValue[string]{set: true, value: &date} })
+}
+func ClearTaskDueDate() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.dueDate = nullableTaskValue[string]{set: true} })
+}
+func WithTaskStartDate(date string) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.startDate = nullableTaskValue[string]{set: true, value: &date} })
+}
+func ClearTaskStartDate() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.startDate = nullableTaskValue[string]{set: true} })
+}
+func WithTaskAssigneeID(id UserID) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.assigneeID = nullableTaskValue[UserID]{set: true, value: &id} })
+}
+func ClearTaskAssigneeID() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.assigneeID = nullableTaskValue[UserID]{set: true} })
+}
+func WithTaskAssigneeIDs(ids ...UserID) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.assigneeIDsSet = true; p.assigneeIDs = append([]UserID{}, ids...) })
+}
+func WithTaskPriority(priority int) TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.priority = nullableTaskValue[int]{set: true, value: &priority} })
+}
+func ClearTaskPriority() TaskOption {
+	return taskFieldOption(func(p *taskPayload) { p.priority = nullableTaskValue[int]{set: true} })
+}
+
+func newListTasksOptions(opts []ListTasksOption) listTasksOptions {
+	var cfg listTasksOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyListTasks(&cfg)
+		}
+	}
+	return cfg
+}
+func newCreateTaskOptions(opts []CreateTaskOption) createTaskOptions {
+	var cfg createTaskOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyCreateTask(&cfg)
+		}
+	}
+	return cfg
+}
+func newUpdateTaskOptions(opts []UpdateTaskOption) updateTaskOptions {
+	var cfg updateTaskOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt.applyUpdateTask(&cfg)
+		}
+	}
+	return cfg
+}
+func taskRequestOptionValues(opts []TaskRequestOption) []pipedrive.RequestOption {
+	var out []pipedrive.RequestOption
+	for _, opt := range opts {
+		if opt != nil {
+			out = append(out, opt.taskRequestOptions()...)
+		}
+	}
+	return out
+}
+
+func (p taskPayload) body() map[string]interface{} {
+	body := map[string]interface{}{}
+	if p.title != nil {
+		body["title"] = *p.title
+	}
+	if p.projectID != nil {
+		body["project_id"] = int(*p.projectID)
+	}
+	if p.parentTaskID.set {
+		body["parent_task_id"] = p.parentTaskID.value
+	}
+	if p.description.set {
+		body["description"] = p.description.value
+	}
+	if p.done != nil {
+		if *p.done {
+			body["done"] = 1
+		} else {
+			body["done"] = 0
+		}
+	}
+	if p.milestone != nil {
+		if *p.milestone {
+			body["milestone"] = 1
+		} else {
+			body["milestone"] = 0
+		}
+	}
+	if p.dueDate.set {
+		body["due_date"] = p.dueDate.value
+	}
+	if p.startDate.set {
+		body["start_date"] = p.startDate.value
+	}
+	if p.assigneeID.set {
+		body["assignee_id"] = p.assigneeID.value
+	}
+	if p.assigneeIDsSet {
+		body["assignee_ids"] = p.assigneeIDs
+	}
+	if p.priority.set {
+		body["priority"] = p.priority.value
+	}
+	return body
+}
+
+func (s *TasksService) List(ctx context.Context, opts ...ListTasksOption) ([]Task, *string, error) {
+	cfg := newListTasksOptions(opts)
+	return s.list(ctx, cfg.params, cfg.requestOptions)
+}
+func (s *TasksService) ListPager(opts ...ListTasksOption) *pipedrive.CursorPager[Task] {
+	cfg := newListTasksOptions(opts)
+	start := cfg.params.Cursor
+	cfg.params.Cursor = nil
+	return pipedrive.NewCursorPager(func(ctx context.Context, cursor *string) ([]Task, *string, error) {
+		params := cfg.params
+		if cursor != nil {
+			params.Cursor = cursor
+		} else if start != nil {
+			params.Cursor = start
+		}
+		return s.list(ctx, params, cfg.requestOptions)
+	})
+}
+func (s *TasksService) ForEach(ctx context.Context, fn func(Task) error, opts ...ListTasksOption) error {
+	return s.ListPager(opts...).ForEach(ctx, fn)
+}
+
+func (s *TasksService) Get(ctx context.Context, id TaskID, opts ...TaskRequestOption) (*Task, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, taskRequestOptionValues(opts)...)
+	resp, err := s.client.gen.GetTaskWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Task](resp.HTTPResponse, resp.Body, "task")
+}
+
+func (s *TasksService) Create(ctx context.Context, opts ...CreateTaskOption) (*Task, error) {
+	cfg := newCreateTaskOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.AddTaskWithBodyWithResponse(ctx, "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Task](resp.HTTPResponse, resp.Body, "task")
+}
+
+func (s *TasksService) Update(ctx context.Context, id TaskID, opts ...UpdateTaskOption) (*Task, error) {
+	cfg := newUpdateTaskOptions(opts)
+	body, err := encodeV2Body(cfg.payload.body())
+	if err != nil {
+		return nil, err
+	}
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
+	resp, err := s.client.gen.UpdateTaskWithBodyWithResponse(ctx, int(id), "application/json", body, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[Task](resp.HTTPResponse, resp.Body, "task")
+}
+
+func (s *TasksService) Delete(ctx context.Context, id TaskID, opts ...TaskRequestOption) (*TaskDeleteResult, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, taskRequestOptionValues(opts)...)
+	resp, err := s.client.gen.DeleteTaskWithResponse(ctx, int(id), toRequestEditors(editors)...)
+	if err != nil {
+		return nil, err
+	}
+	return decodeV2Data[TaskDeleteResult](resp.HTTPResponse, resp.Body, "task delete")
+}
+
+func (s *TasksService) list(ctx context.Context, params genv2.GetTasksParams, requestOptions []pipedrive.RequestOption) ([]Task, *string, error) {
+	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
+	resp, err := s.client.gen.GetTasksWithResponse(ctx, &params, toRequestEditors(editors)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeV2List[Task](resp.HTTPResponse, resp.Body)
+}

--- a/pipedrive/v2/tasks_test.go
+++ b/pipedrive/v2/tasks_test.go
@@ -5,15 +5,28 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/juhokoskela/pipedrive-go/pipedrive"
 )
 
 func TestTasksService_AllOperations(t *testing.T) {
 	t.Parallel()
 	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Test"); got != "tasks" {
+			t.Fatalf("unexpected request header: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method + " " + r.URL.Path {
 		case "GET /tasks":
-			if r.URL.Query().Get("project_id") != "4" || r.URL.Query().Get("is_done") != "false" {
+			query := r.URL.Query()
+			if query.Get("parent_task_id") == "null" {
+				_, _ = w.Write([]byte(`{"data":[],"additional_data":{"next_cursor":null}}`))
+				return
+			}
+			if query.Get("project_id") != "4" || query.Get("is_done") != "false" ||
+				query.Get("is_milestone") != "true" || query.Get("assignee_id") != "2" ||
+				query.Get("parent_task_id") != "5" || query.Get("limit") != "25" ||
+				query.Get("cursor") != "tasks-start" {
 				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
 			}
 			_, _ = w.Write([]byte(`{"data":[{"id":9,"title":"Ship","project_id":4,"assignee_ids":[2,3]}],"additional_data":{"next_cursor":null}}`))
@@ -22,13 +35,30 @@ func TestTasksService_AllOperations(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if body["title"] != "Ship" || body["project_id"] != float64(4) {
+			if body["title"] != "Ship" || body["project_id"] != float64(4) ||
+				body["parent_task_id"] != float64(5) || body["description"] != "Release" ||
+				body["done"] != float64(0) || body["milestone"] != float64(1) ||
+				body["due_date"] != "2026-08-15" || body["start_date"] != "2026-08-10" ||
+				body["assignee_id"] != float64(2) || body["priority"] != float64(3) ||
+				len(body["assignee_ids"].([]any)) != 2 {
 				t.Fatalf("unexpected body: %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Ship","project_id":4}}`))
 		case "GET /tasks/9":
 			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Ship","project_id":4}}`))
 		case "PATCH /tasks/9":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			for _, key := range []string{"parent_task_id", "description", "due_date", "start_date", "assignee_id", "priority"} {
+				if value, ok := body[key]; !ok || value != nil {
+					t.Fatalf("expected %s to be null in %#v", key, body)
+				}
+			}
+			if body["done"] != float64(1) || body["milestone"] != float64(0) || len(body["assignee_ids"].([]any)) != 0 {
+				t.Fatalf("unexpected update body: %#v", body)
+			}
 			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Shipped","project_id":4,"is_done":true}}`))
 		case "DELETE /tasks/9":
 			_, _ = w.Write([]byte(`{"data":{"id":9}}`))
@@ -38,24 +68,105 @@ func TestTasksService_AllOperations(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	tasks, _, err := client.Tasks.List(ctx, WithTasksProjectID(4), WithTasksDone(false))
+	requestOpt := WithTaskRequestOptions(pipedrive.WithHeader("X-Test", "tasks"))
+	tasks, _, err := client.Tasks.List(ctx,
+		WithTasksPageSize(25),
+		WithTasksCursor("tasks-start"),
+		WithTasksDone(false),
+		WithTasksMilestone(true),
+		WithTasksAssigneeID(2),
+		WithTasksProjectID(4),
+		WithTasksParentTaskID(5),
+		requestOpt,
+	)
 	if err != nil || len(tasks) != 1 || len(tasks[0].AssigneeIDs) != 2 {
 		t.Fatalf("List = %#v, %v", tasks, err)
 	}
-	created, err := client.Tasks.Create(ctx, WithTaskTitle("Ship"), WithTaskProjectID(4), WithTaskAssigneeIDs(2, 3))
+	rootTasks, _, err := client.Tasks.List(ctx, WithTasksRootOnly(), requestOpt)
+	if err != nil || len(rootTasks) != 0 {
+		t.Fatalf("root List = %#v, %v", rootTasks, err)
+	}
+	created, err := client.Tasks.Create(ctx,
+		WithTaskTitle("Ship"),
+		WithTaskProjectID(4),
+		WithTaskParentTaskID(5),
+		WithTaskDescription("Release"),
+		WithTaskDone(false),
+		WithTaskMilestone(true),
+		WithTaskDueDate("2026-08-15"),
+		WithTaskStartDate("2026-08-10"),
+		WithTaskAssigneeID(2),
+		WithTaskAssigneeIDs(2, 3),
+		WithTaskPriority(3),
+		requestOpt,
+	)
 	if err != nil || created.ID != 9 {
 		t.Fatalf("Create = %#v, %v", created, err)
 	}
-	got, err := client.Tasks.Get(ctx, 9)
+	got, err := client.Tasks.Get(ctx, 9, requestOpt)
 	if err != nil || got.ID != 9 {
 		t.Fatalf("Get = %#v, %v", got, err)
 	}
-	updated, err := client.Tasks.Update(ctx, 9, WithTaskTitle("Shipped"), WithTaskDone(true), ClearTaskDescription())
+	updated, err := client.Tasks.Update(ctx, 9,
+		WithTaskTitle("Shipped"),
+		ClearTaskParentTaskID(),
+		ClearTaskDescription(),
+		WithTaskDone(true),
+		WithTaskMilestone(false),
+		ClearTaskDueDate(),
+		ClearTaskStartDate(),
+		ClearTaskAssigneeID(),
+		WithTaskAssigneeIDs(),
+		ClearTaskPriority(),
+		requestOpt,
+	)
 	if err != nil || !updated.IsDone {
 		t.Fatalf("Update = %#v, %v", updated, err)
 	}
-	deleted, err := client.Tasks.Delete(ctx, 9)
+	deleted, err := client.Tasks.Delete(ctx, 9, requestOpt)
 	if err != nil || deleted.ID != 9 {
 		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+}
+
+func TestTasksService_PagerAndIterator(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/tasks" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("cursor") {
+		case "start":
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"additional_data":{"next_cursor":"next"}}`))
+		case "next":
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"additional_data":{"next_cursor":null}}`))
+		default:
+			_, _ = w.Write([]byte(`{"data":[{"id":3}],"additional_data":{"next_cursor":null}}`))
+		}
+	})
+
+	ctx := context.Background()
+	pager := client.Tasks.ListPager(WithTasksPageSize(2), WithTasksCursor("start"))
+	var ids []TaskID
+	for pager.Next(ctx) {
+		for _, task := range pager.Items() {
+			ids = append(ids, task.ID)
+		}
+	}
+	if err := pager.Err(); err != nil || len(ids) != 2 || ids[1] != 2 {
+		t.Fatalf("pager = %v, %v", ids, err)
+	}
+
+	var iterated []TaskID
+	if err := client.Tasks.ForEach(ctx, func(task Task) error {
+		iterated = append(iterated, task.ID)
+		return nil
+	}); err != nil {
+		t.Fatalf("ForEach error: %v", err)
+	}
+	if len(iterated) != 1 || iterated[0] != 3 {
+		t.Fatalf("unexpected iterated tasks: %v", iterated)
 	}
 }

--- a/pipedrive/v2/tasks_test.go
+++ b/pipedrive/v2/tasks_test.go
@@ -1,0 +1,61 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTasksService_AllOperations(t *testing.T) {
+	t.Parallel()
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /tasks":
+			if r.URL.Query().Get("project_id") != "4" || r.URL.Query().Get("is_done") != "false" {
+				t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"id":9,"title":"Ship","project_id":4,"assignee_ids":[2,3]}],"additional_data":{"next_cursor":null}}`))
+		case "POST /tasks":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body["title"] != "Ship" || body["project_id"] != float64(4) {
+				t.Fatalf("unexpected body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Ship","project_id":4}}`))
+		case "GET /tasks/9":
+			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Ship","project_id":4}}`))
+		case "PATCH /tasks/9":
+			_, _ = w.Write([]byte(`{"data":{"id":9,"title":"Shipped","project_id":4,"is_done":true}}`))
+		case "DELETE /tasks/9":
+			_, _ = w.Write([]byte(`{"data":{"id":9}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.RequestURI())
+		}
+	})
+
+	ctx := context.Background()
+	tasks, _, err := client.Tasks.List(ctx, WithTasksProjectID(4), WithTasksDone(false))
+	if err != nil || len(tasks) != 1 || len(tasks[0].AssigneeIDs) != 2 {
+		t.Fatalf("List = %#v, %v", tasks, err)
+	}
+	created, err := client.Tasks.Create(ctx, WithTaskTitle("Ship"), WithTaskProjectID(4), WithTaskAssigneeIDs(2, 3))
+	if err != nil || created.ID != 9 {
+		t.Fatalf("Create = %#v, %v", created, err)
+	}
+	got, err := client.Tasks.Get(ctx, 9)
+	if err != nil || got.ID != 9 {
+		t.Fatalf("Get = %#v, %v", got, err)
+	}
+	updated, err := client.Tasks.Update(ctx, 9, WithTaskTitle("Shipped"), WithTaskDone(true), ClearTaskDescription())
+	if err != nil || !updated.IsDone {
+		t.Fatalf("Update = %#v, %v", updated, err)
+	}
+	deleted, err := client.Tasks.Delete(ctx, 9)
+	if err != nil || deleted.ID != 9 {
+		t.Fatalf("Delete = %#v, %v", deleted, err)
+	}
+}

--- a/pipedrive/v2/types.go
+++ b/pipedrive/v2/types.go
@@ -22,6 +22,14 @@ type ActivityID int64
 
 type ProjectID int64
 
+type ProjectBoardID int64
+
+type ProjectPhaseID int64
+
+type ProjectTemplateID int64
+
+type TaskID int64
+
 type LeadID string
 
 type ConversionID string


### PR DESCRIPTION
## Summary

- Refresh the official Pipedrive v1 and v2 OpenAPI specifications and regenerate the internal clients
- Add handwritten v2 services for Projects, Tasks, Project Boards, Project Phases, Project Templates, and Project Fields
- Bring the public v2 SDK to 158/158 operations documented by the current specification
- Re-derive the v1 legacy-only surface and expose newly documented legacy query parameters
- Preserve Product category and field-option compatibility across the regenerated clients
- Add a scheduled and manually runnable workflow for detecting upstream OpenAPI drift

## Compatibility notes

- Generated packages remain internal and are not exposed through the public SDK
- `FieldOption.ID` remains an `int`; string-valued IDs are available through the additive `StringID` field