### PR TITLE
fix(v2): align response decoding and update semantics

### DIFF
--- a/pipedrive/v2/activities.go
+++ b/pipedrive/v2/activities.go
@@ -54,28 +54,34 @@ type ActivityParticipant struct {
 }
 
 type Activity struct {
-	ID                ActivityID            `json:"id"`
-	Subject           string                `json:"subject,omitempty"`
-	Type              string                `json:"type,omitempty"`
-	Done              bool                  `json:"done,omitempty"`
-	Busy              bool                  `json:"busy,omitempty"`
-	DueDate           string                `json:"due_date,omitempty"`
-	DueTime           string                `json:"due_time,omitempty"`
-	Duration          string                `json:"duration,omitempty"`
-	OwnerID           *UserID               `json:"owner_id,omitempty"`
-	PersonID          *PersonID             `json:"person_id,omitempty"`
-	OrgID             *OrganizationID       `json:"org_id,omitempty"`
-	DealID            *DealID               `json:"deal_id,omitempty"`
-	LeadID            *LeadID               `json:"lead_id,omitempty"`
-	ProjectID         *ProjectID            `json:"project_id,omitempty"`
-	Location          *ActivityLocation     `json:"location,omitempty"`
-	Participants      []ActivityParticipant `json:"participants,omitempty"`
-	Attendees         []ActivityAttendee    `json:"attendees,omitempty"`
-	PublicDescription string                `json:"public_description,omitempty"`
-	Priority          *int                  `json:"priority,omitempty"`
-	Note              string                `json:"note,omitempty"`
-	AddTime           *time.Time            `json:"add_time,omitempty"`
-	UpdateTime        *time.Time            `json:"update_time,omitempty"`
+	ID                      ActivityID            `json:"id"`
+	Subject                 string                `json:"subject,omitempty"`
+	Type                    string                `json:"type,omitempty"`
+	Done                    bool                  `json:"done,omitempty"`
+	Busy                    bool                  `json:"busy,omitempty"`
+	DueDate                 string                `json:"due_date,omitempty"`
+	DueTime                 string                `json:"due_time,omitempty"`
+	Duration                string                `json:"duration,omitempty"`
+	OwnerID                 *UserID               `json:"owner_id,omitempty"`
+	CreatorUserID           *UserID               `json:"creator_user_id,omitempty"`
+	IsDeleted               bool                  `json:"is_deleted,omitempty"`
+	PersonID                *PersonID             `json:"person_id,omitempty"`
+	OrgID                   *OrganizationID       `json:"org_id,omitempty"`
+	DealID                  *DealID               `json:"deal_id,omitempty"`
+	LeadID                  *LeadID               `json:"lead_id,omitempty"`
+	ProjectID               *ProjectID            `json:"project_id,omitempty"`
+	Location                *ActivityLocation     `json:"location,omitempty"`
+	Participants            []ActivityParticipant `json:"participants,omitempty"`
+	Attendees               []ActivityAttendee    `json:"attendees,omitempty"`
+	MarkedAsDoneTime        *time.Time            `json:"marked_as_done_time,omitempty"`
+	ConferenceMeetingClient string                `json:"conference_meeting_client,omitempty"`
+	ConferenceMeetingURL    string                `json:"conference_meeting_url,omitempty"`
+	ConferenceMeetingID     string                `json:"conference_meeting_id,omitempty"`
+	PublicDescription       string                `json:"public_description,omitempty"`
+	Priority                *int                  `json:"priority,omitempty"`
+	Note                    string                `json:"note,omitempty"`
+	AddTime                 *time.Time            `json:"add_time,omitempty"`
+	UpdateTime              *time.Time            `json:"update_time,omitempty"`
 }
 
 type ActivityDeleteResult struct {
@@ -158,8 +164,8 @@ type activityPayload struct {
 	busy              *bool
 	done              *bool
 	location          *ActivityLocation
-	participants      []ActivityParticipant
-	attendees         []ActivityAttendee
+	participants      optionalSlice[ActivityParticipant]
+	attendees         optionalSlice[ActivityAttendee]
 	publicDescription *string
 	priority          *int
 	note              *string
@@ -312,19 +318,13 @@ func WithActivityLocation(location ActivityLocation) ActivityOption {
 
 func WithActivityParticipants(participants ...ActivityParticipant) ActivityOption {
 	return activityFieldOption(func(payload *activityPayload) {
-		if len(participants) == 0 {
-			return
-		}
-		payload.participants = append(payload.participants, participants...)
+		payload.participants.append(participants...)
 	})
 }
 
 func WithActivityAttendees(attendees ...ActivityAttendee) ActivityOption {
 	return activityFieldOption(func(payload *activityPayload) {
-		if len(attendees) == 0 {
-			return
-		}
-		payload.attendees = append(payload.attendees, attendees...)
+		payload.attendees.append(attendees...)
 	})
 }
 
@@ -717,11 +717,11 @@ func (p activityPayload) toMap() map[string]interface{} {
 	if p.location != nil {
 		body["location"] = p.location
 	}
-	if len(p.participants) > 0 {
-		body["participants"] = p.participants
+	if p.participants.set {
+		body["participants"] = p.participants.value
 	}
-	if len(p.attendees) > 0 {
-		body["attendees"] = p.attendees
+	if p.attendees.set {
+		body["attendees"] = p.attendees.value
 	}
 	if p.publicDescription != nil {
 		body["public_description"] = *p.publicDescription

--- a/pipedrive/v2/activity_fields.go
+++ b/pipedrive/v2/activity_fields.go
@@ -130,18 +130,22 @@ func (s *ActivityFieldsService) Get(ctx context.Context, fieldCode string, opts 
 	cfg := newGetActivityFieldOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetActivityFieldWithResponse(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetActivityField(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -178,12 +182,16 @@ func (s *ActivityFieldsService) ForEach(ctx context.Context, fn func(Field) erro
 func (s *ActivityFieldsService) list(ctx context.Context, params genv2.GetActivityFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetActivityFieldsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetActivityFields(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -192,7 +200,7 @@ func (s *ActivityFieldsService) list(ctx context.Context, params genv2.GetActivi
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 

--- a/pipedrive/v2/activity_fields_test.go
+++ b/pipedrive/v2/activity_fields_test.go
@@ -246,8 +246,8 @@ func runFieldUpdateTest(t *testing.T, path string, update func(context.Context, 
 		if payload["field_type"] != "varchar" {
 			t.Fatalf("unexpected field_type: %#v", payload["field_type"])
 		}
-		if payload["description"] != "Updated description" {
-			t.Fatalf("unexpected description: %#v", payload["description"])
+		if description, ok := payload["description"]; ok {
+			t.Fatalf("unexpected description: %#v", description)
 		}
 		if got := payload["ui_visibility"].(map[string]interface{})["add"]; got != true {
 			t.Fatalf("unexpected ui_visibility: %#v", payload["ui_visibility"])

--- a/pipedrive/v2/api_compatibility_test.go
+++ b/pipedrive/v2/api_compatibility_test.go
@@ -1,0 +1,460 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFieldOption_UnmarshalJSONIdentifierKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		wantID       int
+		wantStringID string
+		wantJSONID   string
+		wantErr      bool
+	}{
+		{
+			name:       "integer identifier",
+			input:      `{"id":42,"label":"High"}`,
+			wantID:     42,
+			wantJSONID: "42",
+			wantErr:    false,
+		},
+		{
+			name:         "string identifier",
+			input:        `{"id":"system-high","label":"High"}`,
+			wantStringID: "system-high",
+			wantJSONID:   `"system-high"`,
+			wantErr:      false,
+		},
+		{
+			name:    "unsupported identifier",
+			input:   `{"id":[42],"label":"High"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var option FieldOption
+			err := json.Unmarshal([]byte(tt.input), &option)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+			if option.ID != tt.wantID || option.StringID != tt.wantStringID {
+				t.Fatalf("unexpected identifier: ID=%d StringID=%q", option.ID, option.StringID)
+			}
+			encoded, err := json.Marshal(option)
+			if err != nil {
+				t.Fatalf("Marshal error: %v", err)
+			}
+			var wire map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &wire); err != nil {
+				t.Fatalf("decode marshaled option: %v", err)
+			}
+			if got := string(wire["id"]); got != tt.wantJSONID {
+				t.Fatalf("marshaled id = %s, want %s", got, tt.wantJSONID)
+			}
+		})
+	}
+}
+
+func TestFieldCreateResponsesAcceptStringOptionIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		path   string
+		create func(*Client) (*Field, error)
+	}{
+		{
+			name: "deal field",
+			path: "/dealFields",
+			create: func(client *Client) (*Field, error) {
+				return client.DealFields.Create(context.Background())
+			},
+		},
+		{
+			name: "organization field",
+			path: "/organizationFields",
+			create: func(client *Client) (*Field, error) {
+				return client.OrganizationFields.Create(context.Background())
+			},
+		},
+		{
+			name: "person field",
+			path: "/personFields",
+			create: func(client *Client) (*Field, error) {
+				return client.PersonFields.Create(context.Background())
+			},
+		},
+		{
+			name: "product field",
+			path: "/productFields",
+			create: func(client *Client) (*Field, error) {
+				return client.ProductFields.Create(context.Background())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost || r.URL.Path != tt.path {
+					t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"field_code":"cf_1","field_name":"Priority","field_type":"enum","options":[{"id":"system-high","label":"High"}]}}`))
+			})
+
+			field, err := tt.create(client)
+			if err != nil {
+				t.Fatalf("Create error: %v", err)
+			}
+			if len(field.Options) != 1 || field.Options[0].StringID != "system-high" {
+				t.Fatalf("unexpected options: %#v", field.Options)
+			}
+		})
+	}
+}
+
+func TestDocumentedResponseFieldsAreRepresented(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		tags []string
+	}{
+		{
+			name: "deal",
+			typ:  reflect.TypeOf(Deal{}),
+			tags: []string{
+				"id", "title", "owner_id", "person_id", "org_id", "pipeline_id", "stage_id",
+				"value", "currency", "add_time", "update_time", "stage_change_time", "is_deleted",
+				"is_archived", "status", "probability", "lost_reason", "visible_to", "close_time",
+				"won_time", "lost_time", "expected_close_date", "label_ids", "origin", "origin_id",
+				"channel", "channel_id", "source_lead_id", "arr", "mrr", "acv", "custom_fields",
+				"activities_count", "done_activities_count", "email_messages_count", "files_count",
+				"first_won_time", "followers_count", "last_activity_id", "last_incoming_mail_time",
+				"last_outgoing_mail_time", "next_activity_id", "notes_count", "participants_count",
+				"products_count", "smart_bcc_email", "undone_activities_count", "labels",
+			},
+		},
+		{
+			name: "person",
+			typ:  reflect.TypeOf(Person{}),
+			tags: []string{
+				"id", "name", "first_name", "last_name", "owner_id", "org_id", "add_time", "update_time",
+				"emails", "phones", "is_deleted", "visible_to", "label_ids", "picture_id", "postal_address",
+				"notes", "im", "birthday", "job_title", "custom_fields", "activities_count",
+				"closed_deals_count", "doi_status", "done_activities_count", "email_messages_count",
+				"files_count", "followers_count", "last_activity_id", "last_incoming_mail_time",
+				"last_outgoing_mail_time", "lost_deals_count", "marketing_status", "next_activity_id",
+				"notes_count", "open_deals_count", "participant_closed_deals_count",
+				"participant_open_deals_count", "related_closed_deals_count", "related_lost_deals_count",
+				"related_open_deals_count", "related_won_deals_count", "undone_activities_count",
+				"won_deals_count", "labels",
+			},
+		},
+		{
+			name: "organization",
+			typ:  reflect.TypeOf(Organization{}),
+			tags: []string{
+				"id", "name", "owner_id", "add_time", "update_time", "is_deleted", "visible_to", "address",
+				"label_ids", "website", "linkedin", "industry", "annual_revenue", "employee_count", "custom_fields",
+				"activities_count", "closed_deals_count", "done_activities_count", "email_messages_count",
+				"files_count", "followers_count", "last_activity_id", "lost_deals_count", "next_activity_id",
+				"notes_count", "open_deals_count", "people_count", "related_closed_deals_count",
+				"related_lost_deals_count", "related_open_deals_count", "related_won_deals_count",
+				"undone_activities_count", "won_deals_count", "labels",
+			},
+		},
+		{
+			name: "product",
+			typ:  reflect.TypeOf(Product{}),
+			tags: []string{
+				"id", "name", "code", "unit", "tax", "is_deleted", "is_linkable", "visible_to",
+				"owner_id", "add_time", "update_time", "description", "category", "custom_fields",
+				"billing_frequency", "billing_frequency_cycles", "prices",
+			},
+		},
+		{
+			name: "activity",
+			typ:  reflect.TypeOf(Activity{}),
+			tags: []string{
+				"id", "subject", "type", "owner_id", "creator_user_id", "is_deleted", "add_time", "update_time",
+				"deal_id", "lead_id", "person_id", "org_id", "project_id", "due_date", "due_time", "duration",
+				"busy", "done", "marked_as_done_time", "location", "participants", "attendees",
+				"conference_meeting_client", "conference_meeting_url", "conference_meeting_id",
+				"public_description", "priority", "note",
+			},
+		},
+		{
+			name: "field",
+			typ:  reflect.TypeOf(Field{}),
+			tags: []string{
+				"field_name", "field_code", "description", "field_type", "options", "subfields",
+				"is_custom_field", "is_optional_response_field", "ui_visibility", "important_fields", "required_fields",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := make(map[string]bool, tt.typ.NumField())
+			for i := 0; i < tt.typ.NumField(); i++ {
+				tag := tt.typ.Field(i).Tag.Get("json")
+				if comma := indexByte(tag, ','); comma >= 0 {
+					tag = tag[:comma]
+				}
+				got[tag] = true
+			}
+			for _, tag := range tt.tags {
+				if !got[tag] {
+					t.Errorf("missing json field %q", tag)
+				}
+			}
+		})
+	}
+}
+
+func TestCollectionOptionsSerializeExplicitEmptyArrays(t *testing.T) {
+	t.Parallel()
+
+	dealCfg := updateDealOptions{}
+	WithDealLabelIDs().applyUpdateDeal(&dealCfg)
+	assertEmptyArrayValue(t, dealCfg.payload.toMap(), "label_ids")
+
+	personCfg := updatePersonOptions{}
+	WithPersonEmails().applyUpdatePerson(&personCfg)
+	WithPersonPhones().applyUpdatePerson(&personCfg)
+	WithPersonLabelIDs().applyUpdatePerson(&personCfg)
+	assertEmptyArrayValue(t, personCfg.payload.toMap(), "emails")
+	assertEmptyArrayValue(t, personCfg.payload.toMap(), "phones")
+	assertEmptyArrayValue(t, personCfg.payload.toMap(), "label_ids")
+
+	organizationCfg := updateOrganizationOptions{}
+	WithOrganizationLabelIDs().applyUpdateOrganization(&organizationCfg)
+	assertEmptyArrayValue(t, organizationCfg.payload.toMap(), "label_ids")
+
+	productCfg := updateProductOptions{}
+	WithProductPrices().applyUpdateProduct(&productCfg)
+	assertEmptyArrayValue(t, productCfg.payload.toMap(), "prices")
+
+	variationCfg := updateProductVariationOptions{}
+	WithProductVariationPrices().applyUpdateProductVariation(&variationCfg)
+	assertEmptyArrayValue(t, variationCfg.payload.toMap(), "prices")
+
+	activityCfg := updateActivityOptions{}
+	WithActivityParticipants().applyUpdateActivity(&activityCfg)
+	WithActivityAttendees().applyUpdateActivity(&activityCfg)
+	assertEmptyArrayValue(t, activityCfg.payload.toMap(), "participants")
+	assertEmptyArrayValue(t, activityCfg.payload.toMap(), "attendees")
+}
+
+func TestNullableOptionsSerializeExplicitNull(t *testing.T) {
+	t.Parallel()
+
+	dealCfg := updateDealOptions{}
+	ClearDealProbability().applyUpdateDeal(&dealCfg)
+	ClearDealLostReason().applyUpdateDeal(&dealCfg)
+	ClearDealCloseTime().applyUpdateDeal(&dealCfg)
+	dealBody := dealCfg.payload.toMap()
+	assertNullValue(t, dealBody, "probability")
+	assertNullValue(t, dealBody, "lost_reason")
+	assertNullValue(t, dealBody, "close_time")
+
+	productCfg := updateProductOptions{}
+	ClearProductBillingFrequencyCycles().applyUpdateProduct(&productCfg)
+	assertNullValue(t, productCfg.payload.toMap(), "billing_frequency_cycles")
+}
+
+func TestLegacyEmptyDealOptionsRemainOmitted(t *testing.T) {
+	t.Parallel()
+
+	cfg := updateDealOptions{}
+	WithDealLostReason("").applyUpdateDeal(&cfg)
+	WithDealCloseTime("").applyUpdateDeal(&cfg)
+
+	body := cfg.payload.toMap()
+	assertMissingValue(t, body, "lost_reason")
+	assertMissingValue(t, body, "close_time")
+}
+
+func TestPersonCustomFieldsOption(t *testing.T) {
+	t.Parallel()
+
+	cfg := updatePersonOptions{}
+	fields := map[string]interface{}{"custom-key": "custom-value"}
+	WithPersonCustomFieldsMap(fields).applyUpdatePerson(&cfg)
+
+	got, ok := cfg.payload.toMap()["custom_fields"].(map[string]interface{})
+	if !ok || !reflect.DeepEqual(got, fields) {
+		t.Fatalf("unexpected custom_fields: %#v", got)
+	}
+}
+
+func TestUnsupportedFieldDescriptionsAreOmitted(t *testing.T) {
+	t.Parallel()
+
+	personCfg := createPersonFieldOptions{}
+	WithPersonFieldDescription("unsupported").applyCreatePersonField(&personCfg)
+	assertMissingValue(t, personCfg.payload.toMap(), "description")
+
+	organizationCfg := createOrganizationFieldOptions{}
+	WithOrganizationFieldDescription("unsupported").applyCreateOrganizationField(&organizationCfg)
+	assertMissingValue(t, organizationCfg.payload.toMap(), "description")
+
+	productCfg := createProductFieldOptions{}
+	WithProductFieldDescription("unsupported").applyCreateProductField(&productCfg)
+	assertMissingValue(t, productCfg.payload.toMap(), "description")
+
+	dealCfg := createDealFieldOptions{}
+	WithDealFieldDescription("supported").applyCreateDealField(&dealCfg)
+	if got := dealCfg.payload.toMap()["description"]; got != "supported" {
+		t.Fatalf("unexpected deal field description: %#v", got)
+	}
+}
+
+func TestNewEntityQueryOptions(t *testing.T) {
+	t.Parallel()
+
+	dealGet := getDealOptions{}
+	WithDealIncludeLabels(true).applyGetDeal(&dealGet)
+	WithDealIncludeOptionLabels(true).applyGetDeal(&dealGet)
+	if dealGet.params.IncludeLabels == nil || !*dealGet.params.IncludeLabels ||
+		dealGet.params.IncludeOptionLabels == nil || !*dealGet.params.IncludeOptionLabels {
+		t.Fatalf("unexpected deal get params: %#v", dealGet.params)
+	}
+
+	dealsList := listDealsOptions{}
+	WithDealsIncludeLabels(true).applyListDeals(&dealsList)
+	WithDealsIncludeOptionLabels(true).applyListDeals(&dealsList)
+	if dealsList.params.IncludeLabels == nil || !*dealsList.params.IncludeLabels ||
+		dealsList.params.IncludeOptionLabels == nil || !*dealsList.params.IncludeOptionLabels {
+		t.Fatalf("unexpected deals list params: %#v", dealsList.params)
+	}
+
+	personGet := getPersonOptions{}
+	WithPersonIncludeLabels(true).applyGetPerson(&personGet)
+	WithPersonIncludeOptionLabels(true).applyGetPerson(&personGet)
+	if personGet.params.IncludeLabels == nil || !*personGet.params.IncludeLabels ||
+		personGet.params.IncludeOptionLabels == nil || !*personGet.params.IncludeOptionLabels {
+		t.Fatalf("unexpected person get params: %#v", personGet.params)
+	}
+
+	personsList := listPersonsOptions{}
+	WithPersonsIncludeLabels(true).applyListPersons(&personsList)
+	WithPersonsIncludeOptionLabels(true).applyListPersons(&personsList)
+	if personsList.params.IncludeLabels == nil || !*personsList.params.IncludeLabels ||
+		personsList.params.IncludeOptionLabels == nil || !*personsList.params.IncludeOptionLabels {
+		t.Fatalf("unexpected persons list params: %#v", personsList.params)
+	}
+
+	organizationGet := getOrganizationOptions{}
+	WithOrganizationIncludeLabels(true).applyGetOrganization(&organizationGet)
+	WithOrganizationIncludeOptionLabels(true).applyGetOrganization(&organizationGet)
+	if organizationGet.params.IncludeLabels == nil || !*organizationGet.params.IncludeLabels ||
+		organizationGet.params.IncludeOptionLabels == nil || !*organizationGet.params.IncludeOptionLabels {
+		t.Fatalf("unexpected organization get params: %#v", organizationGet.params)
+	}
+
+	organizationsList := listOrganizationsOptions{}
+	WithOrganizationsIncludeLabels(true).applyListOrganizations(&organizationsList)
+	WithOrganizationsIncludeOptionLabels(true).applyListOrganizations(&organizationsList)
+	if organizationsList.params.IncludeLabels == nil || !*organizationsList.params.IncludeLabels ||
+		organizationsList.params.IncludeOptionLabels == nil || !*organizationsList.params.IncludeOptionLabels {
+		t.Fatalf("unexpected organizations list params: %#v", organizationsList.params)
+	}
+
+	updatedSince := time.Date(2026, 8, 1, 12, 30, 0, 0, time.FixedZone("test", 2*60*60))
+	productsList := listProductsOptions{}
+	WithProductsUpdatedSince(updatedSince).applyListProducts(&productsList)
+	if productsList.params.UpdatedSince == nil || *productsList.params.UpdatedSince != updatedSince.Format(time.RFC3339) {
+		t.Fatalf("unexpected products updated_since: %#v", productsList.params.UpdatedSince)
+	}
+}
+
+func assertEmptyArrayValue(t *testing.T, body map[string]interface{}, key string) {
+	t.Helper()
+
+	value, ok := body[key]
+	if !ok {
+		t.Fatalf("missing %q", key)
+	}
+	valueOf := reflect.ValueOf(value)
+	if valueOf.Kind() != reflect.Slice || valueOf.Len() != 0 {
+		t.Fatalf("%q is not an empty array: %#v", key, value)
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got := string(wire[key]); got != "[]" {
+		t.Fatalf("%q JSON is %s, want []", key, got)
+	}
+}
+
+func assertNullValue(t *testing.T, body map[string]interface{}, key string) {
+	t.Helper()
+
+	value, ok := body[key]
+	if !ok {
+		t.Fatalf("missing %q", key)
+	}
+	if value != nil {
+		t.Fatalf("%q is not null: %#v", key, value)
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	var wire map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got := string(wire[key]); got != "null" {
+		t.Fatalf("%q JSON is %s, want null", key, got)
+	}
+}
+
+func assertMissingValue(t *testing.T, body map[string]interface{}, key string) {
+	t.Helper()
+
+	if value, ok := body[key]; ok {
+		t.Fatalf("unexpected %q: %#v", key, value)
+	}
+}
+
+func indexByte(value string, target byte) int {
+	for i := 0; i < len(value); i++ {
+		if value[i] == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/pipedrive/v2/deal_fields.go
+++ b/pipedrive/v2/deal_fields.go
@@ -334,18 +334,22 @@ func (s *DealFieldsService) Get(ctx context.Context, fieldCode string, opts ...G
 	cfg := newGetDealFieldOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetDealFieldWithResponse(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetDealField(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -388,18 +392,22 @@ func (s *DealFieldsService) Create(ctx context.Context, opts ...CreateDealFieldO
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddDealFieldWithBodyWithResponse(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddDealFieldWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -417,18 +425,22 @@ func (s *DealFieldsService) Update(ctx context.Context, fieldCode string, opts .
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdateDealFieldWithBodyWithResponse(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdateDealFieldWithBody(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -575,12 +587,16 @@ func (s *DealFieldsService) DeleteOptions(ctx context.Context, fieldCode string,
 func (s *DealFieldsService) list(ctx context.Context, params genv2.GetDealFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetDealFieldsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetDealFields(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -589,7 +605,7 @@ func (s *DealFieldsService) list(ctx context.Context, params genv2.GetDealFields
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 

--- a/pipedrive/v2/deal_fields_test.go
+++ b/pipedrive/v2/deal_fields_test.go
@@ -34,7 +34,7 @@ func TestDealFieldsService_List(t *testing.T) {
 			t.Fatalf("unexpected header X-Test: %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1","field_name":"Priority"}],"additional_data":{"next_cursor":null}}`))
+		_, _ = w.Write([]byte(`{"data":[{"field_code":"cf_1","field_name":"Priority","options":[{"id":"system-high","label":"High"}]}],"additional_data":{"next_cursor":null}}`))
 	}))
 	t.Cleanup(srv.Close)
 
@@ -58,6 +58,9 @@ func TestDealFieldsService_List(t *testing.T) {
 	}
 	if len(fields) != 1 || fields[0].FieldCode != "cf_1" {
 		t.Fatalf("unexpected fields: %#v", fields)
+	}
+	if len(fields[0].Options) != 1 || fields[0].Options[0].StringID != "system-high" {
+		t.Fatalf("unexpected field options: %#v", fields[0].Options)
 	}
 }
 

--- a/pipedrive/v2/deals.go
+++ b/pipedrive/v2/deals.go
@@ -112,27 +112,54 @@ const (
 )
 
 type Deal struct {
-	ID                DealID                 `json:"id"`
-	Title             string                 `json:"title,omitempty"`
-	Value             *float64               `json:"value,omitempty"`
-	Currency          string                 `json:"currency,omitempty"`
-	Status            DealStatus             `json:"status,omitempty"`
-	OwnerID           *UserID                `json:"owner_id,omitempty"`
-	PersonID          *PersonID              `json:"person_id,omitempty"`
-	OrgID             *OrganizationID        `json:"org_id,omitempty"`
-	StageID           *StageID               `json:"stage_id,omitempty"`
-	PipelineID        *PipelineID            `json:"pipeline_id,omitempty"`
-	AddTime           *time.Time             `json:"add_time,omitempty"`
-	UpdateTime        *time.Time             `json:"update_time,omitempty"`
-	ExpectedCloseDate *string                `json:"expected_close_date,omitempty"`
-	LostReason        *string                `json:"lost_reason,omitempty"`
-	WonTime           *time.Time             `json:"won_time,omitempty"`
-	LostTime          *time.Time             `json:"lost_time,omitempty"`
-	IsArchived        bool                   `json:"is_archived,omitempty"`
-	IsDeleted         bool                   `json:"is_deleted,omitempty"`
-	VisibleTo         *int                   `json:"visible_to,omitempty"`
-	LabelIDs          []int                  `json:"label_ids,omitempty"`
-	CustomFields      map[string]interface{} `json:"custom_fields,omitempty"`
+	ID                    DealID                 `json:"id"`
+	Title                 string                 `json:"title,omitempty"`
+	Value                 *float64               `json:"value,omitempty"`
+	Currency              string                 `json:"currency,omitempty"`
+	Status                DealStatus             `json:"status,omitempty"`
+	OwnerID               *UserID                `json:"owner_id,omitempty"`
+	PersonID              *PersonID              `json:"person_id,omitempty"`
+	OrgID                 *OrganizationID        `json:"org_id,omitempty"`
+	StageID               *StageID               `json:"stage_id,omitempty"`
+	PipelineID            *PipelineID            `json:"pipeline_id,omitempty"`
+	AddTime               *time.Time             `json:"add_time,omitempty"`
+	UpdateTime            *time.Time             `json:"update_time,omitempty"`
+	StageChangeTime       *time.Time             `json:"stage_change_time,omitempty"`
+	ExpectedCloseDate     *string                `json:"expected_close_date,omitempty"`
+	Probability           *float64               `json:"probability,omitempty"`
+	LostReason            *string                `json:"lost_reason,omitempty"`
+	CloseTime             *time.Time             `json:"close_time,omitempty"`
+	WonTime               *time.Time             `json:"won_time,omitempty"`
+	LostTime              *time.Time             `json:"lost_time,omitempty"`
+	IsArchived            bool                   `json:"is_archived,omitempty"`
+	IsDeleted             bool                   `json:"is_deleted,omitempty"`
+	VisibleTo             *int                   `json:"visible_to,omitempty"`
+	LabelIDs              []int                  `json:"label_ids,omitempty"`
+	Origin                string                 `json:"origin,omitempty"`
+	OriginID              *string                `json:"origin_id,omitempty"`
+	Channel               *int                   `json:"channel,omitempty"`
+	ChannelID             *string                `json:"channel_id,omitempty"`
+	SourceLeadID          *LeadID                `json:"source_lead_id,omitempty"`
+	ARR                   *float64               `json:"arr,omitempty"`
+	MRR                   *float64               `json:"mrr,omitempty"`
+	ACV                   *float64               `json:"acv,omitempty"`
+	CustomFields          map[string]interface{} `json:"custom_fields,omitempty"`
+	ActivitiesCount       *int                   `json:"activities_count,omitempty"`
+	DoneActivitiesCount   *int                   `json:"done_activities_count,omitempty"`
+	EmailMessagesCount    *int                   `json:"email_messages_count,omitempty"`
+	FilesCount            *int                   `json:"files_count,omitempty"`
+	FirstWonTime          *time.Time             `json:"first_won_time,omitempty"`
+	FollowersCount        *int                   `json:"followers_count,omitempty"`
+	LastActivityID        *ActivityID            `json:"last_activity_id,omitempty"`
+	LastIncomingMailTime  *time.Time             `json:"last_incoming_mail_time,omitempty"`
+	LastOutgoingMailTime  *time.Time             `json:"last_outgoing_mail_time,omitempty"`
+	NextActivityID        *ActivityID            `json:"next_activity_id,omitempty"`
+	NotesCount            *int                   `json:"notes_count,omitempty"`
+	ParticipantsCount     *int                   `json:"participants_count,omitempty"`
+	ProductsCount         *int                   `json:"products_count,omitempty"`
+	SmartBCCEmail         *string                `json:"smart_bcc_email,omitempty"`
+	UndoneActivitiesCount *int                   `json:"undone_activities_count,omitempty"`
+	Labels                []EntityLabel          `json:"labels,omitempty"`
 }
 
 type DealSearchItem struct {
@@ -532,15 +559,15 @@ type dealPayload struct {
 	pipelineID        *PipelineID
 	status            *DealStatus
 	expectedCloseDate *string
-	probability       *float64
-	lostReason        *string
+	probability       nullableValue[float64]
+	lostReason        nullableValue[string]
 	visibleTo         *int
-	labelIDs          []int
+	labelIDs          optionalSlice[int]
 	customFields      map[string]interface{}
 	isArchived        *bool
 	isDeleted         *bool
 	archiveTime       *string
-	closeTime         *string
+	closeTime         nullableValue[string]
 	lostTime          *string
 	wonTime           *string
 }
@@ -894,6 +921,18 @@ func WithDealsIncludeFields(fields ...DealIncludeField) ListDealsOption {
 	})
 }
 
+func WithDealsIncludeLabels(enabled bool) ListDealsOption {
+	return listDealsOptionFunc(func(cfg *listDealsOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithDealsIncludeOptionLabels(enabled bool) ListDealsOption {
+	return listDealsOptionFunc(func(cfg *listDealsOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
+	})
+}
+
 func WithDealsCustomFields(fields ...string) ListDealsOption {
 	return listDealsOptionFunc(func(cfg *listDealsOptions) {
 		csv := joinCSV(fields)
@@ -1062,6 +1101,18 @@ func WithDealIncludeFields(fields ...DealIncludeField) GetDealOption {
 	})
 }
 
+func WithDealIncludeLabels(enabled bool) GetDealOption {
+	return getDealOptionFunc(func(cfg *getDealOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithDealIncludeOptionLabels(enabled bool) GetDealOption {
+	return getDealOptionFunc(func(cfg *getDealOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
+	})
+}
+
 func WithDealCustomFields(fields ...string) GetDealOption {
 	return getDealOptionFunc(func(cfg *getDealOptions) {
 		csv := joinCSV(fields)
@@ -1137,7 +1188,14 @@ func WithDealExpectedCloseDate(date string) DealOption {
 
 func WithDealProbability(probability float64) DealOption {
 	return dealFieldOption(func(payload *dealPayload) {
-		payload.probability = &probability
+		payload.probability.assign(probability)
+	})
+}
+
+// ClearDealProbability sends an explicit JSON null probability.
+func ClearDealProbability() DealOption {
+	return dealFieldOption(func(payload *dealPayload) {
+		payload.probability.clear()
 	})
 }
 
@@ -1146,7 +1204,14 @@ func WithDealLostReason(reason string) DealOption {
 		if reason == "" {
 			return
 		}
-		payload.lostReason = &reason
+		payload.lostReason.assign(reason)
+	})
+}
+
+// ClearDealLostReason sends an explicit JSON null lost reason.
+func ClearDealLostReason() DealOption {
+	return dealFieldOption(func(payload *dealPayload) {
+		payload.lostReason.clear()
 	})
 }
 
@@ -1158,10 +1223,7 @@ func WithDealVisibleTo(visibleTo int) DealOption {
 
 func WithDealLabelIDs(ids ...int) DealOption {
 	return dealFieldOption(func(payload *dealPayload) {
-		if len(ids) == 0 {
-			return
-		}
-		payload.labelIDs = append(payload.labelIDs, ids...)
+		payload.labelIDs.append(ids...)
 	})
 }
 
@@ -1200,7 +1262,14 @@ func WithDealCloseTime(value string) DealOption {
 		if value == "" {
 			return
 		}
-		payload.closeTime = &value
+		payload.closeTime.assign(value)
+	})
+}
+
+// ClearDealCloseTime sends an explicit JSON null close time.
+func ClearDealCloseTime() DealOption {
+	return dealFieldOption(func(payload *dealPayload) {
+		payload.closeTime.clear()
 	})
 }
 
@@ -2264,6 +2333,9 @@ func (s *DealsService) ListProductsAcrossDeals(ctx context.Context, dealIDs []De
 }
 
 func (s *DealsService) ListProductsAcrossDealsPager(dealIDs []DealID, opts ...ListDealsProductsOption) *pipedrive.CursorPager[DealProduct] {
+	if len(dealIDs) == 0 {
+		return newDealIDsRequiredPager[DealProduct]()
+	}
 	cfg := newListDealsProductsOptions(opts)
 	cfg.params.DealIds = make([]int, 0, len(dealIDs))
 	for _, id := range dealIDs {
@@ -2566,6 +2638,9 @@ func (s *DealsService) ListInstallments(ctx context.Context, dealIDs []DealID, o
 }
 
 func (s *DealsService) ListInstallmentsPager(dealIDs []DealID, opts ...ListInstallmentsOption) *pipedrive.CursorPager[Installment] {
+	if len(dealIDs) == 0 {
+		return newDealIDsRequiredPager[Installment]()
+	}
 	cfg := newListInstallmentsOptions(opts)
 	cfg.params.DealIds = make([]int, 0, len(dealIDs))
 	for _, id := range dealIDs {
@@ -2582,6 +2657,12 @@ func (s *DealsService) ListInstallmentsPager(dealIDs []DealID, opts ...ListInsta
 			params.Cursor = startCursor
 		}
 		return s.listInstallments(ctx, params, cfg.requestOptions)
+	})
+}
+
+func newDealIDsRequiredPager[T any]() *pipedrive.CursorPager[T] {
+	return pipedrive.NewCursorPager(func(context.Context, *string) ([]T, *string, error) {
+		return nil, nil, fmt.Errorf("deal IDs are required")
 	})
 }
 
@@ -2899,17 +2980,25 @@ func (p dealPayload) toMap() map[string]interface{} {
 	if p.expectedCloseDate != nil {
 		body["expected_close_date"] = *p.expectedCloseDate
 	}
-	if p.probability != nil {
-		body["probability"] = *p.probability
+	if p.probability.set {
+		if p.probability.value == nil {
+			body["probability"] = nil
+		} else {
+			body["probability"] = *p.probability.value
+		}
 	}
-	if p.lostReason != nil {
-		body["lost_reason"] = *p.lostReason
+	if p.lostReason.set {
+		if p.lostReason.value == nil {
+			body["lost_reason"] = nil
+		} else {
+			body["lost_reason"] = *p.lostReason.value
+		}
 	}
 	if p.visibleTo != nil {
 		body["visible_to"] = *p.visibleTo
 	}
-	if len(p.labelIDs) > 0 {
-		body["label_ids"] = p.labelIDs
+	if p.labelIDs.set {
+		body["label_ids"] = p.labelIDs.value
 	}
 	if p.customFields != nil {
 		body["custom_fields"] = p.customFields
@@ -2923,8 +3012,12 @@ func (p dealPayload) toMap() map[string]interface{} {
 	if p.archiveTime != nil {
 		body["archive_time"] = *p.archiveTime
 	}
-	if p.closeTime != nil {
-		body["close_time"] = *p.closeTime
+	if p.closeTime.set {
+		if p.closeTime.value == nil {
+			body["close_time"] = nil
+		} else {
+			body["close_time"] = *p.closeTime.value
+		}
 	}
 	if p.lostTime != nil {
 		body["lost_time"] = *p.lostTime

--- a/pipedrive/v2/deals_test.go
+++ b/pipedrive/v2/deals_test.go
@@ -1403,6 +1403,48 @@ func TestDealsService_ListProductsAcrossDealsPager(t *testing.T) {
 	}
 }
 
+func TestDealsService_RequiredDealIDsFailBeforePagerRequest(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient(t, func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+
+	tests := []struct {
+		name string
+		next func(context.Context) (bool, error)
+	}{
+		{
+			name: "products across deals",
+			next: func(ctx context.Context) (bool, error) {
+				pager := client.Deals.ListProductsAcrossDealsPager(nil)
+				return pager.Next(ctx), pager.Err()
+			},
+		},
+		{
+			name: "installments",
+			next: func(ctx context.Context) (bool, error) {
+				pager := client.Deals.ListInstallmentsPager(nil)
+				return pager.Next(ctx), pager.Err()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			next, err := tt.next(context.Background())
+			if next {
+				t.Fatal("unexpected page")
+			}
+			if err == nil || err.Error() != "deal IDs are required" {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestDealsService_ForEachProductsAcrossDeals(t *testing.T) {
 	t.Parallel()
 

--- a/pipedrive/v2/options_line_coverage_test.go
+++ b/pipedrive/v2/options_line_coverage_test.go
@@ -149,13 +149,13 @@ func TestProductOptionsIgnoreEmptyInputs(t *testing.T) {
 	}
 
 	create := newCreateProductOptions([]CreateProductOption{nil, WithProductPrices()})
-	if len(create.payload.prices) != 0 {
-		t.Fatalf("expected no product prices, got %#v", create.payload.prices)
+	if !create.payload.prices.set || len(create.payload.prices.value) != 0 {
+		t.Fatalf("expected explicit empty product prices, got %#v", create.payload.prices)
 	}
 
 	variationCreate := newCreateProductVariationOptions([]CreateProductVariationOption{nil, WithProductVariationPrices()})
-	if len(variationCreate.payload.prices) != 0 {
-		t.Fatalf("expected no variation prices, got %#v", variationCreate.payload.prices)
+	if !variationCreate.payload.prices.set || len(variationCreate.payload.prices.value) != 0 {
+		t.Fatalf("expected explicit empty variation prices, got %#v", variationCreate.payload.prices)
 	}
 
 	if _, _, err := (productImagePayload{}).toMultipart(); err == nil {
@@ -267,8 +267,10 @@ func TestPersonOptionsIgnoreEmptyInputs(t *testing.T) {
 		WithPersonPhones(),
 		WithPersonLabelIDs(),
 	})
-	if len(create.payload.emails) != 0 || len(create.payload.phones) != 0 || len(create.payload.labelIDs) != 0 {
-		t.Fatalf("expected empty person payload, got %#v", create.payload)
+	if !create.payload.emails.set || len(create.payload.emails.value) != 0 ||
+		!create.payload.phones.set || len(create.payload.phones.value) != 0 ||
+		!create.payload.labelIDs.set || len(create.payload.labelIDs.value) != 0 {
+		t.Fatalf("expected explicit empty person payload, got %#v", create.payload)
 	}
 
 	followers := newGetPersonFollowersOptions([]GetPersonFollowersOption{
@@ -386,8 +388,8 @@ func TestOrganizationOptionsIgnoreEmptyInputs(t *testing.T) {
 		nil,
 		WithOrganizationLabelIDs(),
 	})
-	if len(create.payload.labelIDs) != 0 {
-		t.Fatalf("expected empty organization label IDs, got %#v", create.payload.labelIDs)
+	if !create.payload.labelIDs.set || len(create.payload.labelIDs.value) != 0 {
+		t.Fatalf("expected explicit empty organization label IDs, got %#v", create.payload.labelIDs)
 	}
 
 	followers := newGetOrganizationFollowersOptions([]GetOrganizationFollowersOption{

--- a/pipedrive/v2/organization_fields.go
+++ b/pipedrive/v2/organization_fields.go
@@ -212,10 +212,13 @@ func WithOrganizationFieldType(fieldType FieldType) OrganizationFieldOption {
 	})
 }
 
+// WithOrganizationFieldDescription is retained for source compatibility.
+//
+// Deprecated: Pipedrive API v2 no longer accepts descriptions for
+// organization fields. This option is intentionally ignored.
 func WithOrganizationFieldDescription(description string) OrganizationFieldOption {
-	return organizationFieldOptionFunc(func(payload *fieldPayload) {
-		payload.description = &description
-	})
+	_ = description
+	return organizationFieldOptionFunc(func(*fieldPayload) {})
 }
 
 func WithOrganizationFieldOptions(labels ...string) OrganizationFieldOption {
@@ -334,18 +337,22 @@ func (s *OrganizationFieldsService) Get(ctx context.Context, fieldCode string, o
 	cfg := newGetOrganizationFieldOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetOrganizationFieldWithResponse(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetOrganizationField(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -388,18 +395,22 @@ func (s *OrganizationFieldsService) Create(ctx context.Context, opts ...CreateOr
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddOrganizationFieldWithBodyWithResponse(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddOrganizationFieldWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -417,18 +428,22 @@ func (s *OrganizationFieldsService) Update(ctx context.Context, fieldCode string
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdateOrganizationFieldWithBodyWithResponse(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdateOrganizationFieldWithBody(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -575,12 +590,16 @@ func (s *OrganizationFieldsService) DeleteOptions(ctx context.Context, fieldCode
 func (s *OrganizationFieldsService) list(ctx context.Context, params genv2.GetOrganizationFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetOrganizationFieldsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetOrganizationFields(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -589,7 +608,7 @@ func (s *OrganizationFieldsService) list(ctx context.Context, params genv2.GetOr
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 

--- a/pipedrive/v2/organization_fields_test.go
+++ b/pipedrive/v2/organization_fields_test.go
@@ -85,8 +85,8 @@ func TestOrganizationFieldsService_Create(t *testing.T) {
 		if payload["field_type"] != "enum" {
 			t.Fatalf("unexpected field_type: %v", payload["field_type"])
 		}
-		if payload["description"] != "Organization priority" {
-			t.Fatalf("unexpected description: %v", payload["description"])
+		if description, ok := payload["description"]; ok {
+			t.Fatalf("unexpected description: %v", description)
 		}
 		options, ok := payload["options"].([]interface{})
 		if !ok || len(options) != 1 {

--- a/pipedrive/v2/organizations.go
+++ b/pipedrive/v2/organizations.go
@@ -65,13 +65,40 @@ type OrganizationAddress struct {
 }
 
 type Organization struct {
-	ID           OrganizationID         `json:"id"`
-	Name         string                 `json:"name,omitempty"`
-	OwnerID      *UserID                `json:"owner_id,omitempty"`
-	AddTime      *time.Time             `json:"add_time,omitempty"`
-	UpdateTime   *time.Time             `json:"update_time,omitempty"`
-	Address      *OrganizationAddress   `json:"address,omitempty"`
-	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
+	ID                      OrganizationID         `json:"id"`
+	Name                    string                 `json:"name,omitempty"`
+	OwnerID                 *UserID                `json:"owner_id,omitempty"`
+	AddTime                 *time.Time             `json:"add_time,omitempty"`
+	UpdateTime              *time.Time             `json:"update_time,omitempty"`
+	IsDeleted               bool                   `json:"is_deleted,omitempty"`
+	VisibleTo               *int                   `json:"visible_to,omitempty"`
+	Address                 *OrganizationAddress   `json:"address,omitempty"`
+	LabelIDs                []int                  `json:"label_ids,omitempty"`
+	Website                 *string                `json:"website,omitempty"`
+	LinkedIn                *string                `json:"linkedin,omitempty"`
+	Industry                *int                   `json:"industry,omitempty"`
+	AnnualRevenue           *int                   `json:"annual_revenue,omitempty"`
+	EmployeeCount           *int                   `json:"employee_count,omitempty"`
+	CustomFields            map[string]interface{} `json:"custom_fields,omitempty"`
+	ActivitiesCount         *int                   `json:"activities_count,omitempty"`
+	ClosedDealsCount        *int                   `json:"closed_deals_count,omitempty"`
+	DoneActivitiesCount     *int                   `json:"done_activities_count,omitempty"`
+	EmailMessagesCount      *int                   `json:"email_messages_count,omitempty"`
+	FilesCount              *int                   `json:"files_count,omitempty"`
+	FollowersCount          *int                   `json:"followers_count,omitempty"`
+	LastActivityID          *ActivityID            `json:"last_activity_id,omitempty"`
+	LostDealsCount          *int                   `json:"lost_deals_count,omitempty"`
+	NextActivityID          *ActivityID            `json:"next_activity_id,omitempty"`
+	NotesCount              *int                   `json:"notes_count,omitempty"`
+	OpenDealsCount          *int                   `json:"open_deals_count,omitempty"`
+	PeopleCount             *int                   `json:"people_count,omitempty"`
+	RelatedClosedDealsCount *int                   `json:"related_closed_deals_count,omitempty"`
+	RelatedLostDealsCount   *int                   `json:"related_lost_deals_count,omitempty"`
+	RelatedOpenDealsCount   *int                   `json:"related_open_deals_count,omitempty"`
+	RelatedWonDealsCount    *int                   `json:"related_won_deals_count,omitempty"`
+	UndoneActivitiesCount   *int                   `json:"undone_activities_count,omitempty"`
+	WonDealsCount           *int                   `json:"won_deals_count,omitempty"`
+	Labels                  []EntityLabel          `json:"labels,omitempty"`
 }
 
 type OrganizationSearchItem struct {
@@ -200,7 +227,7 @@ type organizationPayload struct {
 	name         *string
 	ownerID      *UserID
 	address      *OrganizationAddress
-	labelIDs     []int
+	labelIDs     optionalSlice[int]
 	visibleTo    *int
 	customFields map[string]interface{}
 }
@@ -304,6 +331,18 @@ func WithOrganizationIncludeFields(fields ...OrganizationIncludeField) GetOrgani
 	})
 }
 
+func WithOrganizationIncludeLabels(enabled bool) GetOrganizationOption {
+	return getOrganizationOptionFunc(func(cfg *getOrganizationOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithOrganizationIncludeOptionLabels(enabled bool) GetOrganizationOption {
+	return getOrganizationOptionFunc(func(cfg *getOrganizationOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
+	})
+}
+
 func WithOrganizationCustomFields(fields ...string) GetOrganizationOption {
 	return getOrganizationOptionFunc(func(cfg *getOrganizationOptions) {
 		csv := joinCSV(fields)
@@ -334,10 +373,7 @@ func WithOrganizationAddress(address OrganizationAddress) OrganizationOption {
 
 func WithOrganizationLabelIDs(ids ...int) OrganizationOption {
 	return organizationFieldOption(func(payload *organizationPayload) {
-		if len(ids) == 0 {
-			return
-		}
-		payload.labelIDs = append(payload.labelIDs, ids...)
+		payload.labelIDs.append(ids...)
 	})
 }
 
@@ -401,6 +437,18 @@ func WithOrganizationsIncludeFields(fields ...OrganizationIncludeField) ListOrga
 		}
 		value := genv2.GetOrganizationsParamsIncludeFields(csv)
 		cfg.params.IncludeFields = &value
+	})
+}
+
+func WithOrganizationsIncludeLabels(enabled bool) ListOrganizationsOption {
+	return listOrganizationsOptionFunc(func(cfg *listOrganizationsOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithOrganizationsIncludeOptionLabels(enabled bool) ListOrganizationsOption {
+	return listOrganizationsOptionFunc(func(cfg *listOrganizationsOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
 	})
 }
 
@@ -987,8 +1035,8 @@ func (p organizationPayload) toMap() map[string]interface{} {
 	if p.address != nil {
 		body["address"] = p.address
 	}
-	if len(p.labelIDs) > 0 {
-		body["label_ids"] = p.labelIDs
+	if p.labelIDs.set {
+		body["label_ids"] = p.labelIDs.value
 	}
 	if p.visibleTo != nil {
 		body["visible_to"] = *p.visibleTo

--- a/pipedrive/v2/person_fields.go
+++ b/pipedrive/v2/person_fields.go
@@ -212,10 +212,13 @@ func WithPersonFieldType(fieldType FieldType) PersonFieldOption {
 	})
 }
 
+// WithPersonFieldDescription is retained for source compatibility.
+//
+// Deprecated: Pipedrive API v2 no longer accepts descriptions for person
+// fields. This option is intentionally ignored.
 func WithPersonFieldDescription(description string) PersonFieldOption {
-	return personFieldOptionFunc(func(payload *fieldPayload) {
-		payload.description = &description
-	})
+	_ = description
+	return personFieldOptionFunc(func(*fieldPayload) {})
 }
 
 func WithPersonFieldOptions(labels ...string) PersonFieldOption {
@@ -334,18 +337,22 @@ func (s *PersonFieldsService) Get(ctx context.Context, fieldCode string, opts ..
 	cfg := newGetPersonFieldOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetPersonFieldWithResponse(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetPersonField(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -388,18 +395,22 @@ func (s *PersonFieldsService) Create(ctx context.Context, opts ...CreatePersonFi
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddPersonFieldWithBodyWithResponse(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddPersonFieldWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -417,18 +428,22 @@ func (s *PersonFieldsService) Update(ctx context.Context, fieldCode string, opts
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdatePersonFieldWithBodyWithResponse(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdatePersonFieldWithBody(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -575,12 +590,16 @@ func (s *PersonFieldsService) DeleteOptions(ctx context.Context, fieldCode strin
 func (s *PersonFieldsService) list(ctx context.Context, params genv2.GetPersonFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetPersonFieldsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetPersonFields(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -589,7 +608,7 @@ func (s *PersonFieldsService) list(ctx context.Context, params genv2.GetPersonFi
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 

--- a/pipedrive/v2/person_fields_test.go
+++ b/pipedrive/v2/person_fields_test.go
@@ -85,8 +85,8 @@ func TestPersonFieldsService_Create(t *testing.T) {
 		if payload["field_type"] != "enum" {
 			t.Fatalf("unexpected field_type: %v", payload["field_type"])
 		}
-		if payload["description"] != "Person priority" {
-			t.Fatalf("unexpected description: %v", payload["description"])
+		if description, ok := payload["description"]; ok {
+			t.Fatalf("unexpected description: %v", description)
 		}
 		options, ok := payload["options"].([]interface{})
 		if !ok || len(options) != 1 {

--- a/pipedrive/v2/persons.go
+++ b/pipedrive/v2/persons.go
@@ -79,17 +79,50 @@ type LabeledValue struct {
 }
 
 type Person struct {
-	ID           PersonID               `json:"id"`
-	Name         string                 `json:"name,omitempty"`
-	FirstName    string                 `json:"first_name,omitempty"`
-	LastName     string                 `json:"last_name,omitempty"`
-	OwnerID      *UserID                `json:"owner_id,omitempty"`
-	OrgID        *OrganizationID        `json:"org_id,omitempty"`
-	AddTime      *time.Time             `json:"add_time,omitempty"`
-	UpdateTime   *time.Time             `json:"update_time,omitempty"`
-	Emails       []LabeledValue         `json:"emails,omitempty"`
-	Phones       []LabeledValue         `json:"phones,omitempty"`
-	CustomFields map[string]interface{} `json:"custom_fields,omitempty"`
+	ID                          PersonID               `json:"id"`
+	Name                        string                 `json:"name,omitempty"`
+	FirstName                   string                 `json:"first_name,omitempty"`
+	LastName                    string                 `json:"last_name,omitempty"`
+	OwnerID                     *UserID                `json:"owner_id,omitempty"`
+	OrgID                       *OrganizationID        `json:"org_id,omitempty"`
+	AddTime                     *time.Time             `json:"add_time,omitempty"`
+	UpdateTime                  *time.Time             `json:"update_time,omitempty"`
+	Emails                      []LabeledValue         `json:"emails,omitempty"`
+	Phones                      []LabeledValue         `json:"phones,omitempty"`
+	IsDeleted                   bool                   `json:"is_deleted,omitempty"`
+	VisibleTo                   *int                   `json:"visible_to,omitempty"`
+	LabelIDs                    []int                  `json:"label_ids,omitempty"`
+	PictureID                   *int                   `json:"picture_id,omitempty"`
+	PostalAddress               *OrganizationAddress   `json:"postal_address,omitempty"`
+	Notes                       string                 `json:"notes,omitempty"`
+	IM                          []LabeledValue         `json:"im,omitempty"`
+	Birthday                    *string                `json:"birthday,omitempty"`
+	JobTitle                    string                 `json:"job_title,omitempty"`
+	CustomFields                map[string]interface{} `json:"custom_fields,omitempty"`
+	ActivitiesCount             *int                   `json:"activities_count,omitempty"`
+	ClosedDealsCount            *int                   `json:"closed_deals_count,omitempty"`
+	DOIStatus                   *string                `json:"doi_status,omitempty"`
+	DoneActivitiesCount         *int                   `json:"done_activities_count,omitempty"`
+	EmailMessagesCount          *int                   `json:"email_messages_count,omitempty"`
+	FilesCount                  *int                   `json:"files_count,omitempty"`
+	FollowersCount              *int                   `json:"followers_count,omitempty"`
+	LastActivityID              *ActivityID            `json:"last_activity_id,omitempty"`
+	LastIncomingMailTime        *time.Time             `json:"last_incoming_mail_time,omitempty"`
+	LastOutgoingMailTime        *time.Time             `json:"last_outgoing_mail_time,omitempty"`
+	LostDealsCount              *int                   `json:"lost_deals_count,omitempty"`
+	MarketingStatus             *PersonMarketingStatus `json:"marketing_status,omitempty"`
+	NextActivityID              *ActivityID            `json:"next_activity_id,omitempty"`
+	NotesCount                  *int                   `json:"notes_count,omitempty"`
+	OpenDealsCount              *int                   `json:"open_deals_count,omitempty"`
+	ParticipantClosedDealsCount *int                   `json:"participant_closed_deals_count,omitempty"`
+	ParticipantOpenDealsCount   *int                   `json:"participant_open_deals_count,omitempty"`
+	RelatedClosedDealsCount     *int                   `json:"related_closed_deals_count,omitempty"`
+	RelatedLostDealsCount       *int                   `json:"related_lost_deals_count,omitempty"`
+	RelatedOpenDealsCount       *int                   `json:"related_open_deals_count,omitempty"`
+	RelatedWonDealsCount        *int                   `json:"related_won_deals_count,omitempty"`
+	UndoneActivitiesCount       *int                   `json:"undone_activities_count,omitempty"`
+	WonDealsCount               *int                   `json:"won_deals_count,omitempty"`
+	Labels                      []EntityLabel          `json:"labels,omitempty"`
 }
 
 type PersonSearchItem struct {
@@ -237,11 +270,12 @@ type personPayload struct {
 	name            *string
 	ownerID         *UserID
 	orgID           *OrganizationID
-	emails          []LabeledValue
-	phones          []LabeledValue
-	labelIDs        []int
+	emails          optionalSlice[LabeledValue]
+	phones          optionalSlice[LabeledValue]
+	labelIDs        optionalSlice[int]
 	visibleTo       *int
 	marketingStatus *PersonMarketingStatus
+	customFields    map[string]interface{}
 }
 
 type personRequestOptions struct {
@@ -347,6 +381,18 @@ func WithPersonIncludeFields(fields ...PersonIncludeField) GetPersonOption {
 	})
 }
 
+func WithPersonIncludeLabels(enabled bool) GetPersonOption {
+	return getPersonOptionFunc(func(cfg *getPersonOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithPersonIncludeOptionLabels(enabled bool) GetPersonOption {
+	return getPersonOptionFunc(func(cfg *getPersonOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
+	})
+}
+
 func WithPersonCustomFields(fields ...string) GetPersonOption {
 	return getPersonOptionFunc(func(cfg *getPersonOptions) {
 		csv := joinCSV(fields)
@@ -377,28 +423,25 @@ func WithPersonOrgID(id OrganizationID) PersonOption {
 
 func WithPersonEmails(emails ...LabeledValue) PersonOption {
 	return personFieldOption(func(payload *personPayload) {
-		if len(emails) == 0 {
-			return
-		}
-		payload.emails = append(payload.emails, emails...)
+		payload.emails.append(emails...)
 	})
 }
 
 func WithPersonPhones(phones ...LabeledValue) PersonOption {
 	return personFieldOption(func(payload *personPayload) {
-		if len(phones) == 0 {
-			return
-		}
-		payload.phones = append(payload.phones, phones...)
+		payload.phones.append(phones...)
 	})
 }
 
 func WithPersonLabelIDs(ids ...int) PersonOption {
 	return personFieldOption(func(payload *personPayload) {
-		if len(ids) == 0 {
-			return
-		}
-		payload.labelIDs = append(payload.labelIDs, ids...)
+		payload.labelIDs.append(ids...)
+	})
+}
+
+func WithPersonCustomFieldsMap(fields map[string]interface{}) PersonOption {
+	return personFieldOption(func(payload *personPayload) {
+		payload.customFields = fields
 	})
 }
 
@@ -476,6 +519,18 @@ func WithPersonsIncludeFields(fields ...PersonIncludeField) ListPersonsOption {
 		}
 		value := genv2.GetPersonsParamsIncludeFields(csv)
 		cfg.params.IncludeFields = &value
+	})
+}
+
+func WithPersonsIncludeLabels(enabled bool) ListPersonsOption {
+	return listPersonsOptionFunc(func(cfg *listPersonsOptions) {
+		cfg.params.IncludeLabels = &enabled
+	})
+}
+
+func WithPersonsIncludeOptionLabels(enabled bool) ListPersonsOption {
+	return listPersonsOptionFunc(func(cfg *listPersonsOptions) {
+		cfg.params.IncludeOptionLabels = &enabled
 	})
 }
 
@@ -1115,20 +1170,23 @@ func (p personPayload) toMap() map[string]interface{} {
 	if p.orgID != nil {
 		body["org_id"] = int(*p.orgID)
 	}
-	if len(p.emails) > 0 {
-		body["emails"] = p.emails
+	if p.emails.set {
+		body["emails"] = p.emails.value
 	}
-	if len(p.phones) > 0 {
-		body["phones"] = p.phones
+	if p.phones.set {
+		body["phones"] = p.phones.value
 	}
-	if len(p.labelIDs) > 0 {
-		body["label_ids"] = p.labelIDs
+	if p.labelIDs.set {
+		body["label_ids"] = p.labelIDs.value
 	}
 	if p.visibleTo != nil {
 		body["visible_to"] = *p.visibleTo
 	}
 	if p.marketingStatus != nil {
 		body["marketing_status"] = *p.marketingStatus
+	}
+	if p.customFields != nil {
+		body["custom_fields"] = p.customFields
 	}
 	return body
 }

--- a/pipedrive/v2/product_fields.go
+++ b/pipedrive/v2/product_fields.go
@@ -212,10 +212,13 @@ func WithProductFieldType(fieldType FieldType) ProductFieldOption {
 	})
 }
 
+// WithProductFieldDescription is retained for source compatibility.
+//
+// Deprecated: Pipedrive API v2 no longer accepts descriptions for product
+// fields. This option is intentionally ignored.
 func WithProductFieldDescription(description string) ProductFieldOption {
-	return productFieldOptionFunc(func(payload *fieldPayload) {
-		payload.description = &description
-	})
+	_ = description
+	return productFieldOptionFunc(func(*fieldPayload) {})
 }
 
 func WithProductFieldOptions(labels ...string) ProductFieldOption {
@@ -334,18 +337,22 @@ func (s *ProductFieldsService) Get(ctx context.Context, fieldCode string, opts .
 	cfg := newGetProductFieldOptions(opts)
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, cfg.requestOptions...)
 
-	resp, err := s.client.gen.GetProductFieldWithResponse(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetProductField(ctx, fieldCode, &cfg.params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -388,18 +395,22 @@ func (s *ProductFieldsService) Create(ctx context.Context, opts ...CreateProduct
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.AddProductFieldWithBodyWithResponse(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.AddProductFieldWithBody(ctx, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -417,18 +428,22 @@ func (s *ProductFieldsService) Update(ctx context.Context, fieldCode string, opt
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	resp, err := s.client.gen.UpdateProductFieldWithBodyWithResponse(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
+	resp, err := s.client.gen.UpdateProductFieldWithBody(ctx, fieldCode, "application/json", bytes.NewReader(body), toRequestEditors(editors)...)
 	if err != nil {
 		return nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
 		Data *Field `json:"data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
 	if payload.Data == nil {
@@ -575,12 +590,16 @@ func (s *ProductFieldsService) DeleteOptions(ctx context.Context, fieldCode stri
 func (s *ProductFieldsService) list(ctx context.Context, params genv2.GetProductFieldsParams, requestOptions []pipedrive.RequestOption) ([]Field, *string, error) {
 	ctx, editors := pipedrive.ApplyRequestOptions(ctx, requestOptions...)
 
-	resp, err := s.client.gen.GetProductFieldsWithResponse(ctx, &params, toRequestEditors(editors)...)
+	resp, err := s.client.gen.GetProductFields(ctx, &params, toRequestEditors(editors)...)
 	if err != nil {
 		return nil, nil, err
 	}
-	if resp.HTTPResponse.StatusCode < 200 || resp.HTTPResponse.StatusCode > 299 {
-		return nil, nil, errorFromResponse(resp.HTTPResponse, resp.Body)
+	responseBody, err := readFieldResponseBody(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, nil, errorFromResponse(resp, responseBody)
 	}
 
 	var payload struct {
@@ -589,7 +608,7 @@ func (s *ProductFieldsService) list(ctx context.Context, params genv2.GetProduct
 			NextCursor *string `json:"next_cursor"`
 		} `json:"additional_data"`
 	}
-	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
 		return nil, nil, fmt.Errorf("decode response: %w", err)
 	}
 

--- a/pipedrive/v2/product_fields_test.go
+++ b/pipedrive/v2/product_fields_test.go
@@ -85,8 +85,8 @@ func TestProductFieldsService_Create(t *testing.T) {
 		if payload["field_type"] != "enum" {
 			t.Fatalf("unexpected field_type: %v", payload["field_type"])
 		}
-		if payload["description"] != "Product priority" {
-			t.Fatalf("unexpected description: %v", payload["description"])
+		if description, ok := payload["description"]; ok {
+			t.Fatalf("unexpected description: %v", description)
 		}
 		options, ok := payload["options"].([]interface{})
 		if !ok || len(options) != 1 {

--- a/pipedrive/v2/products.go
+++ b/pipedrive/v2/products.go
@@ -66,6 +66,9 @@ type Product struct {
 	IsDeleted              bool                   `json:"is_deleted,omitempty"`
 	IsLinkable             bool                   `json:"is_linkable,omitempty"`
 	VisibleTo              int                    `json:"visible_to,omitempty"`
+	AddTime                *time.Time             `json:"add_time,omitempty"`
+	UpdateTime             *time.Time             `json:"update_time,omitempty"`
+	Description            string                 `json:"description,omitempty"`
 	CustomFields           map[string]interface{} `json:"custom_fields,omitempty"`
 	BillingFrequency       BillingFrequency       `json:"billing_frequency,omitempty"`
 	BillingFrequencyCycles *int                   `json:"billing_frequency_cycles,omitempty"`
@@ -365,14 +368,14 @@ type productPayload struct {
 	ownerID                *UserID
 	isLinkable             *bool
 	visibleTo              *int
-	prices                 []ProductPrice
+	prices                 optionalSlice[ProductPrice]
 	billingFrequency       *BillingFrequency
-	billingFrequencyCycles *int
+	billingFrequencyCycles nullableValue[int]
 }
 
 type productVariationPayload struct {
 	name   *string
-	prices []ProductPrice
+	prices optionalSlice[ProductPrice]
 }
 
 type productImagePayload struct {
@@ -579,6 +582,13 @@ func WithProductsSortDirection(direction SortDirection) ListProductsOption {
 	})
 }
 
+func WithProductsUpdatedSince(t time.Time) ListProductsOption {
+	return listProductsOptionFunc(func(cfg *listProductsOptions) {
+		value := formatTime(t)
+		cfg.params.UpdatedSince = &value
+	})
+}
+
 func WithProductsCustomFields(fields ...string) ListProductsOption {
 	return listProductsOptionFunc(func(cfg *listProductsOptions) {
 		csv := joinCSV(fields)
@@ -645,10 +655,7 @@ func WithProductVisibleTo(visibleTo int) ProductOption {
 
 func WithProductPrices(prices ...ProductPrice) ProductOption {
 	return productFieldOption(func(payload *productPayload) {
-		if len(prices) == 0 {
-			return
-		}
-		payload.prices = append(payload.prices, prices...)
+		payload.prices.append(prices...)
 	})
 }
 
@@ -660,7 +667,14 @@ func WithProductBillingFrequency(frequency BillingFrequency) ProductOption {
 
 func WithProductBillingFrequencyCycles(cycles int) ProductOption {
 	return productFieldOption(func(payload *productPayload) {
-		payload.billingFrequencyCycles = &cycles
+		payload.billingFrequencyCycles.assign(cycles)
+	})
+}
+
+// ClearProductBillingFrequencyCycles sends an explicit JSON null cycle count.
+func ClearProductBillingFrequencyCycles() ProductOption {
+	return productFieldOption(func(payload *productPayload) {
+		payload.billingFrequencyCycles.clear()
 	})
 }
 
@@ -725,10 +739,7 @@ func WithProductVariationName(name string) ProductVariationOption {
 
 func WithProductVariationPrices(prices ...ProductPrice) ProductVariationOption {
 	return productVariationFieldOption(func(payload *productVariationPayload) {
-		if len(prices) == 0 {
-			return
-		}
-		payload.prices = append(payload.prices, prices...)
+		payload.prices.append(prices...)
 	})
 }
 
@@ -1673,14 +1684,18 @@ func (p productPayload) toMap() map[string]interface{} {
 	if p.visibleTo != nil {
 		body["visible_to"] = *p.visibleTo
 	}
-	if len(p.prices) > 0 {
-		body["prices"] = p.prices
+	if p.prices.set {
+		body["prices"] = p.prices.value
 	}
 	if p.billingFrequency != nil {
 		body["billing_frequency"] = *p.billingFrequency
 	}
-	if p.billingFrequencyCycles != nil {
-		body["billing_frequency_cycles"] = *p.billingFrequencyCycles
+	if p.billingFrequencyCycles.set {
+		if p.billingFrequencyCycles.value == nil {
+			body["billing_frequency_cycles"] = nil
+		} else {
+			body["billing_frequency_cycles"] = *p.billingFrequencyCycles.value
+		}
 	}
 	return body
 }
@@ -1690,8 +1705,8 @@ func (p productVariationPayload) toMap() map[string]interface{} {
 	if p.name != nil {
 		body["name"] = *p.name
 	}
-	if len(p.prices) > 0 {
-		body["prices"] = p.prices
+	if p.prices.set {
+		body["prices"] = p.prices.value
 	}
 	return body
 }


### PR DESCRIPTION
## Summary

- Accept field-option IDs returned by Pipedrive as either integers or strings without generated-client decoding failures
- Represent documented Deal, Person, Organization, Product, Activity, and Field response properties
- Add missing label, option-label, updated-since, and Person custom-field request options
- Support explicit JSON null and empty-array updates while preserving existing empty-string behavior
- Reject missing deal IDs locally in cursor pagers instead of issuing invalid API requests
- Add regression coverage for response compatibility and request serialization

## Compatibility notes

- No public signatures are removed
- `FieldOption.ID` and `Product.Category` remain source-compatible, with additive fields representing string-valued responses
- Zero-argument collection options now deliberately serialize an empty array and can be used to clear collections
- Person, Organization, and Product field-description options remain callable but are deprecated no-ops because API v2 does not accept those descriptions